### PR TITLE
Add Airtable MCP Server

### DIFF
--- a/servers/airtable-mcp-server/server.yaml
+++ b/servers/airtable-mcp-server/server.yaml
@@ -1,0 +1,28 @@
+name: airtable-mcp-server
+image: mcp/airtable-mcp-server
+type: server
+meta:
+    category: productivity
+    tags:
+        - productivity
+about:
+    title: Airtable mcp server
+    description: Provides AI assistants with direct access to Airtable bases, allowing them to read schemas, query records, and interact with your Airtable data. Supports listing bases, retrieving table structures, and searching through records to help automate workflows and answer questions about your organized data.
+    icon: https://avatars.githubusercontent.com/u/4953590?v=4
+source:
+    project: https://github.com/domdomegg/airtable-mcp-server
+config:
+    description: Configure the connection to Airtable mcp server
+    secrets:
+        - name: airtable-mcp-server.api_key
+          env: AIRTABLE_API_KEY
+          example: patABC123.def456ghi789jkl012mno345pqr678stu901vwx
+    env:
+        - name: NODE_ENV
+          example: production
+          value: '{{airtable-mcp-server.node_env}}'
+    parameters:
+        type: object
+        properties:
+            nodeenv:
+                type: string


### PR DESCRIPTION
Adding Airtable MCP Server to enable AI assistants to interact with Airtable databases.

Server Details:
- Repository: https://github.com/domdomegg/airtable-mcp-server
- Category: productivity
- Environment: AIRTABLE_API_KEY (secret)
- Description: Provides AI assistants with direct access to Airtable bases for reading schemas, querying records, and automating workflows.