### PR TITLE
Fix playwright server with long lived container

### DIFF
--- a/pkg/servers/types.go
+++ b/pkg/servers/types.go
@@ -30,6 +30,7 @@ type Server struct {
 	Name        string          `yaml:"name" json:"name"`
 	Image       string          `yaml:"image,omitempty" json:"image,omitempty"`
 	Type        string          `yaml:"type" json:"type"`
+	LongLived   bool            `yaml:"longLived,omitempty" json:"longLived,omitempty"`
 	Meta        Meta            `yaml:"meta,omitempty" json:"meta,omitempty"`
 	About       About           `yaml:"about,omitempty" json:"about,omitempty"`
 	Source      Source          `yaml:"source,omitempty" json:"source,omitempty"`

--- a/servers/playwright/server.yaml
+++ b/servers/playwright/server.yaml
@@ -1,6 +1,7 @@
 name: playwright
 image: mcp/playwright
 type: server
+longLived: true
 meta:
   category: devops
   tags:


### PR DESCRIPTION
Playwright is currently broken because a new container is created every time a tool is called, losing the browsing context. We've added a `longLived` field to support long lived containers on our backend and gateway. This will fix the playwright server!

Are there any other servers that need this fix?
