### PR TITLE
This image only supports stdio transport today

### DIFF
--- a/servers/brave/server.yaml
+++ b/servers/brave/server.yaml
@@ -20,20 +20,4 @@ config:
       example: YOUR_API_KEY_HERE
   env:
     - name: BRAVE_MCP_TRANSPORT
-      example: stdio
-      value: '{{brave.mcp_transport}}'
-    - name: BRAVE_MCP_PORT
-      example: "8080"
-      value: '{{brave.mcp_port}}'
-    - name: BRAVE_MCP_HOST
-      example: 0.0.0.0
-      value: '{{brave.mcp_host}}'
-  parameters:
-    type: object
-    properties:
-      mcp_transport:
-        type: string
-      mcp_port:
-        type: string
-      mcp_host:
-        type: string
+      value: 'stdio'

--- a/servers/brave/server.yaml
+++ b/servers/brave/server.yaml
@@ -20,4 +20,5 @@ config:
       example: YOUR_API_KEY_HERE
   env:
     - name: BRAVE_MCP_TRANSPORT
-      value: 'stdio'
+      example: "stdio"
+      value: "stdio"


### PR DESCRIPTION
This is a fix to the brave entry. The image is not yet set up to support non-stdio transport so we should not include that option. 

Also, existing users of the brave catalog were broken by the previous change because stdio was no longer the default. This change will fix the catalog for existing users of the brave catalog entry.