### PR TITLE
adding text-to-graphql server

### DIFF
--- a/servers/text-to-graphql/server.yaml
+++ b/servers/text-to-graphql/server.yaml
@@ -1,0 +1,50 @@
+name: text-to-graphql
+image: mcp/text-to-graphql
+type: server
+meta:
+  category: devops
+  tags:
+    - graphql
+    - ai
+    - natural-language
+    - api
+    - query-generation
+about:
+  title: Text-to-GraphQL
+  description: Transform natural language queries into GraphQL queries using an AI agent. Provides schema management, query validation, execution, and history tracking.
+  icon: https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg
+source:
+  project: https://github.com/Arize-ai/text-to-graphql-mcp
+  branch: main
+  dockerfile: Dockerfile
+config:
+  description: Configure API keys and model settings for text-to-graphql
+  secrets:
+    - name: text-to-graphql.openai_api_key
+      env: OPENAI_API_KEY
+      example: sk-proj-xxx
+      description: OpenAI API key for LLM operations
+    - name: text-to-graphql.graphql_endpoint
+      env: GRAPHQL_ENDPOINT
+      example: https://your-graphql-api.com/graphql
+      description: GraphQL API endpoint URL
+    - name: text-to-graphql.graphql_api_key
+      env: GRAPHQL_API_KEY
+      example: your_api_key_here
+      description: API key for your GraphQL service
+  parameters:
+    type: object
+    properties:
+      graphql_auth_type:
+        type: string
+        enum: ["bearer", "apikey", "direct"]
+        default: bearer
+        description: Authentication method for GraphQL API
+      model_name:
+        type: string
+        default: gpt-4o
+        description: OpenAI model to use
+      model_temperature:
+        type: number
+        default: 0
+        description: Model temperature for responses 


### PR DESCRIPTION
Adding text-to-graphql server that allows users to connect and interact with a graphql api endpoint using an LLM.  This tool can be used to pull schema information, generate queries to execute tasks, and execute the queries on the endpoint directly.