### PR TITLE
Rename buildkite-mcp-server to just buildkite

### DIFF
--- a/servers/buildkite/server.yaml
+++ b/servers/buildkite/server.yaml
@@ -1,5 +1,5 @@
-name: buildkite-mcp-server
-image: mcp/buildkite-mcp-server
+name: buildkite
+image: mcp/buildkite
 type: server
 meta:
   category: devops


### PR DESCRIPTION
Followup to #101 that was just merged. I realised that I'd chosen a poor choice of names for the Buildkite MCP server, and it would be cleaner as just `buildkite`