### PR TITLE
feat: add code-review-mcp server entry (shadabbi/code-review-mcp:latest)

### DIFF
--- a/servers/code-review-mcp/server.yaml
+++ b/servers/code-review-mcp/server.yaml
@@ -1,0 +1,47 @@
+name: code-review-mcp
+image: shadabbi/code-review-mcp:latest
+type: server
+meta:
+  category: code-review
+  tags:
+    - code-review
+    - github
+    - jira
+    - security
+    - tests
+about:
+  title: AI Code Review MCP
+  description: AI-powered PR reviews with ESLint/Prettier/TypeScript, Semgrep, Playwright, and Jira context
+  icon: https://raw.githubusercontent.com/github/explore/main/topics/javascript/javascript.png
+source:
+  project: https://github.com/shadabbi/code-review-mcp
+config:
+  description: Configure tokens and optional integrations for code review
+  secrets:
+    - name: code-review-mcp.github_token
+      env: GITHUB_TOKEN
+      example: ghp_xxx
+  env:
+    - name: JIRA_BASE_URL
+      example: https://your-org.atlassian.net
+    - name: JIRA_EMAIL
+      example: you@org.com
+    - name: JIRA_API_KEY
+      example: atlassian_api_key
+    - name: FIGMA_TOKEN
+      example: figd_xxx
+    - name: SEMGREP_RULES_DIR
+      example: .mcp/code-review/semgrep-rules
+  parameters:
+    type: object
+    properties:
+      jira_base_url:
+        type: string
+      jira_email:
+        type: string
+      jira_api_key:
+        type: string
+      figma_token:
+        type: string
+      semgrep_rules_dir:
+        type: string


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Add code-review-mcp: AI Code Review MCP server (GitHub/Jira, ESLint/Prettier/TS, Semgrep, Playwright)"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** code-review-mcp  
**Repository URL:** https://github.com/shadabbi/code-review-mcp  
**Brief Description:** AI-powered PR reviews for GitHub. Orchestrates ESLint/Prettier/TypeScript checks, Semgrep security scan, optional Playwright tests, and Jira/Figma context. Posts inline PR comments and generates a Markdown summary report. License: MIT.

- **Image:** `shadabbi/code-review-mcp:latest` (public)
- **Category:** code-review
- **Tags:** code-review, github, jira, security, tests, linting
- **Tools exposed:**  
  - `code-review` (orchestration)  
  - Sub-tools: `github.resolve_pr`, `github.fetch_files`, `jira.fetch`, `analysis.run_static`, `security.run_semgrep`, `tests.run_playwright`, `report.generate`, `cleanup.prune`
- **Secrets/Env:**  
  - Secrets: `GITHUB_TOKEN` (required)  
  - Env (optional): `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_KEY`, `FIGMA_TOKEN`, `SEMGREP_RULES_DIR`
- **Source repo (docs/code):** https://github.com/shadabbi/code-review-mcp
- **Server descriptor (in this PR):** `servers/code-review-mcp/server.yaml`

## Basic Requirements

- [x] **Open Source**: MIT (per LICENSE in repo)
- [x] **MCP Compliant**: Implements MCP server over stdio and lists callable tools
- [x] **Active Development**: Recent commits present
- [x] **Docker Artifact**: Dockerfile at repo root, image published to Docker Hub
- [x] **Documentation**: README with setup/usage + Platform-Setup.md
- [x] **Security Contact**: GitHub Issues in source repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above  
- [x] I understand this will undergo automated and manual review.  
- [x] I have tested the MCP Server locally (container built, tools list accessible)  
- [x] I have a working Docker image: `docker pull shadabbi/code-review-mcp:latest`

## Notes

- This MCP focuses on developer workflows: PR code review with project-local ESLint/Prettier/TS rules, Semgrep scans (custom rules supported), and Playwright if configured.  
- Optional enrichments: Jira ticket fetch, Figma design metadata.  
- If GitHub disallows author self-review comments, the MCP gracefully skips posting but still generates the report.
