### PR TITLE
Fix CI check for non-mcp namespaces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           while IFS= read -r file; do
             dir=$(dirname "$file")
             name=$(basename "$dir")
-            task build -- --tools $name
+            task build -- --tools --pull-community $name
             echo "--------------------------------"
             task catalog -- $name
             echo "--------------------------------"

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -17,6 +17,7 @@ import (
 
 func main() {
 	listTools := flag.Bool("tools", false, "List the tools")
+	pullCommunity := flag.Bool("pull-community", false, "Pull images that are not in the mcp/ namespace")
 
 	flag.Parse()
 	args := flag.Args()
@@ -26,12 +27,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(context.Background(), args[0], *listTools); err != nil {
+	if err := run(context.Background(), args[0], *listTools, *pullCommunity); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func run(ctx context.Context, name string, listTools bool) error {
+func run(ctx context.Context, name string, listTools bool, pullCommunity bool) error {
 	server, err := servers.Read(filepath.Join("servers", name, "server.yaml"))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -40,10 +41,47 @@ func run(ctx context.Context, name string, listTools bool) error {
 		return err
 	}
 
-	if !strings.HasPrefix(server.Image, "mcp/") {
-		return fmt.Errorf("server is not docker built (ie, in the 'mcp/' namespace), you must either build it yourself or pull it with `docker pull %s` if you want to use it", server.Image)
+	isMcpImage := strings.HasPrefix(server.Image, "mcp/")
+
+	if isMcpImage {
+		if err := buildMcpImage(ctx, server); err != nil {
+			return err
+		}
+	} else {
+		if !pullCommunity {
+			return fmt.Errorf("server is not docker built (ie, in the 'mcp/' namespace), you must either build it yourself or pull it with `docker pull %s` if you want to use it", server.Image)
+		}
+		if err := pullCommunityImage(ctx, server); err != nil {
+			return err
+		}
 	}
 
+	if listTools {
+		tools, err := mcp.Tools(ctx, server, false, false, false)
+		if err != nil {
+			return err
+		}
+
+		if len(tools) == 0 {
+			fmt.Println()
+			fmt.Println("No tools found.")
+		} else {
+			fmt.Println()
+			fmt.Println(len(tools), "tools found.")
+		}
+	}
+	fmt.Printf("\n-----------------------------------------\n\n")
+
+	if isMcpImage {
+		fmt.Println("✅ Image built as", server.Image)
+	} else {
+		fmt.Println("✅ Image pulled as", server.Image)
+	}
+
+	return nil
+}
+
+func buildMcpImage(ctx context.Context, server servers.Server) error {
 	projectURL := server.Source.Project
 	branch := server.Source.Branch
 	directory := server.Source.Directory
@@ -87,27 +125,13 @@ func run(ctx context.Context, name string, listTools bool) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if err := cmd.Run(); err != nil {
-		return err
-	}
+	return cmd.Run()
+}
 
-	if listTools {
-		tools, err := mcp.Tools(ctx, server, false, false, false)
-		if err != nil {
-			return err
-		}
+func pullCommunityImage(ctx context.Context, server servers.Server) error {
+	cmd := exec.CommandContext(ctx, "docker", "pull", server.Image)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-		if len(tools) == 0 {
-			fmt.Println()
-			fmt.Println("No tools found.")
-		} else {
-			fmt.Println()
-			fmt.Println(len(tools), "tools found.")
-		}
-	}
-	fmt.Printf("\n-----------------------------------------\n\n")
-
-	fmt.Println("✅ Image built as", server.Image)
-
-	return nil
+	return cmd.Run()
 }


### PR DESCRIPTION
This pulls the community provided image rather than preventing the check when the namespace isn't `mcp/`