### PR TITLE
Add Interactive Brokers MCP Server

### DIFF
--- a/servers/ibkr-mcp/server.yaml
+++ b/servers/ibkr-mcp/server.yaml
@@ -1,0 +1,51 @@
+name: ibkr-mcp
+image: mcp/ibkr-mcp
+type: server
+meta:
+  category: trading
+  tags:
+    - interactive-brokers
+    - ibkr
+    - trading
+    - finance
+    - api
+about:
+  title: Interactive Brokers MCP Server
+  icon: https://www.interactivebrokers.com/images/web/logos/ib-logo.svg
+  description: Connect to Interactive Brokers API for trading operations, market data, and portfolio management
+source:
+  project: https://github.com/yourusername/ibkr-mcp-server
+config:
+  description: Configure the connection to Interactive Brokers TWS or IB Gateway
+  env:
+    - name: IBKR_HOST
+      example: "127.0.0.1"
+      value: '{{ibkr.host}}'
+      default: "127.0.0.1"
+    - name: IBKR_PORT
+      example: "4001"
+      value: '{{ibkr.port}}'
+      default: "4001"
+    - name: IBKR_CLIENT_ID
+      example: "0"
+      value: '{{ibkr.client_id}}'
+      default: "0"
+  parameters:
+    type: object
+    properties:
+      host:
+        type: string
+        description: IBKR TWS/Gateway host address
+        default: "127.0.0.1"
+      port:
+        type: integer
+        description: IBKR TWS/Gateway port (4001 for IB Gateway, 7497 for TWS Paper Trading)
+        default: 4001
+      client_id:
+        type: integer
+        description: Client ID for IBKR connection
+        default: 0
+    required:
+      - host
+      - port
+      - client_id


### PR DESCRIPTION
Title: Add Interactive Brokers MCP Server
Description:
MCP Server Information
Server Name: Interactive Brokers MCP Server (ibkr-mcp)
Repository URL: https://github.com/gpolydatas/ibkr-mcp-server
Brief Description: MCP server that connects to Interactive Brokers API for trading operations, market data retrieval, portfolio management, and order execution. Supports both TWS and IB Gateway connections with comprehensive trading functionality including real-time quotes, historical data, position tracking, and order management.
Basic Requirements

 Open Source: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
 MCP Compliant: Implements MCP API specification
 Active Development: Recent commits and maintained
 Docker Artifact: Dockerfile
 Documentation: Basic README and setup instructions
 Security Contact: Method for reporting security issues

Submitter Checklist

 This server meets the basic requirements listed above
 I understand this will undergo automated and manual review.
 I have tested the MCP Server using task validate -- --name ibkr-mcp
 I have built the MCP Server using task build -- --tools ibkr-mcp