### PR TITLE
Add LinkedIn MCP Server

### DIFF
--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -1,0 +1,24 @@
+name: linkedin-mcp-server
+image: stickerdaniel/linkedin-mcp-server:latest
+type: server
+meta:
+  category: business
+  tags:
+    - linkedin
+    - business
+    - scraping
+    - profiles
+    - jobs
+    - networking
+about:
+  title: LinkedIn MCP Server
+  description: This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches.
+  icon: https://raw.githubusercontent.com/stickerdaniel/linkedin-mcp-server/main/assets/icons/linkedin.svg
+source:
+  project: https://github.com/stickerdaniel/linkedin-mcp-server
+config:
+  description: Configure LinkedIn authentication using your session cookie
+  secrets:
+    - name: linkedin-mcp-server.linkedin_cookie
+      env: LINKEDIN_COOKIE
+      example: AQETADxR7bsCqpZlAAACm-lNHKAAAAGXDGmgoE0ARivAnr-8lRlxIM4RDkJcImu3xIucKbYZiKMYUidcyY85e0Fg2gjCpXQ3h_SxVyhJ1TEY_Bp-3z9MWkoRk__bVlwgy9OaHOuxNL4IK-E9yc_ghrwk


### PR DESCRIPTION
This PR adds the LinkedIn MCP Server to the registry. 

Docker image: stickerdaniel/linkedin-mcp-server:latest

**Features:**
- LinkedIn profile reading
- Company profile reading
- Job search and personal recommendations
- Login via session cookie