### PR TITLE
Update Azure MCP entry

### DIFF
--- a/servers/azure/server.yaml
+++ b/servers/azure/server.yaml
@@ -1,5 +1,5 @@
 name: azure
-image: mcp/azure
+image: microsoft/azure-sdk-azure-mcp
 type: server
 meta:
   category: devops
@@ -11,7 +11,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/6844498?s=200&v=4
 source:
   project: https://github.com/Azure/azure-mcp
-  branch: 1ea702cb489ba95c5d9bea8d41fc18e9343703f8
+  branch: main
 run:
   command:
     - server


### PR DESCRIPTION
Updates Azure MCP server to official image.

Is there a way to update https://hub.docker.com/r/mcp/azure/ to point to this image? We've gotten feedback from customers about that image lagging behind our main branch (because they believe we own that image and its the first one they find).