### PR TITLE
chore: if a tools file is provide, use that

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -62,6 +62,16 @@ func run(ctx context.Context, name string, listTools bool, pullCommunity bool) e
 			return err
 		}
 	}
+	// check if the server has a tools.json file
+	if _, err := os.Stat(filepath.Join("servers", name, "tools.json")); err == nil {
+		listTools = false
+		tools, err := mcp.ReadToolsFromFile(filepath.Join("servers", name, "tools.json"))
+		if err != nil {
+			return err
+		}
+		fmt.Println()
+		fmt.Println(len(tools), "tools found.")
+	}
 
 	if listTools {
 		tools, err := mcp.Tools(ctx, server, false, false, false)

--- a/internal/mcp/helper.go
+++ b/internal/mcp/helper.go
@@ -24,7 +24,9 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -342,4 +344,18 @@ func extractDescription(input string, name string) string {
 	}
 
 	return ""
+}
+
+func ReadToolsFromFile(path string) ([]mcp.Tool, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var tools []mcp.Tool
+	if err := json.Unmarshal(buf, &tools); err != nil {
+		return nil, err
+	}
+
+	return tools, nil
 }

--- a/servers/clickhouse/tools.json
+++ b/servers/clickhouse/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "list_databases",
+    "description": "List available ClickHouse databases"
+  },
+  {
+    "name": "list_tables",
+    "description": "List available ClickHouse tables in a database, including schema, comment,\nrow count, and column count.",
+    "arguments": [
+      {
+        "name": "database",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "like",
+        "type": "string",
+        "desc": "",
+        "optional": true
+      },
+      {
+        "name": "not_like",
+        "type": "string",
+        "desc": "",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "run_select_query",
+    "description": "Run a SELECT query in a ClickHouse database",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This change enables users to provide their own `tools.json` file and avoid the need to configure the MCP Server properly to run it.