### PR TITLE
Add Gmail MCP Server for email operations

### DIFF
--- a/servers/gmail-mcp/server.yaml
+++ b/servers/gmail-mcp/server.yaml
@@ -1,0 +1,48 @@
+name: gmail-mcp
+image: yashtekwani/gmail-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - email
+    - gmail
+    - imap
+    - smtp
+    - communication
+about:
+  title: Gmail MCP Server
+  description: A Model Context Protocol server for Gmail operations using IMAP/SMTP with app password authentication. Supports listing messages, searching emails, and sending messages.
+  icon: https://www.google.com/gmail/about/static/images/logo-gmail.png
+source:
+  project: https://github.com/Sallytion/Gmail-MCP
+config:
+  description: Configure Gmail access with app password authentication
+  secrets:
+    - name: gmail-mcp.email_password
+      env: EMAIL_PASSWORD
+      example: <your-gmail-app-password>
+  env:
+    - name: EMAIL_ADDRESS
+      example: your-email@gmail.com
+      value: '{{gmail-mcp.email_address}}'
+    - name: IMAP_HOST
+      example: imap.gmail.com
+      value: imap.gmail.com
+    - name: IMAP_PORT
+      example: "993"
+      value: "993"
+    - name: SMTP_HOST
+      example: smtp.gmail.com
+      value: smtp.gmail.com
+    - name: SMTP_PORT
+      example: "587"
+      value: "587"
+  parameters:
+    type: object
+    properties:
+      email_address:
+        type: string
+        description: Your Gmail email address
+        format: email
+    required:
+      - email_address

--- a/servers/gmail-mcp/tools.json
+++ b/servers/gmail-mcp/tools.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "listMessages",
+    "description": "List recent messages from Gmail inbox",
+    "arguments": [
+      {
+        "name": "count",
+        "type": "number",
+        "desc": "Number of messages to retrieve (default: 10, max: 100)"
+      }
+    ]
+  },
+  {
+    "name": "findMessage",
+    "description": "Search for messages containing specific words or phrases",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Search query (supports Gmail search syntax)"
+      }
+    ]
+  },
+  {
+    "name": "sendMessage",
+    "description": "Send an email message",
+    "arguments": [
+      {
+        "name": "to",
+        "type": "string",
+        "desc": "Recipient email address"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": "Email subject"
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "desc": "Email message body"
+      },
+      {
+        "name": "cc",
+        "type": "string",
+        "desc": "CC email address (optional)"
+      },
+      {
+        "name": "bcc",
+        "type": "string",
+        "desc": "BCC email address (optional)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Supports listing messages, searching emails, and sending messages
- Uses IMAP/SMTP with app password authentication
- Includes proper tools.json for build process
- Pre-built Docker image: yashtekwani/gmail-mcp:latest

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
