### PR TITLE
Added kubectl mcp server

### DIFF
--- a/servers/kubectl-mcp-server/server.yaml
+++ b/servers/kubectl-mcp-server/server.yaml
@@ -13,4 +13,18 @@ about:
   description: MCP Server that enables AI assistants to interact with Kubernetes clusters via kubectl operations.
   icon: https://avatars.githubusercontent.com/u/13629408?s=200&v=4
 source:
-  project: https://github.com/rohitg00/kubectl-mcp-server 
+  project: https://github.com/rohitg00/kubectl-mcp-server
+run:
+  volumes:
+    - '{{kubectl-mcp-server.kubeconfig}}:/root/.kube'
+config:
+  description: The MCP server is allowed to access this path
+  parameters:
+    type: object
+    properties:
+      kubeconfig:
+        type: string
+        default:
+          $HOME/.kube
+    required:
+      - kubeconfig

--- a/servers/kubectl-mcp-server/server.yaml
+++ b/servers/kubectl-mcp-server/server.yaml
@@ -1,0 +1,16 @@
+name: kubectl-mcp-server
+image: mcp/kubectl-mcp-server
+type: server
+meta:
+  category: devops
+  tags:
+    - kubectl-mcp-server
+    - kubernetes
+    - kubectl
+    - devops
+about:
+  title: Kubectl MCP Server
+  description: MCP Server that enables AI assistants to interact with Kubernetes clusters via kubectl operations.
+  icon: https://avatars.githubusercontent.com/u/13629408?s=200&v=4
+source:
+  project: https://github.com/rohitg00/kubectl-mcp-server 


### PR DESCRIPTION
This pull request adds a new configuration file for the `kubectl-mcp-server` to the repository. The file defines metadata and details about the server, which facilitates AI assistants in interacting with Kubernetes clusters through `kubectl` operations.

### Key Changes:

* **New Server Configuration:**
  * Added `servers/kubectl-mcp-server/server.yaml` to define the `kubectl-mcp-server` with metadata such as name, image, type, category, tags, and a description of its purpose.