### PR TITLE
No spaces in secret names

### DIFF
--- a/servers/metabase/server.yaml
+++ b/servers/metabase/server.yaml
@@ -15,10 +15,10 @@ source:
 config:
   description: Configure the connection to MetaBase MCP
   secrets:
-    - name: metabase.MetaBase API Key
+    - name: metabase.MetaBaseAPIKey
       env: METABASE_API_KEY
       example: metabase api key
-    - name: metabase.MetaBase Password
+    - name: metabase.MetaBasePassword
       env: METABASE_PASSWORD
       example: yourpassword
   env:


### PR DESCRIPTION
We do not current support having spaces in the names of secrets.