### PR TITLE
Fix issue with Grafana MCP server not building with latest changes

### DIFF
--- a/servers/grafana/server.yaml
+++ b/servers/grafana/server.yaml
@@ -12,7 +12,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/7195757?s=200&v=4
 source:
   project: https://github.com/grafana/mcp-grafana
-  branch: c03ca3c387b2cd9b3d8d2fbd56d2a9e6b7b603fb
+  branch: main
 run:
   command:
     - --transport=stdio


### PR DESCRIPTION
Hi,

The [Grafana MCP Server](https://github.com/grafana/mcp-grafana) is not building with the latest changes. I noticed the issue when I ran into issue [#177](https://github.com/grafana/mcp-grafana/issues/177) in the Grafana repo but the maintainer does not seem to be aware of how builds are pushed to the Docker MCP registry. 

I believe it is because `servers/grafana/server.yaml` in this project references a branch called `c03ca3c387b2cd9b3d8d2fbd56d2a9e6b7b603fb` which I cannot find in the Grafana MCP project. I changed it to main instead.

Thanks.