### PR TITLE
Add buildkite-mcp-server

### DIFF
--- a/servers/buildkite-mcp-server/server.yaml
+++ b/servers/buildkite-mcp-server/server.yaml
@@ -1,0 +1,20 @@
+name: buildkite-mcp-server
+image: mcp/buildkite-mcp-server
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+about:
+  title: Buildkite
+  description: Buildkite MCP lets agents interact with Buildkite Builds, Jobs, Logs, Packages and Test Suites
+  icon: https://avatars.githubusercontent.com/u/5055988?v=4
+source:
+  project: https://github.com/buildkite/buildkite-mcp-server
+  dockerfile: Dockerfile.local
+config:
+  description: Configure the connection to Buildkite
+  secrets:
+    - name: buildkite-mcp-server.api_key
+      env: BUILDKITE_API_TOKEN
+      example: bkua_xxxxx


### PR DESCRIPTION
Hi there, we'd like to add our official Buildkite MCP server to the Docker MCP Registry and catalog.

https://buildkite.com/
https://github.com/buildkite/buildkite-mcp-server

To test this locally with `task build` as per the contribution guide, I also had to modify cmd/build to pass through overridden dockerfiles in server config, which I pushed up as #103 independently.