### PR TITLE
Add Prometheus MCP Server to registry

### DIFF
--- a/servers/prometheus/server.yaml
+++ b/servers/prometheus/server.yaml
@@ -1,54 +1,34 @@
 name: prometheus
-image: mcp/prometheus
+image: ghcr.io/pab1it0/prometheus-mcp-server
 type: server
 meta:
   category: monitoring
   tags:
+    - ai
+    - devops
+    - llm
+    - model-context-protocol
     - prometheus
-    - monitoring
     - metrics
+    - monitoring
+    - observability
 about:
-  title: Prometheus MCP Server
-  description: A Model Context Protocol server for Prometheus, providing access to metrics and queries through standardized MCP interfaces
-  icon: https://avatars.githubusercontent.com/u/3380462?s=200&v=4
+  title: Prometheus
+  description: A Model Context Protocol (MCP) server that enables AI assistants to query and analyze Prometheus metrics through standardized interfaces. Connect to your Prometheus instance to retrieve metrics, perform queries, and gain insights into your system's performance and health.
+  icon: https://upload.wikimedia.org/wikipedia/commons/3/38/Prometheus_software_logo.svg
 source:
   project: https://github.com/pab1it0/prometheus-mcp-server
-  branch: main
 config:
-  description: Configure the connection to Prometheus
+  description: Configure the connection to your Prometheus server
   env:
     - name: PROMETHEUS_URL
-      example: http://localhost:9090
+      example: http://host.docker.internal:9090
       value: '{{prometheus.prometheus_url}}'
-    - name: PROMETHEUS_USERNAME
-      example: your_username
-      value: '{{prometheus.prometheus_username}}'
-    - name: PROMETHEUS_PASSWORD
-      example: your_password
-      value: '{{prometheus.prometheus_password}}'
-    - name: PROMETHEUS_TOKEN
-      example: your_token
-      value: '{{prometheus.prometheus_token}}'
-    - name: ORG_ID
-      example: your_organization_id
-      value: '{{prometheus.org_id}}'
   parameters:
     type: object
     properties:
       prometheus_url:
         type: string
-        description: URL of your Prometheus server
-      prometheus_username:
-        type: string
-        description: Basic auth username (optional)
-      prometheus_password:
-        type: string
-        description: Basic auth password (optional)
-      prometheus_token:
-        type: string
-        description: Bearer token for authentication (optional)
-      org_id:
-        type: string
-        description: Organization ID for multi-tenant setups (optional)
+        description: The URL of your Prometheus server
     required:
       - prometheus_url

--- a/servers/prometheus/server.yaml
+++ b/servers/prometheus/server.yaml
@@ -1,0 +1,54 @@
+name: prometheus
+image: mcp/prometheus
+type: server
+meta:
+  category: monitoring
+  tags:
+    - prometheus
+    - monitoring
+    - metrics
+about:
+  title: Prometheus MCP Server
+  description: A Model Context Protocol server for Prometheus, providing access to metrics and queries through standardized MCP interfaces
+  icon: https://avatars.githubusercontent.com/u/3380462?s=200&v=4
+source:
+  project: https://github.com/pab1it0/prometheus-mcp-server
+  branch: main
+config:
+  description: Configure the connection to Prometheus
+  env:
+    - name: PROMETHEUS_URL
+      example: http://localhost:9090
+      value: '{{prometheus.prometheus_url}}'
+    - name: PROMETHEUS_USERNAME
+      example: your_username
+      value: '{{prometheus.prometheus_username}}'
+    - name: PROMETHEUS_PASSWORD
+      example: your_password
+      value: '{{prometheus.prometheus_password}}'
+    - name: PROMETHEUS_TOKEN
+      example: your_token
+      value: '{{prometheus.prometheus_token}}'
+    - name: ORG_ID
+      example: your_organization_id
+      value: '{{prometheus.org_id}}'
+  parameters:
+    type: object
+    properties:
+      prometheus_url:
+        type: string
+        description: URL of your Prometheus server
+      prometheus_username:
+        type: string
+        description: Basic auth username (optional)
+      prometheus_password:
+        type: string
+        description: Basic auth password (optional)
+      prometheus_token:
+        type: string
+        description: Bearer token for authentication (optional)
+      org_id:
+        type: string
+        description: Organization ID for multi-tenant setups (optional)
+    required:
+      - prometheus_url


### PR DESCRIPTION
This commit adds the Prometheus MCP Server to the official Docker MCP Registry.

The server provides:
- PromQL query execution against Prometheus
- Metrics discovery and exploration
- Authentication support (basic auth and bearer token)
- Multi-tenant support for setups like Cortex, Mimir, or Thanos

## MCP Server Information

**Server Name:Prometheus**
**Repository URL:https://github.com/pab1it0/prometheus-mcp-server**
**Brief Description:A Model Context Protocol (MCP) server that enables AI assistants to query and analyze Prometheus metrics through standardized interfaces. **

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
