### PR TITLE
Add Rook Ceph MCP Server

### DIFF
--- a/servers/rook-ceph-mcp-server/server.yaml
+++ b/servers/rook-ceph-mcp-server/server.yaml
@@ -1,5 +1,5 @@
 name: rook-ceph-mcp-server
-image: rook-ceph-mcp-server
+image: mcp/rook-ceph-mcp-server
 type: server
 metadata:
   category: Infrastructure
@@ -13,8 +13,9 @@ metadata:
 about:
   title: Rook Ceph MCP Server
   description: A Model Context Protocol server for managing Rook Ceph storage clusters in Kubernetes environments. Provides tools for cluster management, storage resource operations, and pre-configured YAML templates.
-  icon: 🗂️
-source: https://github.com/shreyanshjain7174/ceph-mcp
+  icon: https://avatars.githubusercontent.com/u/35940573?s=200&v=4
+source:
+  project: https://github.com/shreyanshjain7174/rook-ceph-mcp
 config:
   variables:
     - name: KUBECONFIG


### PR DESCRIPTION
## Summary

This PR adds the Rook Ceph MCP Server to the registry. This server enables AI assistants to manage Rook Ceph storage clusters in Kubernetes environments.

### Features
- **Cluster Management**: List and monitor Ceph clusters
- **Storage Resources**: Manage block pools, filesystems, and object stores  
- **Manifest Templates**: Access pre-configured YAML templates for common resources
- **Kubernetes Integration**: Native Kubernetes API integration
- **Dual Transport**: Both stdio and HTTP transport support

### Tools Provided
- `list_clusters` - List all Ceph clusters
- `get_cluster_status` - Get detailed cluster status
- `list_block_pools` - List Ceph block pools
- `list_filesystems` - List Ceph filesystems
- `list_object_stores` - List Ceph object stores
- `create_block_pool` - Create new block pools
- `delete_resource` - Delete any Ceph resource

### Resources Provided
- YAML templates for Ceph clusters, block pools, filesystems, and object stores

### Prerequisites
- Kubernetes cluster with Rook Ceph operator installed
- Valid kubeconfig file for cluster access

### License
MIT License (compatible with registry requirements)

### Repository
https://github.com/shreyanshjain7174/ceph-mcp

The server is production-ready with comprehensive error handling, TypeScript implementation, and Docker support.