### PR TITLE
Add Teamwork.com MCP server to registry

### DIFF
--- a/servers/teamwork/server.yaml
+++ b/servers/teamwork/server.yaml
@@ -1,0 +1,25 @@
+name: teamwork
+image: mcp/teamwork
+type: server
+meta:
+  category: productivity
+  tags:
+    - ai
+    - artificial-intelligence
+    - teamwork
+about:
+  title: Teamwork
+  description: Tools for Teamwork.com products.
+  icon: https://avatars.githubusercontent.com/u/4037476?v=4
+source:
+  project: https://github.com/teamwork/mcp
+  branch: main
+run:
+  command:
+    - /bin/tw-mcp-stdio
+config:
+  description: Configure the connection to Teamwork.com MCP server
+  secrets:
+    - name: teamwork.tw_mcp_bearer_token
+      env: TW_MCP_BEARER_TOKEN
+      example: tkn.v1_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=

--- a/servers/teamwork/server.yaml
+++ b/servers/teamwork/server.yaml
@@ -14,9 +14,6 @@ about:
 source:
   project: https://github.com/teamwork/mcp
   branch: main
-run:
-  command:
-    - /bin/tw-mcp-stdio
 config:
   description: Configure the connection to Teamwork.com MCP server
   secrets:

--- a/servers/teamwork/server.yaml
+++ b/servers/teamwork/server.yaml
@@ -19,4 +19,5 @@ config:
   secrets:
     - name: teamwork.tw_mcp_bearer_token
       env: TW_MCP_BEARER_TOKEN
-      example: tkn.v1_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=
+      example: <TW_MCP_BEARER_TOKEN>
+      required: true


### PR DESCRIPTION
Adds the official Teamwork.com MCP server to the registry: https://github.com/Teamwork/mcp

The MCP server (HTTP) is available at:
https://mcp.ai.teamwork.com

Additional information can be found at:
https://www.teamwork.com/product/ai/

## MCP Server Information

**Server Name:** Teamwork.com
**Repository URL:** https://github.com/Teamwork/mcp
**Brief Description:** Provides a standardised interface for LLMs to interact with Teamwork.com, allowing AI agents to perform various project management operations.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
