### PR TITLE
feat: add mcp-hackernews server to MCP catalog

### DIFF
--- a/servers/mcp-hackernews/server.yaml
+++ b/servers/mcp-hackernews/server.yaml
@@ -1,0 +1,13 @@
+name: mcp-hackernews
+image: mcp/hackernews-mcp
+type: server
+meta:
+    category: search
+    tags:
+        - search
+about:
+    title: Hackernews mcp
+    description: A Model Context Protocol (MCP) server that provides access to Hacker News stories, comments, and user data, with support for search and content retrieval.
+    icon: https://news.ycombinator.com/y18.svg
+source:
+    project: https://github.com/AayushBahukhandi/hackernews-mcp


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Add Hacker News MCP Server"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** mcp-hackernews
**Repository URL:** https://github.com/AayushBahukhandi/hackernews-mcp
**Brief Description:** A Model Context Protocol (MCP) server that provides access to Hacker News stories, comments, and user data, with support for search and content retrieval.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcp-hackernews`
- [x] I have built the MCP Server using `task build -- --tools mcp-hackernews`

## Server Details

**Author:** Aayush Bahukhandi
**Category:** Search
**Tags:** search, hackernews, news, api
**Tools Provided:** 4 tools
- `get_stories`: Get stories from Hacker News
- `get_story_info`: Get detailed story info from Hacker News, including the comments
- `get_user_info`: Get user info from Hacker News, including the stories they've submitted
- `search_stories`: Search stories from Hacker News

**Icon:** https://news.ycombinator.com/y18.svg