### PR TITLE
Fix "Get changed servers" step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          git diff --name-only --diff-filter=AM origin/${{ github.event.pull_request.base.ref }} HEAD | grep "^servers/" > changed-servers.txt || true
+          git diff --name-only --diff-filter=AM origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^servers/" > changed-servers.txt || true
 
       - name: Build and catalog changed servers
         shell: bash


### PR DESCRIPTION
The problem was that it was including changes not in the current `origin/main` but in an older branch of `origin/main` ([failure example](https://github.com/docker/mcp-registry/actions/runs/16291178226/job/46979522509?pr=71)). Now, it will diff against the merge base instead of the newest commit on `main`.