### PR TITLE
Add npm-sentinel-mcp to Docker MCP Registry

### DIFF
--- a/servers/npm-sentinel/server.yaml
+++ b/servers/npm-sentinel/server.yaml
@@ -1,0 +1,14 @@
+name: npm-sentinel
+image: mcp/npm-sentinel
+type: server
+meta:
+  category: devops
+  tags:
+    - npm
+    - npm-package
+about:
+  title: NPM Sentinel
+  description: MCP server that enables intelligent NPM package analysis powered by AI. 
+  icon: https://avatars.githubusercontent.com/u/85507589?v=4
+source:
+  project: https://github.com/Nekzus/npm-sentinel-mcp


### PR DESCRIPTION
This PR adds the `npm-sentinel-mcp` server to the Docker MCP catalog.

### Details
- Repo: [https://github.com/Nekzus/npm-sentinel-mcp](https://github.com/Nekzus/npm-sentinel-mcp)
- No environment variables required.

### Checklist
- [x] Created `server.yaml` using `task create`
- [x] Correct metadata and category
- [x] Local testing completed