### PR TITLE
add Cloud Run server

### DIFF
--- a/servers/cloud-run-mcp/server.yaml
+++ b/servers/cloud-run-mcp/server.yaml
@@ -1,0 +1,28 @@
+name: cloud-run-mcp
+image: mcp/cloud-run-mcp:latest
+type: server
+meta:
+    category: devops
+    tags:
+        - devops
+about:
+    title: Cloud Run MCP
+    description: MCP server to deploy apps to Cloud Run
+    icon: https://avatars.githubusercontent.com/u/2810941?v=4
+source:
+    project: https://github.com/GoogleCloudPlatform/cloud-run-mcp
+config:
+  description: Configure the connection to Google Cloud Run
+  env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: '/app/.config/gcloud/application_default_credentials.json'
+      example: '/Users/slim/.config/gcloud/application_default-credentials.json'
+  parameters:
+    type: object
+    properties:
+      credentials_path:
+        type: string
+        description: path to application-default credentials (eg $HOME/.config/gcloud/application_default_credentials.json )
+run:
+    volumes:
+      - '{{cloud-run-mcp.credentials_path}}:/app/.config/gcloud/application_default_credentials.json'


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** cloud-run-mcp
**Repository URL:** https://github.com/GoogleCloudPlatform/cloud-run-mcp
**Brief Description:** MCP server to deploy apps to Cloud Run

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
