### PR TITLE
Add task build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ task create -- --category database --image myorg/my-mcp https://github.com/myorg
 After creating your server file with `task create`, you will be given instructions for running it locally. In the case of my-orgdb-mcp, we would run the following commands next.
 
 ```
+task build -- my-orgdb-mcp # Not needed if providing your own image
 task catalog -- my-orgdb-mcp
 docker mcp catalog import $PWD/catalogs/my-orgdb-mcp/catalog.yaml
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,6 +4,10 @@ tasks:
   create:
     desc: Create a new mcp server definition
     cmd: go run ./cmd/create {{.CLI_ARGS}}
+  
+  build:
+    desc: Build a server image
+    cmd: go run ./cmd/build {{.CLI_ARGS}}
 
   catalog:
     desc: Generate a test catalog

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/mcp-registry/pkg/github"
+	"github.com/docker/mcp-registry/pkg/servers"
+)
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+
+	if len(args) != 1 {
+		fmt.Println("Usage: task build -- <server>")
+		os.Exit(1)
+	}
+
+	if err := run(context.Background(), args[0]); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context, name string) error {
+	server, err := servers.Read(filepath.Join("servers", name, "server.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("server %s not found (did you already create it with `task create`?)", name)
+		}
+		return err
+	}
+
+	if !strings.HasPrefix(server.Image, "mcp/") {
+		return fmt.Errorf("server is not docker built (ie, in the 'mcp/' namespace), you must either build it yourself or pull it with `docker pull %s` if you want to use it", server.Image)
+	}
+
+	projectURL := server.Source.Project
+	branch := server.Source.Branch
+	directory := server.Source.Directory
+
+	client := github.New()
+
+	repository, err := client.GetProjectRepository(ctx, projectURL)
+	if err != nil {
+		return err
+	}
+
+	if branch == "" {
+		branch = repository.GetDefaultBranch()
+	}
+
+	sha, err := client.GetCommitSHA1(ctx, projectURL, branch)
+	if err != nil {
+		return err
+	}
+
+	gitURL := projectURL + ".git#"
+	if branch != "" {
+		gitURL += branch
+	}
+	if directory != "" && directory != "." {
+		gitURL += ":" + directory
+	}
+
+	var cmd *exec.Cmd
+	token := os.Getenv("GITHUB_TOKEN")
+
+	if token != "" {
+		cmd = exec.CommandContext(ctx, "docker", "buildx", "build", "--secret", "id=GIT_AUTH_TOKEN", "-t", "check", "-t", server.Image, "--label", "org.opencontainers.image.revision="+sha, gitURL)
+		cmd.Env = []string{"GIT_AUTH_TOKEN=" + token, "PATH=" + os.Getenv("PATH")}
+	} else {
+		cmd = exec.CommandContext(ctx, "docker", "buildx", "build", "-t", "check", "-t", server.Image, "--label", "org.opencontainers.image.revision="+sha, gitURL)
+		cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
+	}
+
+	cmd.Dir = os.TempDir()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	fmt.Println("✅ Image built as", server.Image)
+
+	return nil
+}

--- a/cmd/create/main.go
+++ b/cmd/create/main.go
@@ -271,26 +271,39 @@ func run(ctx context.Context, buildURL, name, category, userProvidedImage string
 
 	fmt.Printf("Server definition written to %s.\n", serverFile)
 
+	// Default to mcp build instructions
+	step2 := fmt.Sprintf(`
+  2. Test out your server in Docker Desktop building the image, generating a catalog, and importing it:
+
+     task build -- %[1]s
+     task catalog -- %[1]s
+     docker mcp catalog import $PWD/catalogs/%[1]s/catalog.yaml
+`, name)
+
+	if userProvidedImage != "" {
+		step2 = fmt.Sprintf(`
+  2. Test out your server in Docker Desktop by generating a catalog and importing it:
+
+     task catalog -- %[1]s
+     docker mcp catalog import $PWD/catalogs/%[1]s/catalog.yaml
+`, name)
+	}
+
 	fmt.Printf(`
 -----------------------------------------
 
 What to do next?
 
   1. Review %[2]s and make sure no TODO remains.
-
-  2. Test out your server in Docker Desktop by generating a catalog and importing it:
-
-     task catalog -- %[1]s
-     docker mcp catalog import $PWD/catalogs/%[1]s/catalog.yaml
-
-  3. After doing so, you should be able to test it with the MCP Toolkit.
+%[3]s
+  3. After doing so, you should be able to test it with the MCP Toolkit. Repeat step 2 as needed while making changes.
 
   4. Reset your catalog after testing:
 
      docker mcp catalog reset
 
   5. Open a Pull Request with the %[2]s file.
-`, name, serverFile)
+`, name, serverFile, step2)
 
 	return nil
 }


### PR DESCRIPTION
Adds `task build` so that existing servers can be tested easier.

The instructions have been updated in the case of an `mcp/` namespaced server.

```
What to do next?

  1. Review servers/wikipedia/server.yaml and make sure no TODO remains.

  2. Test out your server in Docker Desktop building the image, generating a catalog, and importing it:

     task build -- wikipedia
     task catalog -- wikipedia
     docker mcp catalog import $PWD/catalogs/wikipedia/catalog.yaml


  3. After doing so, you should be able to test it with the MCP Toolkit. Repeat step 2 as needed while making changes.

  4. Reset your catalog after testing:

     docker mcp catalog reset

  5. Open a Pull Request with the servers/wikipedia/server.yaml file.
```