### PR TITLE
Add Astro Docs MCP server to registry

### DIFF
--- a/servers/astro-docs/server.yaml
+++ b/servers/astro-docs/server.yaml
@@ -1,0 +1,17 @@
+name: astro-docs
+type: server
+meta:
+  category: documentation
+  tags:
+    - documentation
+    - astro
+    - web-framework
+about:
+  title: Astro Docs MCP Server
+  description: Connect your AI tools to the latest Astro documentation using the Model Context Protocol
+  icon: https://astro.build/favicon.svg
+remote:
+  transport_type: streamable
+  url: https://mcp.docs.astro.build/mcp
+source:
+  project: https://github.com/withastro/docs-mcp


### PR DESCRIPTION
## Summary
This PR adds the [Astro Docs MCP server](https://mcp.docs.astro.build/) to the registry, enabling AI tools to connect to the latest Astro documentation using the Model Context Protocol.

## Details
- Server Name: `astro-docs`
- Transport Type: `streamable`
- Remote URL: `https://mcp.docs.astro.build/mcp`
- Source: https://github.com/withastro/docs-mcp

## Testing
Validated with:
- `task validate -- --name astro-docs` ✅
- `task build -- --tools astro-docs` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)