### PR TITLE
feat: Add support for User

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,22 @@ run:
     - --transport=stdio
 ```
 
+## User
+
+If you need to run the container with a specific user, you can do it in the `run` block. If you want the user to be able to define the container user, you will need to create a parameter first and then add the `run` block to the server.
+
+```
+run:
+  user: '{{server_name.container_user}}'
+config:
+  description: example of a user
+  parameters:
+    type: object
+    properties:
+      container_user:
+        type: string
+```
+
 ## Full Example
 
 Here you can see a full example:

--- a/pkg/catalog/tile.go
+++ b/pkg/catalog/tile.go
@@ -183,6 +183,7 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 		Env:            env,
 		Command:        server.Run.Command,
 		Volumes:        server.Run.Volumes,
+		User:           server.Run.User,
 		DisableNetwork: server.Run.DisableNetwork,
 		AllowHosts:     server.Run.AllowHosts,
 		Config:         config,

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -147,6 +147,7 @@ type Tile struct {
 	Env            []Env          `json:"env,omitempty" yaml:"env,omitempty"`
 	Command        []string       `json:"command,omitempty" yaml:"command,omitempty"`
 	Volumes        []string       `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	User           string         `json:"user,omitempty" yaml:"user,omitempty"`
 	DisableNetwork bool           `json:"disableNetwork,omitempty" yaml:"disableNetwork,omitempty"`
 	AllowHosts     []string       `json:"allowHosts,omitempty" yaml:"allowHosts,omitempty"`
 	Prompts        int            `json:"prompts" yaml:"prompts"`

--- a/pkg/servers/types.go
+++ b/pkg/servers/types.go
@@ -107,6 +107,7 @@ type Source struct {
 type Run struct {
 	Command        []string          `yaml:"command,omitempty" json:"command,omitempty"`
 	Volumes        []string          `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	User           string            `yaml:"user,omitempty" json:"user,omitempty"`
 	Env            map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	AllowHosts     []string          `yaml:"allowHosts,omitempty" json:"allowHosts,omitempty"`
 	DisableNetwork bool              `yaml:"disableNetwork,omitempty" json:"disableNetwork,omitempty"`

--- a/servers/aks/server.yaml
+++ b/servers/aks/server.yaml
@@ -23,6 +23,7 @@ run:
   volumes:
     - '{{aks.azure_dir}}:/home/mcp/.azure'
     - '{{aks.kubeconfig}}:/home/mcp/.kube/config'
+  user: '{{aks.container_user}}'
 config:
   description: Configuration for AKS-MCP server
   parameters:
@@ -44,6 +45,9 @@ config:
       additional_tools:
         type: string
         description: Comma-separated list of additional tools, One of [ helm, cilium ]
+      container_user:
+        type: string
+        description: Username or UID of the container user (format <name|uid>[:<group|gid>] e.g. 10000), ensuring correct permissions to access the Azure and kubeconfig files. Leave empty to use default user in the container.
     required:
       - azure_dir
       - kubeconfig


### PR DESCRIPTION
This change add support for "user" based on https://github.com/docker/mcp-gateway/pull/104. Also, to highlight the use-case by updating `aks` MCP server where this feature is needed. The default user in aks container image is `mcp` (uid:100) so this change will allow defining [custom container user](https://github.com/docker/mcp-gateway/issues/103) if needed.

## Testing Done:

```bash
# docker/mcp-gateway
$ make docker-mcp
$ docker mcp version
16ffe718a43528c8b30fdf42dd733dda21f99b31
# in docker/mcp-registry
task catalog -- aks
$ cat catalogs/aks/catalog.yaml | grep 'aks.container_user'
    user: '{{aks.container_user}}'
```


define the aks config:

```bash
→ cat ~/.docker/mcp/config.yaml 
aks:
  azure_dir: /home/qasim/.azure
  kubeconfig: /home/qasim/.kube/config
  access_level: readonly
  container_user: 1000
```

run the gateway:

```bash
- Listing MCP tools...
  - Running mcp/aks with [run --rm -i --init --security-opt no-new-privileges --cpus 1 --memory 2Gb --pull never -l docker-mcp=true -l docker-mcp-tool-type=mcp -l docker-mcp-name=aks -l docker-mcp-transport=stdio -v /home/qasim/.azure:/home/mcp/.azure -v /home/qasim/.kube/config:/home/mcp/.kube/config -u 1000] and command [--transport=stdio --access-level=readonly --allow-namespaces= --additional-tools=]
  > aks: (15 tools) (2 prompts)
> 15 tools listed in 2.697127846s
- Using images:
  - mcp/aks
```

See `-u 1000` being passed here. For current (`< 16ffe718a43528c8b30fdf42dd733dda21f99b31`) version of mcp-gateway, user will be ignored. 