### PR TITLE
Add Rube MCP server in servers

### DIFF
--- a/servers/rube/server.yaml
+++ b/servers/rube/server.yaml
@@ -1,0 +1,16 @@
+name: rube
+type: http
+url: https://rube.composio.dev/
+meta:
+    category: ai
+    tags:
+        - ai
+        - composio
+        - integrations
+        - productivity
+about:
+    title: Rube
+    description: Rube is a Model‑Context‑Protocol (MCP) server built on the Composio integration platform. It connects AI chat tools to more than 500 business and productivity applications – things like Gmail, Slack, Notion, GitHub, Linear, Airtable, and many others. Once installed, you can ask your AI tool to perform everyday tasks (e.g. "send an email to the latest customer," "create a Linear issue," "update my Notion database," or "post an update to Slack") and Rube will securely talk to the relevant apps on your behalf. Instead of writing complex API integrations yourself, you just tell your AI assistant what you want to do.    icon: https://avatars.githubusercontent.com/u/128464815?s=200&v=4
+    homepage: https://rube.composio.dev/
+source:
+    project: https://github.com/ComposioHQ/Rube


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Rube"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** Rube
**Repository URL:** https://github.com/composiohq/rube
**Brief Description:** Rube is a Model Context Protocol (MCP) server that connects your AI tools to 500+ apps like Gmail, Slack, GitHub, and Notion. Simply install it in your AI client, authenticate once with your apps, and start asking your AI to perform real actions like "Send an email" or "Create a task."

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
