### PR TITLE
Update remote mcp server names that have a local counterpart

### DIFF
--- a/servers/apify/server.yaml
+++ b/servers/apify/server.yaml
@@ -10,7 +10,7 @@ meta:
     - data-extraction
     - remote
 about:
-  title: Apify
+  title: Apify Remote MCP Server
   description: Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation. You can extract structured data from social media, e-commerce, search engines, maps, travel sites, or any other website.
   icon: https://www.google.com/s2/favicons?domain=apify.com&sz=64
 remote:

--- a/servers/dappier-remote/server.yaml
+++ b/servers/dappier-remote/server.yaml
@@ -10,7 +10,7 @@ meta:
     - knowledge-base
     - remote
 about:
-  title: Dappier
+  title: Dappier Remote MCP Server
   description: Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.
   icon: https://avatars.githubusercontent.com/u/152645347?s=200&v=4
 remote:

--- a/servers/needle/server.yaml
+++ b/servers/needle/server.yaml
@@ -10,7 +10,7 @@ meta:
     - knowledge-base
     - remote
 about:
-  title: Needle
+  title: Needle Remote MCP Server
   description: Production-ready RAG service to search and retrieve data from your documents.
   icon: https://www.google.com/s2/favicons?domain=needle.app&sz=64
 remote:


### PR DESCRIPTION
This clarifies the difference between the remote and local MCP servers for Apify, Needle and Dappier until we have more UX around differentiating remotes: 

Old:
<img width="720" height="244" alt="image" src="https://github.com/user-attachments/assets/6fa81ae3-5378-4924-bff1-c05a4f280177" />
