### PR TITLE
feat: update pluggedin-mcp-proxy to v1.8.0

### DIFF
--- a/servers/pluggedin-mcp-proxy/server.yaml
+++ b/servers/pluggedin-mcp-proxy/server.yaml
@@ -1,5 +1,5 @@
 name: pluggedin-mcp-proxy
-image: mcp/pluggedin-mcp-proxy
+image: mcp/pluggedin-mcp-proxy:v1.8.0
 type: server
 meta:
   category: productivity
@@ -9,14 +9,20 @@ meta:
     - management
     - tools
     - ai
+    - oauth
+    - notifications
+    - documents
+    - data-ownership
+    - ai-hub
+    - unified-interface
 about:
-  title: Plugged.in MCP Proxy
-  description: A unified MCP proxy that aggregates multiple MCP servers into one interface, enabling seamless tool discovery and management across all your AI interactions. Manage all your MCP servers from a single connection point with RAG capabilities and real-time notifications.
+  title: Plugged.in - The Crossroads for AI Data Exchanges
+  description: The central hub where all your AI interactions converge - and where you maintain complete ownership. Connect any AI model through a unified MCP interface while keeping every insight, configuration, and successful prompt as YOUR asset. Break free from platform lock-in and build compounding value from your AI-generated data across Claude, GPT, and any other model.
   icon: https://www.plugged.in/favicon.ico
 source:
   project: https://github.com/VeriTeknik/pluggedin-mcp-proxy
 config:
-  description: Configure your Plugged.in API connection. Get your API key from https://plugged.in in the API Keys section.
+  description: Connect to the crossroads for your AI data exchanges. Get your API key from https://plugged.in to start owning every AI interaction.
   secrets:
     - name: pluggedin-mcp-proxy.pluggedin_api_key
       env: PLUGGEDIN_API_KEY


### PR DESCRIPTION
This PR updates the pluggedin-mcp-proxy server to version 1.8.0, which includes significant new features and aligns the description with plugged.in's value proposition as
  "The Crossroads for AI Data Exchanges."

  Changes Made

  - Updated Docker image tag from mcp/pluggedin-mcp-proxy to mcp/pluggedin-mcp-proxy:v1.8.0
  - Updated title to: "Plugged.in - The Crossroads for AI Data Exchanges"
  - Rewrote description to emphasize data ownership, control, and breaking free from platform lock-in
  - Added new tags: oauth, notifications, documents, data-ownership, ai-hub, unified-interface
  - Updated config description to align with the value proposition

  New Features in v1.8.0

  AI Document Management Tools:
  - pluggedin_create_document - Create AI-generated documents with multiple formats (Markdown, text, JSON, HTML)
  - pluggedin_list_documents - Browse documents with filtering, sorting, and pagination
  - pluggedin_search_documents - Semantic search powered by RAG with natural language queries
  - pluggedin_get_document - Retrieve document details with version history
  - pluggedin_update_document - Update documents with version tracking

  Additional Enhancements:
  - OAuth token management for seamless authentication
  - Bidirectional notifications system
  - Registry v2 support
  - Trending analytics for tool usage
  - Enhanced security with Zod validation

  Testing

  - Built and tested the Docker image locally
  - Verified MCP server functionality
  - Confirmed all environment variables are properly configured

  References

  - Upstream repository: https://github.com/VeriTeknik/pluggedin-mcp
  - Release notes: https://github.com/VeriTeknik/pluggedin-mcp/releases/tag/v1.8.0