### PR TITLE
Add Microsoft Learn MCP Server (remote)

### DIFF
--- a/servers/microsoft-learn/README.md
+++ b/servers/microsoft-learn/README.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/microsoftdocs/mcp

--- a/servers/microsoft-learn/server.yaml
+++ b/servers/microsoft-learn/server.yaml
@@ -1,0 +1,15 @@
+name: microsoft-learn
+type: remote
+meta:
+  category: documentation
+  tags:
+    - microsoft-learn
+    - documentation
+    - remote
+about:
+  title: Microsoft Learn
+  description: Add trusted and up-to-date content from Microsoft Learn to your AI agent.
+  icon: https://avatars.githubusercontent.com/microsoft?s=64
+remote:
+  transport_type: streamable-http
+  url: https://learn.microsoft.com/api/mcp


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Microsoft Learn"
labels: submission
assignees: ""
---

This issue template seems to assume MCP Server with source and Docker image, while Learn MCP is a remote server and anonymous. Let's see how this goes. Feel free to reach out. cc @TianqiZhang

## MCP Server Information

**Server Name:** Microsoft Learn
**Repository URL:** https://github.com/microsoftdocs/mcp
**Brief Description:** The Microsoft Learn MCP Server is a remote MCP Server that enables clients like GitHub Copilot and other AI agents to bring trusted and up-to-date information directly from Microsoft's official documentation. It supports streamable http transport, which is lightweight for clients to use.

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [v] **MCP Compliant**: Implements MCP API specification
- [v] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [v] **Documentation**: Basic README and setup instructions
- [v] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [v] This server meets the basic requirements listed above
- [v] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
