### PR TITLE
Add Azure Kubernetes Service (AKS) official MCP server

### DIFF
--- a/servers/aks/server.yaml
+++ b/servers/aks/server.yaml
@@ -1,0 +1,51 @@
+name: aks
+image: mcp/aks
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - azure
+    - kubernetes
+    - aks
+about:
+  title: Azure Kubernetes Service (AKS)
+  description: Azure Kubernetes Service (AKS) official MCP server
+  icon: https://raw.githubusercontent.com/Azure/AKS/master/blog/assets/images/400x400.png
+source:
+  project: https://github.com/Azure/aks-mcp
+run:
+  command:
+    - --transport=stdio
+    - --access-level={{aks.access_level}}
+    - --allow-namespaces={{aks.allow_namespaces}}
+    - --additional-tools={{aks.additional_tools}}
+  volumes:
+    - '{{aks.azure_dir}}:/home/mcp/.azure'
+    - '{{aks.kubeconfig}}:/home/mcp/.kube/config'
+config:
+  description: Configuration for AKS-MCP server
+  parameters:
+    type: object
+    properties:
+      azure_dir:
+        type: string
+        description: Path to the Azure configuration directory (e.g. /home/azureuser/.azure). Used for Azure CLI authentication, you should be logged in (e.g. run `az login`) on the host before starting the MCP server.
+      kubeconfig:
+        type: string
+        description: Path to the kubeconfig file for the AKS cluster (e.g. /home/azureuser/.kube/config). Used to connect to the AKS cluster.
+      access_level:
+        type: string
+        description: Access level for the MCP server, One of [ readonly, readwrite, admin ]
+        default: readonly
+      allow_namespaces:
+        type: string
+        description: Comma-separated list of namespaces to allow access to. If not specified, all namespaces are allowed.
+      additional_tools:
+        type: string
+        description: Comma-separated list of additional tools, One of [ helm, cilium ]
+    required:
+      - azure_dir
+      - kubeconfig
+      - access_level
+


### PR DESCRIPTION
## MCP Server Information

**Server Name:** AKS MCP Server 
**Repository URL:** https://github.com/Azure/aks-mcp
**Brief Description:** Azure Kubernetes Service (AKS) official MCP server. It enables AI assistants to interact with AKS clusters. It serves as a bridge between AI tools (like Claude, Cursor, and GitHub Copilot) and AKS.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name aks`
- [x] I have built the MCP Server using `task build -- --tools aks`

## Testing Done

```
→ task validate -- --name aks
task: [validate] go run ./cmd/validate --name aks
✅ Name is valid
✅ Directory is valid
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
```

```
→ task build -- --tools aks
...
...

14 tools found.

-----------------------------------------

✅ Image built as mcp/aks
```