### PR TITLE
Add pluggedin-mcp-proxy to MCP registry

### DIFF
--- a/servers/pluggedin-mcp-proxy/server.yaml
+++ b/servers/pluggedin-mcp-proxy/server.yaml
@@ -1,0 +1,35 @@
+name: pluggedin-mcp-proxy
+image: mcp/pluggedin-mcp-proxy
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - proxy
+    - management
+    - tools
+    - ai
+about:
+  title: Plugged.in MCP Proxy
+  description: A unified MCP proxy that aggregates multiple MCP servers into one interface, enabling seamless tool discovery and management across all your AI interactions. Manage all your MCP servers from a single connection point with RAG capabilities and real-time notifications.
+  icon: https://www.plugged.in/favicon.ico
+source:
+  project: https://github.com/VeriTeknik/pluggedin-mcp-proxy
+config:
+  description: Configure your Plugged.in API connection. Get your API key from https://plugged.in in the API Keys section.
+  secrets:
+    - name: pluggedin-mcp-proxy.pluggedin_api_key
+      env: PLUGGEDIN_API_KEY
+      example: YOUR_PLUGGEDIN_API_KEY
+  env:
+    - name: PLUGGEDIN_API_BASE_URL
+      example: https://plugged.in
+      value: '{{pluggedin-mcp-proxy.pluggedin_api_base_url}}'
+      default: https://plugged.in
+  parameters:
+    type: object
+    properties:
+      pluggedin_api_base_url:
+        type: string
+        default: https://plugged.in
+        description: Base URL for the Plugged.in API (optional, defaults to https://plugged.in for cloud or http://localhost:12005 for self-hosted)


### PR DESCRIPTION
## Description
This PR adds the Plugged.in MCP Proxy to the Docker MCP Registry.

## About pluggedin-mcp-proxy
Plugged.in MCP Proxy is a unified interface that aggregates multiple MCP servers, providing:
- Seamless tool discovery across multiple MCP servers
- Unified API for all MCP client interactions
- Support for STDIO, SSE, and Streamable HTTP transport protocols
- Integration with the Plugged.in platform for enhanced management

## Configuration
- Requires a Plugged.in API key (available at https://plugged.in)
- Optional base URL configuration for self-hosted instances

## Testing
- [x] Successfully built Docker image
- [x] Tested in Docker Desktop MCP Toolkit
- [x] Verified tool discovery functionality
- [x] Confirmed connection with valid API key

Repository: https://github.com/VeriTeknik/pluggedin-mcp-proxy
Documentation: https://github.com/VeriTeknik/pluggedin-mcp-proxy#readme