### PR TITLE
Use GitHub to official source code and image

### DIFF
--- a/servers/github-official/server.yaml
+++ b/servers/github-official/server.yaml
@@ -13,7 +13,6 @@ about:
   icon: https://avatars.githubusercontent.com/u/9919?s=200&v=4
 source:
   project: https://github.com/github/github-mcp-server
-  branch: main
 run:
   allowHosts:
     - api.github.com:443

--- a/servers/github-official/server.yaml
+++ b/servers/github-official/server.yaml
@@ -1,5 +1,5 @@
 name: github-official
-image: mcp/github-mcp-server
+image: ghcr.io/github/github-mcp-server
 type: server
 meta:
   category: devops

--- a/servers/github-official/server.yaml
+++ b/servers/github-official/server.yaml
@@ -12,13 +12,13 @@ about:
   description: Official GitHub MCP Server, by GitHub. Provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
   icon: https://avatars.githubusercontent.com/u/9919?s=200&v=4
 source:
-  project: https://github.com/dgageot/github-mcp-server
-  upstream: https://github.com/github/github-mcp-server
-  branch: temp-fix
+  project: https://github.com/github/github-mcp-server
+  branch: main
 run:
   allowHosts:
     - api.github.com:443
     - github.com:443
+    - raw.githubusercontent.com:443
 config:
   secrets:
     - name: github.personal_access_token


### PR DESCRIPTION
This should update the GitHub Official MCP Server entry to point to the correct source, and docker images.