### PR TITLE
servers/ramparts: track main branch and use MCP-Dockerfile

### DIFF
--- a/servers/ramparts/server.yaml
+++ b/servers/ramparts/server.yaml
@@ -14,7 +14,8 @@ about:
   icon: https://raw.githubusercontent.com/getjavelin/ramparts/main/assets/ramparts.png
 source:
   project: https://github.com/getjavelin/ramparts
-  branch: docker-registry-dockerfile
+  branch: main
+  dockerfile: MCP-Dockerfile
 config:
   description: Configure Ramparts security scanner
   env:


### PR DESCRIPTION
This PR updates the Ramparts server entry to:

- Track the upstream `main` branch instead of a feature branch
- Use the explicit `MCP-Dockerfile` path for building the image

Changes in `servers/ramparts/server.yaml`:
- source.branch: `docker-registry-dockerfile` -> `main`
- source.dockerfile: added `MCP-Dockerfile`

Rationale:
- The Ramparts repo's default development happens on `main`, so this keeps the integration current.
- Providing `dockerfile` mirrors how other entries specify non-root Dockerfiles in this registry.

Repo: https://github.com/getjavelin/ramparts

Let me know if you'd like this change moved to a feature branch on the fork; happy to update.\n