### PR TITLE
neo4j-cypher - add read only config

### DIFF
--- a/servers/neo4j-cypher/server.yaml
+++ b/servers/neo4j-cypher/server.yaml
@@ -56,6 +56,9 @@ config:
     - name: NEO4J_RESPONSE_TOKEN_LIMIT
       example: "10000"
       value: '{{neo4j-cypher.response_token_limit}}'
+    - name: NEO4J_READ_ONLY
+      example: "false"
+      value: '{{neo4j-cypher.read_only}}'
     
   parameters:
     type: object
@@ -84,6 +87,8 @@ config:
         type: string
       server_allowed_hosts:
         type: string
+      read_only:
+        type: boolean
     required:
       - url
       - username


### PR DESCRIPTION
---
name: update server
about: add read-only mode to config
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name: neo4j-cypher**
**Repository URL: https://github.com/neo4j-contrib/mcp-neo4j/tree/main/servers/mcp-neo4j-cypher**
**Brief Description: add read only config parameter**

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
