### PR TITLE
Update Elasticsearch to v0.4.0

### DIFF
--- a/servers/elasticsearch/server.yaml
+++ b/servers/elasticsearch/server.yaml
@@ -13,7 +13,10 @@ about:
   icon: https://avatars.githubusercontent.com/u/6764390?s=200&v=4
 source:
   project: https://github.com/elastic/mcp-server-elasticsearch
-  branch: v0.2.0
+  branch: v0.4.0
+run:
+  command:
+    - stdio
 config:
   description: Configure the connection to Elasticsearch
   secrets:


### PR DESCRIPTION
Updates Elasticsearch to [v0.4.0](https://github.com/elastic/mcp-server-elasticsearch/releases/tag/v0.4.0).

Also adds the `stdio` CLI parameter which is required as we now also support `http`.