### PR TITLE
Add Firewalla MCP Server

### DIFF
--- a/servers/firewalla-mcp-server/server.yaml
+++ b/servers/firewalla-mcp-server/server.yaml
@@ -24,10 +24,10 @@ config:
   env:
     - name: FIREWALLA_MSP_ID
       example: yourdomain.firewalla.net
-      value: '{{firewalla.msp_id}}'
+      value: '{{msp_id}}'
     - name: FIREWALLA_BOX_ID
       example: 1eb71e38-3a95-4371-8903-ace24c83ab49
-      value: '{{firewalla.box_id}}'
+      value: '{{box_id}}'
   parameters:
     type: object
     properties:

--- a/servers/firewalla-mcp-server/server.yaml
+++ b/servers/firewalla-mcp-server/server.yaml
@@ -1,0 +1,42 @@
+name: firewalla-mcp-server
+image: mcp/firewalla-mcp-server
+type: server
+meta:
+  category: security
+  tags:
+    - firewall
+    - security
+    - monitoring
+    - network
+    - threat-detection
+about:
+  title: Firewalla MCP Server
+  description: Real-time network monitoring, security analysis, and firewall management through 28 specialized tools. Access security alerts, network flows, device status, and firewall rules directly from your Firewalla device.
+  icon: https://avatars.githubusercontent.com/u/16805913?s=200&v=4
+source:
+  project: https://github.com/amittell/firewalla-mcp-server
+config:
+  description: Configure your Firewalla MSP connection credentials
+  secrets:
+    - name: firewalla.msp_token
+      env: FIREWALLA_MSP_TOKEN
+      example: your_msp_access_token_here
+  env:
+    - name: FIREWALLA_MSP_ID
+      example: yourdomain.firewalla.net
+      value: '{{firewalla.msp_id}}'
+    - name: FIREWALLA_BOX_ID
+      example: 1eb71e38-3a95-4371-8903-ace24c83ab49
+      value: '{{firewalla.box_id}}'
+  parameters:
+    type: object
+    properties:
+      msp_id:
+        type: string
+        description: Your Firewalla MSP domain (e.g., company123.firewalla.net)
+      box_id:
+        type: string
+        description: Your Firewalla Box GID (Group ID)
+    required:
+      - msp_id
+      - box_id

--- a/servers/firewalla-mcp-server/server.yaml
+++ b/servers/firewalla-mcp-server/server.yaml
@@ -18,9 +18,20 @@ source:
 config:
   description: Configure your Firewalla MSP connection credentials
   secrets:
-    - name: firewalla.msp_token
+    - name: firewalla-mcp-server.msp_token
       env: FIREWALLA_MSP_TOKEN
       example: your_msp_access_token_here
+  parameters:
+    type: object
+    properties:
+      msp_id:
+        type: string
+        description: Your Firewalla MSP domain (e.g., yourdomain.firewalla.net)
+        example: yourdomain.firewalla.net
+      box_id:
+        type: string
+        description: Your Firewalla Box Global ID
+        example: 1eb71e38-3a95-4371-8903-ace24c83ab49
   env:
     - name: FIREWALLA_MSP_ID
       example: yourdomain.firewalla.net
@@ -28,15 +39,21 @@ config:
     - name: FIREWALLA_BOX_ID
       example: 1eb71e38-3a95-4371-8903-ace24c83ab49
       value: '{{box_id}}'
-  parameters:
-    type: object
-    properties:
-      msp_id:
-        type: string
-        description: Your Firewalla MSP domain (e.g., company123.firewalla.net)
-      box_id:
-        type: string
-        description: Your Firewalla Box GID (Group ID)
-    required:
-      - msp_id
-      - box_id
+    - name: MCP_WAVE0_ENABLED
+      value: 'true'
+    - name: MCP_READ_ONLY_MODE
+      value: 'false'
+    - name: MCP_CACHE_ENABLED
+      value: 'true'
+    - name: MCP_DEBUG_MODE
+      value: 'false'
+    - name: NODE_ENV
+      value: 'production'
+    - name: LOG_LEVEL
+      value: 'info'
+    - name: MCP_CACHE_TTL
+      value: '300'
+    - name: MCP_RATE_LIMIT_WINDOW
+      value: '60000'
+    - name: MCP_RATE_LIMIT_MAX_REQUESTS
+      value: '100'


### PR DESCRIPTION
## Summary

This PR adds the Firewalla MCP Server to the Docker MCP Registry.

## About Firewalla MCP Server

Real-time network monitoring, security analysis, and firewall management through 28 specialized tools. Access security alerts, network flows, device status, and firewall rules directly from your Firewalla device.

### Key Features
- **28 specialized tools** for comprehensive network monitoring
- **Real-time security alerts** and threat detection
- **Network flow analysis** with advanced search capabilities
- **Device status monitoring** and bandwidth tracking
- **Firewall rule management** with pause/resume functionality

### Technical Details
- **License**: MIT
- **Docker Image**: Already published to Docker Hub as 
- **GitHub Repository**: https://github.com/amittell/firewalla-mcp-server
- **Category**: Security
- **Tags**: firewall, security, monitoring, network, threat-detection

### Testing
- Built and tested locally using Usage: task build -- <server> and Usage: catalog <server-name>
- Docker image runs successfully with proper MCP stdio transport
- All 28 tools verified working with test credentials

### Configuration Required
- : MSP access token (secret)
- : MSP domain (e.g., company.firewalla.net)
- : Firewalla Box GID

Looking forward to making Firewalla network monitoring accessible through the MCP ecosystem!