### PR TITLE
Bug fix: Use cli tag for docker image

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -48,6 +48,11 @@ func run(ctx context.Context, name string, listTools bool, pullCommunity bool) e
 		return nil
 	}
 
+	if server.Type == "poci" {
+		fmt.Printf("✅ Build skipped for poci server %s\n", name)
+		return nil
+	}
+
 	isMcpImage := strings.HasPrefix(server.Image, "mcp/")
 
 	if isMcpImage {

--- a/servers/docker/server.yaml
+++ b/servers/docker/server.yaml
@@ -22,7 +22,7 @@ tools:
       required:
         - args
     container:
-      image: docker
+      image: docker:cli
       command:
         - '{{args|into}}'
       volumes:


### PR DESCRIPTION
Updated the image tag to `cli` for the docker mcp server. The `latest` tag happened to switch to a `dind` tag, which is causing permissions issues for users.