### PR TITLE
Update Slack MCP

### DIFF
--- a/servers/slack/server.yaml
+++ b/servers/slack/server.yaml
@@ -1,5 +1,5 @@
 name: slack
-image: mcp/slack
+image: zencoderai/slack-mcp
 type: server
 meta:
   category: communication
@@ -7,13 +7,13 @@ meta:
     - slack
     - communication
 about:
-  title: Slack (Archived)
-  description: Interact with Slack Workspaces over the Slack API.
+  title: Slack
+  description: Interact with Slack Workspaces over the Slack API. Supports stdio and Streamable HTTP transport
   icon: https://avatars.githubusercontent.com/u/6911160?s=200&v=4
 source:
-  project: https://github.com/modelcontextprotocol/servers
+  project: https://github.com/zencoderai/slack-mcp-server
   branch: 2025.4.24
-  dockerfile: src/slack/Dockerfile
+  dockerfile: Dockerfile
 config:
   description: Configure the connection to Slack
   secrets:

--- a/servers/slack/server.yaml
+++ b/servers/slack/server.yaml
@@ -12,8 +12,6 @@ about:
   icon: https://avatars.githubusercontent.com/u/6911160?s=200&v=4
 source:
   project: https://github.com/zencoderai/slack-mcp-server
-  branch: 2025.4.24
-  dockerfile: Dockerfile
 config:
   description: Configure the connection to Slack
   secrets:


### PR DESCRIPTION
Hi, [we](https://github.com/zencoderai/slack-mcp-server) are picking up Slack MCP maintenance and support from archived Anthropic's server. Extended it to support Streamable HTTP as transport. So I decided not to create a separate MCP server but just update the links in the existing one. Hope that's ok! Let me know if there is anything else needed for this PR to be merged