### PR TITLE
Update LinkedIn MCP Server secret name for clarity

### DIFF
--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -12,13 +12,13 @@ meta:
     - networking
 about:
   title: LinkedIn MCP Server
-  description: This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches.
+  description: This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches. Set your li_at LinkedIncookie to use this server.
   icon: https://raw.githubusercontent.com/stickerdaniel/linkedin-mcp-server/main/assets/icons/linkedin.svg
 source:
   project: https://github.com/stickerdaniel/linkedin-mcp-server
 config:
-  description: Configure LinkedIn authentication using your session cookie
+  description: Configure LinkedIn authentication using your li_at cookie
   secrets:
-    - name: LinkedIn li_at cookie value
+    - name: linkedin-mcp-server.cookie
       env: LINKEDIN_COOKIE
-      example: AQETADxR7bsCqpZlAAACm-lNHKAAAAGXDGmgoE0ARivAnr-8lRlxIM4RDkJcImu3xIucKbYZiKMYUidcyY85e0Fg2gjCpXQ3h_SxVyhJ1TEY_Bp-3z9MWkoRk__bVlwgy9OaHOuxNL4IK-E9yc_ghrwk
+      example: AQETADxR7bsCqpZlAAACm-lNHKAAA...

--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -1,5 +1,5 @@
 name: linkedin-mcp-server
-image: stickerdaniel/linkedin-mcp-server:latest
+image: stickerdaniel/linkedin-mcp-server:1.3.1
 type: server
 meta:
   category: business

--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -19,6 +19,6 @@ source:
 config:
   description: Configure LinkedIn authentication using your session cookie
   secrets:
-    - name: linkedin-mcp-server.linkedin_cookie
+    - name: LinkedIn li_at cookie value
       env: LINKEDIN_COOKIE
       example: AQETADxR7bsCqpZlAAACm-lNHKAAAAGXDGmgoE0ARivAnr-8lRlxIM4RDkJcImu3xIucKbYZiKMYUidcyY85e0Fg2gjCpXQ3h_SxVyhJ1TEY_Bp-3z9MWkoRk__bVlwgy9OaHOuxNL4IK-E9yc_ghrwk

--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -1,5 +1,5 @@
 name: linkedin-mcp-server
-image: stickerdaniel/linkedin-mcp-server:1.3.1
+image: stickerdaniel/linkedin-mcp-server:1.3.2
 type: server
 meta:
   category: business

--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -1,0 +1,24 @@
+name: linkedin-mcp-server
+image: stickerdaniel/linkedin-mcp-server:latest
+type: server
+meta:
+  category: business
+  tags:
+    - linkedin
+    - business
+    - scraping
+    - profiles
+    - jobs
+    - networking
+about:
+  title: LinkedIn MCP Server
+  description: This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches.
+  icon: https://raw.githubusercontent.com/stickerdaniel/linkedin-mcp-server/main/assets/icons/linkedin.svg
+source:
+  project: https://github.com/stickerdaniel/linkedin-mcp-server
+config:
+  description: Configure LinkedIn authentication using your session cookie
+  secrets:
+    - name: linkedin-mcp-server.linkedin_cookie
+      env: LINKEDIN_COOKIE
+      example: AQETADxR7bsCqpZlAAACm-lNHKAAAAGXDGmgoE0ARivAnr-8lRlxIM4RDkJcImu3xIucKbYZiKMYUidcyY85e0Fg2gjCpXQ3h_SxVyhJ1TEY_Bp-3z9MWkoRk__bVlwgy9OaHOuxNL4IK-E9yc_ghrwk


### PR DESCRIPTION
This PR updates the secret name in the LinkedIn MCP Server configuration for better user experience.

**Changes:**
- Changed secret name from 'linkedin-mcp-server.linkedin_cookie' to 'LinkedIn li_at cookie value'
- Makes it clearer for users what cookie value they need to provide

Follow-up to the merged LinkedIn MCP Server addition.