### PR TITLE
Add beagle-security MCP Server to MCP Registry. 

### DIFF
--- a/servers/beagle-security/server.yaml
+++ b/servers/beagle-security/server.yaml
@@ -1,0 +1,20 @@
+name: beagle-security
+image: mcp/beagle-security-mcp-server
+type: server
+meta:
+    category: devops
+    tags:
+        - devops
+about:
+    title: Beagle security MCP server
+    description: Connects with the Beagle Security backend using a user token to manage applications, run automated security tests, track vulnerabilities across environments, and gain intelligence from Application and API vulnerability data.
+    icon: https://cdn.beaglesecurity.com/assets/brand/png/beagle-blue-icon.png
+source:
+    project: https://github.com/beaglesecurity/beagle-security-mcp-server
+    branch: main
+config:
+    description: Configure the connection to Beagle security mcp server
+    secrets:
+        - name: beagle-security.Beagle-Security-Personal-access-token
+          env: BEAGLE_SECURITY_API_TOKEN
+          example: your_personal_access_token


### PR DESCRIPTION
Add beagle-security MCP Server to MCP Registry. 

Connects with the Beagle Security backend using a user token to manage applications, run automated security tests, track vulnerabilities across environments, and gain intelligence from Application and API vulnerability data.
