### PR TITLE
Added schogini-mcp-image-border MCP server

### DIFF
--- a/servers/schogini-mcp-image-border/server.yaml
+++ b/servers/schogini-mcp-image-border/server.yaml
@@ -1,0 +1,13 @@
+name: schogini-mcp-image-border
+image: mcp/schogini_mcp_image_border
+type: server
+meta:
+    category: productivity
+    tags:
+        - productivity
+about:
+    title: Schogini MCP Image Border
+    description: This adds a border to an image and returns base64 encoded image
+    icon: https://d1yei2z3i6k35z.cloudfront.net/7429984/669a56c4ca69e_SCHOGINI-LOGO-ROUND.png
+source:
+    project: https://github.com/schogini/schogini_mcp_image_border


### PR DESCRIPTION
Adds a border to the passed image url and returns a base64 encoded image. Color and thickness of the border can be passed.