### PR TITLE
[Feat] Add Federal Reserver Economic Data MCP server

### DIFF
--- a/servers/fred/server.yaml
+++ b/servers/fred/server.yaml
@@ -1,0 +1,23 @@
+name: fred
+image: mcp/fred
+type: server
+meta:
+  category: finance
+  tags:
+    - fred
+    - finance
+    - federal-reserve-economic-data
+    - economic-data
+    - financial-intelligence
+  highlighted: true
+about:
+  title: Federal Reserve Economic Data (FRED)
+  description: A community-developed MCP server for interacting with time series data provided by Federal Reserve Economic Data (FRED) database. Maintained by Stefano Amorelli.
+  icon: https://github.com/stefanoamorelli/fred-mcp-server/blob/main/fred-mcp-server-logo.png
+source:
+  project: https://github.com/stefanoamorelli/fred-mcp-server/
+config:
+  secrets:
+    - name: fred_api_key
+      env: FRED_API_KEY
+      example: "<YOUR_API_KEY>"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Federal Reserve Economic Data
**Repository URL:** https://github.com/stefanoamorelli/fred-mcp-server
**Brief Description:** A community-developed MCP server for interacting with time series data provided by Federal Reserve Economic Data (FRED) database. Maintained by Stefano Amorelli.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server in Docker Desktop
