### PR TITLE
Add ArXiv MCP Server for academic research and paper analysis

### DIFF
--- a/servers/arxiv-mcp-server/server.yaml
+++ b/servers/arxiv-mcp-server/server.yaml
@@ -32,9 +32,6 @@ run:
 config:
   description: Configure local storage path for downloaded papers
   env:
-    - name: STORAGE_PATH
-      example: /Users/local-test/papers
-      value: '{{arxiv-mcp-server.storage_path}}'
     - name: ARXIV_STORAGE_PATH
       example: /Users/local-test/papers
       value: '/app/papers'


### PR DESCRIPTION
Features:
• Search arXiv papers with advanced filtering (date, category, query) • Download and store papers locally as markdown
• Read and analyze paper content programmatically
• Deep research analysis prompts for comprehensive paper review • Configurable local storage path for paper management

Technical Details:
- Category: search (academic research focused)
- License: Apache 2.0 (compatible with Docker registry)
- Source: https://github.com/jasonleinart/arxiv-mcp-server
- Build Status: Successfully tested and validated
- Docker Image: mcp/arxiv-mcp-server

Target Users:
Perfect for researchers, academics, and AI assistants conducting literature reviews, research analysis, and academic paper exploration.

Differentiates from existing paper-search server by providing:
- ArXiv-specific optimizations and direct API integration
- Local paper storage and management capabilities
- Research-focused analysis prompts and workflows
- Advanced filtering and categorization options