### PR TITLE
Fix CircleCI

### DIFF
--- a/servers/circleci/server.yaml
+++ b/servers/circleci/server.yaml
@@ -11,6 +11,10 @@ about:
   icon: https://avatars.githubusercontent.com/u/26607840?s=200&v=4
 source:
   project: https://github.com/CircleCI-Public/mcp-server-circleci
+  branch: refs/pull/99/merge
+run:
+  command:
+    - stdio
 config:
   description: Configure the connection to CircleCI
   secrets:


### PR DESCRIPTION
The CircleCI image now default to `sse` transport because the Dockerfile's entrypoint was changed to run `start:sse`.

This change references a Pull Request that tweaks the entrypoint to still default to `sse` but open the door for a different one, passed as an argument.