### PR TITLE
Add server configuration for mcp-reddit

### DIFF
--- a/servers/mcp-reddit/server.yaml
+++ b/servers/mcp-reddit/server.yaml
@@ -1,0 +1,34 @@
+name: mcp-reddit
+image: mcp/reddit-mcp
+type: server
+meta:
+    category: communication
+    tags:
+        - communication
+about:
+    title: Mcp reddit
+    description: A comprehensive Model Context Protocol (MCP) server for Reddit integration. This server enables AI agents to interact with Reddit programmatically through a standardized interface.
+    icon: https://avatars.githubusercontent.com/u/135265106?v=4
+source:
+    project: https://github.com/KrishnaRandad2023/mcp-reddit
+config:
+    description: Configure the connection to Mcp reddit
+    secrets:
+        - name: mcp-reddit.reddit_client_id
+          env: REDDIT_CLIENT_ID
+          example: <REDDIT_CLIENT_ID>
+        - name: mcp-reddit.reddit_client_secret
+          env: REDDIT_CLIENT_SECRET
+          example: <REDDIT_CLIENT_SECRET>
+        - name: mcp-reddit.reddit_password
+          env: REDDIT_PASSWORD
+          example: <REDDIT_PASSWORD>
+    env:
+        - name: USERNAME
+          example: yourRedditUsername
+          value: '{{mcp-reddit.username}}'
+    parameters:
+        type: object
+        properties:
+            username:
+                type: string


### PR DESCRIPTION
This YAML file defines the configuration for the mcp-reddit server, including metadata, connection settings, and environment variables.

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
