### PR TITLE
Add Seqia MCP server to catalog

### DIFF
--- a/servers/sequa/server.yaml
+++ b/servers/sequa/server.yaml
@@ -22,10 +22,10 @@ config:
           example: your_sequa_api_key
     env:
         - name: MCP_SERVER_URL
-          example: https://mcp.sequa.ai/v1/setup-code-assistant
+          example: https://mcp.sequa.ai/v1/setup-example
           value: '{{sequa.mcp_server_url}}'
     parameters:
         type: object
         properties:
-            mcpserverurl:
+            mcp_server_url:
                 type: string


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Sequa.AI
**Repository URL:** https://github.com/sequa-ai/sequa-mcp
**Brief Description:** Stop stitching context for Copilot and Cursor. With Sequa MCP, your AI tools know your entire codebase and docs out of the box.

Sequa.AI (https://sequa.ai) is a Model Context Protocol (MCP) server that gives Copilot, Cursor, and other MCP‑capable assistants full-codebase and docs awareness without manual prompt stitching. Point it at your repos and knowledge bases once; after that, your AI tools can browse, search, diff, and reason over everything through standardized MCP tools.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME` 

*Why is the last box not checked?*: When running `task build -- --tools sequa` it always exited with status 1 but I tested the mcp server locally with docker desktop and it worked after successful authentication
