### PR TITLE
updates details for brave search

### DIFF
--- a/servers/brave/server.yaml
+++ b/servers/brave/server.yaml
@@ -7,15 +7,33 @@ meta:
     - brave
     - search
 about:
-  title: Brave Search (Archived)
-  description: Web and local search using Brave's Search API
+  title: Brave Search
+  description: Search the Web for pages, images, news, videos, and more using the Brave Search API.
   icon: https://avatars.githubusercontent.com/u/12301619?s=200&v=4
 source:
-  project: https://github.com/modelcontextprotocol/servers
-  branch: 2025.4.24
-  dockerfile: src/brave-search/Dockerfile
+  project: https://github.com/brave/brave-search-mcp-server
 config:
+  description: Configure the Brave Search API connection
   secrets:
     - name: brave.api_key
       env: BRAVE_API_KEY
       example: YOUR_API_KEY_HERE
+  env:
+    - name: BRAVE_MCP_TRANSPORT
+      example: http
+      value: '{{brave.mcp_transport}}'
+    - name: BRAVE_MCP_PORT
+      example: "8080"
+      value: '{{brave.mcp_port}}'
+    - name: BRAVE_MCP_HOST
+      example: 0.0.0.0
+      value: '{{brave.mcp_host}}'
+  parameters:
+    type: object
+    properties:
+      mcp_transport:
+        type: string
+      mcp_port:
+        type: string
+      mcp_host:
+        type: string

--- a/servers/brave/server.yaml
+++ b/servers/brave/server.yaml
@@ -20,7 +20,7 @@ config:
       example: YOUR_API_KEY_HERE
   env:
     - name: BRAVE_MCP_TRANSPORT
-      example: http
+      example: stdio
       value: '{{brave.mcp_transport}}'
     - name: BRAVE_MCP_PORT
       example: "8080"


### PR DESCRIPTION
I have verified that `task build` succeeds (with a [small change for Windows](https://github.com/docker/mcp-registry/pull/98)).

The `task catalog` command also passes, however it does show an incorrect summary of tools, presumably until `http://desktop.docker.com/mcp/catalog/v2/tools/brave.json` is updated—it is unclear to me when/how this resource gets updated. 