### PR TITLE
Add Inspektor Gadget MCP Server

### DIFF
--- a/servers/inspektor-gadget/server.yaml
+++ b/servers/inspektor-gadget/server.yaml
@@ -1,0 +1,37 @@
+name: inspektor-gadget
+image: mcp/inspektor-gadget
+type: server
+meta:
+  category: devops
+  tags:
+    - inspektor-gadget
+    - kubernetes
+    - devops
+    - ebpf
+about:
+  title: Inspektor Gadget
+  description: AI interface to troubleshoot and observe Kubernetes/Container workloads
+  icon: https://avatars.githubusercontent.com/u/111520143?s=200&v=4
+source:
+  project: https://github.com/inspektor-gadget/ig-mcp-server
+run:
+  command:
+    - -gadget-discoverer=artifacthub
+    - -gadget-images={{inspektor-gadget.gadget-images}}
+  volumes:
+    - '{{inspektor-gadget.kubeconfig}}:/kubeconfig'
+config:
+  description: Configuration for the Inspektor Gadget MCP Server
+  parameters:
+    type: object
+    properties:
+      kubeconfig:
+        type: string
+        description: Path to the kubeconfig file for accessing Kubernetes clusters
+        default: $HOME/.kube/config
+      gadget-images:
+        type: string
+        description: Comma-separated list of gadget images (trace_dns, trace_tcp, etc) to use, allowing control over which gadgets are available as MCP tools
+        default: ""
+    required:
+      - kubeconfig


### PR DESCRIPTION
This PR adds [Inspektor Gadget MCP server](https://github.com/inspektor-gadget/ig-mcp-server/tree/main) to the registry, giving users an AI interface to troubleshoot and debug Kubernetes/Container workloads. You can [see the example](https://github.com/inspektor-gadget/ig-mcp-server/blob/main/examples/kubernetes/understanding-kubernetes/README.md) to get an overview of what this MCP server offers. 

I am one of maintainer for Inspektor Gadget and would love to ease setting up Inspektor Gadget MCP server via docker mcp registry.

## Testing Done

Imported the catalog in docker desktop and tested with VS Code.

## Questions:
- We are building our [own image](https://github.com/inspektor-gadget/ig-mcp-server/pkgs/container/ig-mcp-server) as part of ig-mcp-server but I like that we have signature with mcp/inspektor-gadget. I assume the CI will automatically push the image? Will the image be updated automatically after changes to our repository?