### PR TITLE
Add Teamwork MCP server to registry

### DIFF
--- a/servers/teamwork/server.yaml
+++ b/servers/teamwork/server.yaml
@@ -1,0 +1,42 @@
+name: teamwork
+image: mcp/teamwork
+type: server
+meta:
+  category: project-management
+  tags:
+    - teamwork
+    - project-management
+    - tasks
+    - collaboration
+about:
+  title: Teamwork
+  description: Connect to Teamwork API for project management, task creation, subtasks, team collaboration, and comprehensive project tracking.
+  icon: https://www.teamwork.com/favicon-32x32.png
+source:
+  project: https://github.com/Vizioz/Teamwork-MCP
+  branch: main
+config:
+  description: Configure connection to your Teamwork workspace
+  secrets:
+    - name: teamwork.password
+      env: TEAMWORK_PASSWORD
+      example: your-teamwork-password
+  env:
+    - name: TEAMWORK_DOMAIN
+      example: your-company
+      value: '{{teamwork.domain}}'
+    - name: TEAMWORK_USERNAME
+      example: your-email@example.com
+      value: '{{teamwork.username}}'
+  parameters:
+    type: object
+    properties:
+      domain:
+        type: string
+        description: Your Teamwork subdomain (without .teamwork.com)
+      username:
+        type: string
+        description: Your Teamwork username/email
+    required:
+      - domain
+      - username


### PR DESCRIPTION
- Add server configuration for Vizioz/Teamwork-MCP
- Supports project management, task creation, and subtasks
- Category: project-management
- Required env vars: TEAMWORK_DOMAIN, TEAMWORK_USERNAME, TEAMWORK_PASSWORD