### PR TITLE
Support Remote without source

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -42,6 +42,12 @@ func run(ctx context.Context, name string, listTools bool, pullCommunity bool) e
 		return err
 	}
 
+	// Skip build for remote servers - they don't need Docker images
+	if server.Remote.URL != "" {
+		fmt.Printf("✅ Build skipped for remote server %s\n", name)
+		return nil
+	}
+
 	isMcpImage := strings.HasPrefix(server.Image, "mcp/")
 
 	if isMcpImage {

--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -53,6 +53,9 @@ func run(name string) error {
 	if err := isIconValid(name); err != nil {
 		return err
 	}
+	if err := isRemoteValid(name); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -209,6 +212,28 @@ func isIconValid(name string) error {
 	}
 
 	fmt.Println("✅ Icon is valid")
+	return nil
+}
+
+// check if the remote configuration is valid
+func isRemoteValid(name string) error {
+	server, err := readServerYaml(name)
+	if err != nil {
+		return err
+	}
+
+	// Skip validation for non-remote servers
+	if server.Remote.URL == "" {
+		fmt.Println("✅ Remote validation skipped (not a remote server)")
+		return nil
+	}
+
+	// Check that transport_type is not empty for remote servers
+	if server.Remote.TransportType == "" {
+		return fmt.Errorf("remote server must have a transport_type specified")
+	}
+
+	fmt.Println("✅ Remote is valid")
 	return nil
 }
 

--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -140,6 +140,13 @@ func IsLicenseValid(name string) error {
 	if err != nil {
 		return err
 	}
+	
+	// Skip license validation for remote servers without source
+	if server.Source.Project == "" {
+		fmt.Println("✅ License validation skipped (remote server)")
+		return nil
+	}
+	
 	repository, err := client.GetProjectRepository(ctx, server.Source.Project)
 	if err != nil {
 		return err
@@ -179,12 +186,20 @@ func isIconValid(name string) error {
 		fmt.Println("🛑 Icon is too large. It must be less than 2MB")
 		return nil
 	}
+	
+	// Check content type for SVG support
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "image/svg+xml" {
+		fmt.Println("✅ Icon is valid (SVG)")
+		return nil
+	}
+	
 	img, format, err := image.DecodeConfig(resp.Body)
 	if err != nil {
 		return err
 	}
 	if format != "png" {
-		fmt.Println("🛑 Icon is not a png. It must be a png")
+		fmt.Println("🛑 Icon is not a png or svg. It must be a png or svg")
 		return nil
 	}
 

--- a/pkg/catalog/tile.go
+++ b/pkg/catalog/tile.go
@@ -44,7 +44,7 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 	license := "Apache License 2.0"
 	githubStars := 0
 
-	if server.Type == "server" {
+	if server.Type == "server" && server.Remote.URL == "" {
 		client := github.NewFromServer(server)
 		repository, err := client.GetProjectRepository(ctx, upstream)
 		if err != nil {
@@ -127,7 +127,7 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 
 	image := server.Image
 
-	if server.Type == "server" && image == "" {
+	if server.Type == "server" && image == "" && server.Remote.URL == "" {
 		return Tile{}, fmt.Errorf("no image for server: %s", server.Name)
 	}
 	if server.Type == "poci" && image != "" {
@@ -168,6 +168,15 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 
 	dateAdded := time.Now().Format(time.RFC3339)
 
+	var remote Remote
+	if server.Remote.URL != "" {
+		remote = Remote{
+			TransportType: server.Remote.TransportType,
+			URL:           server.Remote.URL,
+			Headers:       server.Remote.Headers,
+		}
+	}
+
 	return Tile{
 		Description:    addDot(strings.TrimSpace(strings.ReplaceAll(description, "\n", " "))),
 		Title:          server.About.Title,
@@ -178,6 +187,7 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 		ToolsURL:       "http://desktop.docker.com/mcp/catalog/v" + strconv.Itoa(Version) + "/tools/" + server.Name + ".json",
 		Source:         source,
 		Upstream:       upstream,
+		Remote:         remote,
 		Icon:           server.About.Icon,
 		Secrets:        secrets,
 		Env:            env,

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -141,6 +141,7 @@ type Tile struct {
 	// Source         string         `json:"source,omitempty" yaml:"source,omitempty"`
 	Source         string         `json:"source" yaml:"source"`
 	Upstream       string         `json:"upstream,omitempty" yaml:"upstream,omitempty"`
+	Remote         Remote         `json:"remote,omitempty" yaml:"remote,omitempty"`
 	Icon           string         `json:"icon" yaml:"icon"`
 	Tools          []servers.Tool `json:"tools" yaml:"tools"`
 	Secrets        []Secret       `json:"secrets,omitempty" yaml:"secrets,omitempty"`
@@ -196,4 +197,48 @@ type Secret struct {
 type Env struct {
 	Name  string `json:"name" yaml:"name"`
 	Value string `json:"value" yaml:"value"`
+}
+
+type Remote struct {
+	TransportType string            `json:"transport_type,omitempty" yaml:"transport_type,omitempty"`
+	URL           string            `json:"url,omitempty" yaml:"url,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+}
+
+func (r Remote) MarshalYAML() (interface{}, error) {
+	mapNode := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{},
+	}
+	
+	if r.TransportType != "" {
+		mapNode.Content = append(mapNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "transport_type"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: r.TransportType})
+	}
+	
+	if r.URL != "" {
+		mapNode.Content = append(mapNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "url"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: r.URL})
+	}
+	
+	if len(r.Headers) > 0 {
+		headersNode := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{},
+		}
+		
+		for k, v := range r.Headers {
+			headersNode.Content = append(headersNode.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: k},
+				&yaml.Node{Kind: yaml.ScalarNode, Value: v, Style: yaml.DoubleQuotedStyle})
+		}
+		
+		mapNode.Content = append(mapNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "headers"},
+			headersNode)
+	}
+	
+	return mapNode, nil
 }

--- a/pkg/servers/types.go
+++ b/pkg/servers/types.go
@@ -36,6 +36,7 @@ type Server struct {
 	Meta        Meta            `yaml:"meta,omitempty" json:"meta,omitempty"`
 	About       About           `yaml:"about,omitempty" json:"about,omitempty"`
 	Source      Source          `yaml:"source,omitempty" json:"source,omitempty"`
+	Remote      Remote          `yaml:"remote,omitempty" json:"remote,omitempty"`
 	Run         Run             `yaml:"run,omitempty" json:"run,omitempty"`
 	Config      Config          `yaml:"config,omitempty" json:"config,omitempty"`
 	OAuth       []OAuthProvider `yaml:"oauth,omitempty" json:"oauth,omitempty"`
@@ -102,6 +103,12 @@ type Source struct {
 	Directory   string `yaml:"directory,omitempty" json:"directory,omitempty"`
 	Dockerfile  string `yaml:"dockerfile,omitempty" json:"dockerfile,omitempty"`
 	BuildTarget string `yaml:"buildTarget,omitempty" json:"buildTarget,omitempty"`
+}
+
+type Remote struct {
+	TransportType string            `yaml:"transport_type,omitempty" json:"transport_type,omitempty"`
+	URL           string            `yaml:"url,omitempty" json:"url,omitempty"`
+	Headers       map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
 }
 
 type Run struct {


### PR DESCRIPTION
Example:

```
name: wayfound
type: server
meta:
  category: ai
  tags:
    - ai
about:
  title: Wayfound MCP
  description: Wayfound’s MCP server addresses critical challenges enterprises face when integrating agentic systems
  icon: https://cdn.prod.website-files.com/682a0b46722bcd80642ab415/682bdd7baf298c1fca1d424d_wayfound-logo-wordmark-black.svg
remote:
  transport_type: sse
  url: https://app.wayfound.ai/sse
  headers:
    Authorization: "Bearer {{wayfound.mcp_api_key}}"
config:
  secrets:
    - name: wayfound.mcp_api_key
      env: MCP_API_KEY
      example: <MCP_API_KEY>

```

* server.yaml supports
  * closed source (not github source available source)
  * a Remote but not Image (remote only)
