### PR TITLE
feat: add Hostinger API MCP to the catalog

### DIFF
--- a/servers/hostinger-mcp-server/server.yaml
+++ b/servers/hostinger-mcp-server/server.yaml
@@ -1,0 +1,19 @@
+name: hostinger-mcp-server
+image: mcp/api-mcp-server
+type: server
+meta:
+    category: devops
+    tags:
+        - devops
+about:
+    title: Hostinger API MCP Server
+    description: Interact with Hostinger services over the Hostinger API.
+    icon: https://avatars.githubusercontent.com/u/2630767?v=4
+source:
+    project: https://github.com/hostinger/api-mcp-server
+config:
+    description: Configure the connection to Hostinger API MCP Server
+    secrets:
+        - name: hostinger-mcp-server.api_token
+          env: APITOKEN
+          example: 0ASvFDoYoloTOoLd6fSRKUx9ihuoejCVbTT6xpmob7adce6d


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: Hostinger API MCP
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** Hostinger API MCP
**Repository URL:** https://github.com/hostinger/api-mcp-server
**Brief Description:** Interact with Hostinger services over the Hostinger API

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
