### PR TITLE
Fix image name for Azure MCP server

### DIFF
--- a/servers/azure/server.yaml
+++ b/servers/azure/server.yaml
@@ -1,5 +1,5 @@
 name: azure
-image: microsoft/azure-sdk-azure-mcp
+image: mcr.microsoft.com/azure-sdk/azure-mcp
 type: server
 meta:
   category: devops


### PR DESCRIPTION
---
name: Fix image name for Azure MCP server
about: Update the location of Azure MCP image name.  Images are hosted in mcr.microsoft.com so the pull won't work.
title: "Fix image name for Azure MCP server"
labels: 
assignees: ""
---

## MCP Server Information

**Server Name:** Azure MCP server
**Repository URL:**  http://github.com/azure/azure-mcp
**Brief Description:**

The original PR points to a syndicated page in Docker Hub, but the actual command should come from mcr.microsoft.com.
Bug Report: https://github.com/docker/mcp-registry/commit/cb8deb598a3a6ea7dfe930903c41c7d2eff9cfef#r163115741


## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
  - This is not docker built, so the output warning to pull `docker pull mcr.microsoft.com/azure-sdk/azure-mcp`  works.
