### PR TITLE
Fix: Failing to create template

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -128,7 +128,7 @@ func buildMcpImage(ctx context.Context, server servers.Server) error {
 	token := os.Getenv("GITHUB_TOKEN")
 
 	buildArgs := []string{
-		"-f", server.GetDockerfile(), "-t", "check", "-t", server.Image, "--label", "org.opencontainers.image.revision=" + sha,
+		"-f", server.GetDockerfile(), "-t", "check", "-t", server.Image, "--label", "org.opencontainers.image.revision=" + sha, "--load",
 	}
 
 	if server.Source.BuildTarget != "" {

--- a/cmd/create/main.go
+++ b/cmd/create/main.go
@@ -140,10 +140,10 @@ func run(ctx context.Context, buildURL, name, category, userProvidedImage string
 		token := os.Getenv("GITHUB_TOKEN")
 
 		if token != "" {
-			cmd = exec.CommandContext(ctx, "docker", "buildx", "build", "--secret", "id=GIT_AUTH_TOKEN", "-t", "check", "-t", tag, "--label", "org.opencontainers.image.revision="+sha, gitURL)
+			cmd = exec.CommandContext(ctx, "docker", "buildx", "build", "--secret", "id=GIT_AUTH_TOKEN", "-t", "check", "-t", tag, "--label", "org.opencontainers.image.revision="+sha, "--load", gitURL)
 			cmd.Env = []string{"GIT_AUTH_TOKEN=" + token, "PATH=" + os.Getenv("PATH")}
 		} else {
-			cmd = exec.CommandContext(ctx, "docker", "buildx", "build", "-t", "check", "-t", tag, "--label", "org.opencontainers.image.revision="+sha, gitURL)
+			cmd = exec.CommandContext(ctx, "docker", "buildx", "build", "-t", "check", "-t", tag, "--label", "org.opencontainers.image.revision="+sha, "--load", gitURL)
 			cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
 		}
 
@@ -177,7 +177,7 @@ func run(ctx context.Context, buildURL, name, category, userProvidedImage string
 				secrets = append(secrets, servers.Secret{
 					Name:    secretName(name, parts[0]),
 					Env:     parts[0],
-					Example: "<" + parts[0] + ">",
+					Example: parts[1],
 				})
 			} else {
 				env = append(env, servers.Env{

--- a/pkg/servers/types.go
+++ b/pkg/servers/types.go
@@ -23,6 +23,8 @@ THE SOFTWARE.
 package servers
 
 import (
+	"encoding/json"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -46,6 +48,21 @@ type Secret struct {
 	Env      string `yaml:"env" json:"env"`
 	Example  string `yaml:"example,omitempty" json:"example,omitempty"`
 	Required *bool  `yaml:"required,omitempty" json:"required,omitempty"`
+}
+
+// secret is an alias used to drop encoding methods to avoid infinite recursion.
+type secret Secret
+
+func (s Secret) MarshalYAML() (any, error) {
+	a := secret(s)
+	a.Example = "<" + s.Env + ">"
+	return a, nil
+}
+
+func (s Secret) MarshalJSON() ([]byte, error) {
+	a := secret(s)
+	a.Example = "<" + s.Env + ">"
+	return json.Marshal(a)
 }
 
 type Env struct {


### PR DESCRIPTION
The secret provided via argument (`-e` flag) was losing its value before listing the tools. This caused failures to connect to the MCP server.

https://github.com/docker/mcp-registry/blob/17fdb6eb0a4b47d4ac1a33535554a6fa7e2b2dd3/cmd/create/main.go#L177-L181

The strategy now is to replace the secret value only when encoding the object to generate the template.

There was also a missing `--load` flag when executing `docker buildx build` to correctly load the image into the memory.

> WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load