### PR TITLE
Add Kafka Schema Registry MCP server

### DIFF
--- a/servers/kafka-schema-reg-mcp/server.yaml
+++ b/servers/kafka-schema-reg-mcp/server.yaml
@@ -1,0 +1,54 @@
+name: kafka-schema-reg-mcp
+image: aywengo/kafka-schema-reg-mcp:stable
+type: server
+meta:
+  category: database
+  tags:
+    - kafka
+    - schema-registry
+    - database
+    - devops
+    - streaming
+about:
+  title: Kafka Schema Registry MCP
+  description: Comprehensive MCP server for Kafka Schema Registry operations. Features multi-registry support, schema contexts, migration tools, OAuth authentication, and 57+ tools for complete schema management. Supports SLIM_MODE for optimal performance.
+  icon: https://raw.githubusercontent.com/aywengo/kafka-schema-reg-mcp/main/docs/logo_400_mcp_kafka_schema_reg.png
+source:
+  project: https://github.com/aywengo/kafka-schema-reg-mcp
+run:
+  allowHosts:
+    - "*:8081"  # Schema Registry default port
+    - "*:443"   # For OAuth providers
+config:
+  description: Configure connection to Kafka Schema Registry
+  env:
+    - name: SCHEMA_REGISTRY_URL
+      example: http://localhost:8081
+      value: '{{kafka-schema-reg.registry_url}}'
+    - name: SLIM_MODE
+      example: "true"
+      value: '{{kafka-schema-reg.slim_mode}}'
+      description: "Enable SLIM_MODE to reduce tools from 57+ to ~9 essential tools (recommended)"
+  secrets:
+    - name: kafka-schema-reg.registry_user
+      env: SCHEMA_REGISTRY_USER
+      example: <REGISTRY_USERNAME>
+      description: "Optional: Schema Registry username for authentication"
+    - name: kafka-schema-reg.registry_password
+      env: SCHEMA_REGISTRY_PASSWORD
+      example: <REGISTRY_PASSWORD>
+      description: "Optional: Schema Registry password for authentication"
+  parameters:
+    type: object
+    properties:
+      registry_url:
+        type: string
+        description: "Schema Registry URL"
+        default: "http://localhost:8081"
+      slim_mode:
+        type: string
+        description: "Enable SLIM_MODE for better performance"
+        default: "true"
+        enum: ["true", "false"]
+    required:
+      - registry_url


### PR DESCRIPTION
## Add Kafka Schema Registry MCP Server

### Overview
Comprehensive MCP server for Kafka Schema Registry operations with advanced features for enterprise schema management.

### Key Features
- 🏢 **Multi-Registry Support** - Manage up to 8 Schema Registry instances
- 📋 **Schema Contexts** - Logical grouping for production/staging isolation  
- 🔄 **Schema Migration** - Cross-registry migration with verification
- 🔒 **OAuth 2.1** - Enterprise-grade authentication
- 🚀 **SLIM_MODE** - Reduce tools from 50+ to ~9 for optimal performance
- 📊 **Full MCP Compliance** - MCP 2025-06-18 specification

### Technical Details
- **Docker Image**: `aywengo/kafka-schema-reg-mcp:stable`
- **License**: MIT
- **Tools**: 50+ (or ~9 in SLIM_MODE)
- **Resources**: 19 MCP resources
- **Framework**: FastMCP 2.8.0+

### Testing
- Tested with Claude Desktop, Cursor, and VS Code
- Docker image available with 1K+ pulls
- Comprehensive test suite included

### Documentation
- Full API documentation: [api-reference.md](https://github.com/aywengo/kafka-schema-reg-mcp/blob/main/docs/api-reference.md)
- Use cases: [use-cases.md](https://github.com/aywengo/kafka-schema-reg-mcp/blob/main/docs/use-cases.md)
- Deployment guide: [deployment.md](https://github.com/aywengo/kafka-schema-reg-mcp/blob/main/docs/deployment.md)