### PR TITLE
Adding the Root.io MCP

### DIFF
--- a/servers/root/server.yaml
+++ b/servers/root/server.yaml
@@ -11,7 +11,7 @@ meta:
 about:
   title: Root.io Vulnerability Remediation MCP
   description: MCP server that provides container image vulnerability scanning and remediation capabilities through Root.io
-  icon: https://raw.githubusercontent.com/rootio-avr/mcp-proxy/refs/heads/main/root-logo.svg
+  icon: https://raw.githubusercontent.com/rootio-avr/mcp-proxy/refs/heads/main/assets/root-logo.svg
 source:
   project: https://github.com/rootio-avr/mcp-proxy
 config:

--- a/servers/root/server.yaml
+++ b/servers/root/server.yaml
@@ -11,7 +11,7 @@ meta:
 about:
   title: Root.io Vulnerability Remediation MCP
   description: MCP server that provides container image vulnerability scanning and remediation capabilities through Root.io
-  icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
+  icon: https://raw.githubusercontent.com/rootio-avr/mcp-proxy/refs/heads/main/root-logo.svg
 source:
   project: https://github.com/rootio-avr/mcp-proxy
 config:

--- a/servers/root/server.yaml
+++ b/servers/root/server.yaml
@@ -1,0 +1,22 @@
+name: root
+image: rootpublic/mcp-proxy
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - vulnerability
+    - scanning
+    - remediation
+about:
+  title: Root.io Vulnerability Remediation MCP
+  description: MCP server that provides container image vulnerability scanning and remediation capabilities through Root.io
+  icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
+source:
+  project: https://github.com/rootio-avr/mcp-proxy
+config:
+  description: Configure the Root.io MCP proxy connection
+  secrets:
+    - name: root.api_access_token
+      env: API_ACCESS_TOKEN
+      example: sk_your_access_token


### PR DESCRIPTION
This MCP server provides container image vulnerability scanning and remediation capabilities through Root.io. The server uses the rootpublic/mcp-proxy docker image and requires API_ACCESS_TOKEN for authentication.