### PR TITLE
added gmail  mcp server

### DIFF
--- a/servers/gmail/server.yaml
+++ b/servers/gmail/server.yaml
@@ -1,0 +1,35 @@
+name: gmail
+image: mcp/gmail
+type: server
+meta:
+  category: productivity
+  tags:
+    - email
+    - gmail
+about:
+  title: Gmail Email Client
+  description: Secure email management for Gmail accounts
+  icon: https://cdn.example.com/gmail-icon.png # 512x512 PNG
+source:
+  project: https://github.com/shreyannandanwar/gmail-mcp-server
+config:
+  description: Configure Gmail OAuth credentials
+  secrets:
+    - name: gmail.client_secret
+      env: GMAIL_CLIENT_SECRET
+      example: <YOUR_GMAIL_SECRET>
+  env:
+    - name: GMAIL_CLIENT_ID
+      example: <YOUR_GMAIL_CLIENT_ID>
+      value: '{{gmail.client_id}}'
+  parameters:
+    type: object
+    properties:
+      client_id:
+        type: string
+    required:
+      - client_id
+oauth:
+  - provider: google
+    secret: gmail.oauth_token
+    env: GMAIL_OAUTH_TOKEN


### PR DESCRIPTION
### Add Gmail AutoAuth MCP Server to MCP Registry

This PR registers the Gmail AutoAuth MCP server to the MCP Registry, enabling integration of Gmail-based workflows through OAuth2 authentication and secure message access.

---

### 📌 About Gmail AutoAuth MCP

The Gmail MCP server provides an MCP interface to Google Mail, allowing AI agents to:

- Programmatically access inbox messages
- Use OAuth2 for secure authentication
- Automate parsing, summarization, and replying to emails
- Enable persistent email access using refresh tokens

This is particularly useful for assistants and communication-focused AI agents.

---

### ✅ Included in This PR

- New server definition: `servers/gmail/server.yaml`
- Category: `productivity`
- Docker image: `mcp/gmail` (must be built locally before use)

To start this server:

```bash
task start gmail
```

---

### 🛠 Build Instructions (before using)

First, build the local Gmail MCP Docker image:

```bash
git clone https://github.com/GongRzhe/Gmail-MCP-Server.git
cd Gmail-MCP-Server
docker build -t mcp/gmail .
```

---

### 🔐 Secrets Required

The following secrets must be provided at runtime:

```yaml
secrets:
  - name: gmail.client_id
    env: GMAIL_CLIENT_ID
  - name: gmail.client_secret
    env: GMAIL_CLIENT_SECRET
  - name: gmail.refresh_token
    env: GMAIL_REFRESH_TOKEN
```

---

### 📎 Additional Info

Gmail MCP GitHub Repo: [https://github.com/shreyannandanwar/Gmail-MCP-Server](https://github.com/shreyannandanwar/Gmail-MCP-Server)

This MCP runs fully local using a developer-built Docker image, allowing for secure Gmail integration without relying on Docker Hub.

Let me know if any updates or changes are needed!

