### PR TITLE
Fix secret name for dockerhub

### DIFF
--- a/servers/dockerhub/server.yaml
+++ b/servers/dockerhub/server.yaml
@@ -19,7 +19,7 @@ run:
 config:
   description: Configure connection to Docker Hub
   secrets:
-    - name: pat_token
+    - name: dockerhub.pat_token
       env: HUB_PAT_TOKEN
       example: your_hub_pat_token
   parameters:


### PR DESCRIPTION
Rolling back change for secret name.
Using `dockerhub.pat_token` to avoid conflicts