### PR TITLE
Fix/kubernetes: Allow mounting kubeconfig

### DIFF
--- a/servers/kubernetes/server.yaml
+++ b/servers/kubernetes/server.yaml
@@ -12,3 +12,23 @@ about:
   icon: https://avatars.githubusercontent.com/u/13629408?s=200&v=4
 source:
   project: https://github.com/Flux159/mcp-server-kubernetes
+run:
+  volumes:
+    - '{{kubernetes.kubeconfig}}:/kubeconfig'
+  user: '{{kubernetes.container_user}}'
+config:
+  description: Configuration for Kubernetes MCP server
+  env:
+    - name: KUBECONFIG_PATH
+      value: /kubeconfig
+  parameters:
+    type: object
+    properties:
+      kubeconfig:
+        type: string
+        description: Path to the kubeconfig file for the Kubernetes cluster (e.g. /home/user/.kube/config). Used to connect to the Kubernetes cluster.
+      container_user:
+        type: string
+        description: Username or UID of the container user (format <name|uid>[:<group|gid>] e.g. 1000), ensuring correct permissions to access the kubeconfig file. Leave empty to use default user in the container.
+    required:
+      - kubeconfig


### PR DESCRIPTION
Fixes: #275 

This change allow mounting `kubeconfig` for Kubernetes MCP server. 

```
$ task validate -- --name kubernetes
task: [validate] go run ./cmd/validate --name kubernetes
✅ Name is valid
✅ Directory is valid
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid
```

```
→ task build -- --tools kubernetes
task: [build] go run ./cmd/build --tools kubernetes
[+] Building 1.4s (27/27) FINISHED                                                                                                                                                                                                                                                                                                                                                                    docker:default
 => CACHED [internal] load git source https://github.com/Flux159/mcp-server-kubernetes.git#main                                                                                                                                                                                                                                                                                                                 0.4s
 => [internal] load metadata for docker.io/library/node:24.2.0-slim                                                                                                                                                                                                                                                                                                                                             1.0s
 => [base  1/17] FROM docker.io/library/node:24.2.0-slim@sha256:b30c143a092c7dced8e17ad67a8783c03234d4844ee84c39090c9780491aaf89                                                                                                                                                                                                                                                                                0.0s
 => CACHED [base  2/17] WORKDIR /usr/local/app                                                                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [base  3/17] COPY package.json .                                                                                                                                                                                                                                                                                                                                                                     0.0s
 => CACHED [base  4/17] RUN apt-get update && apt-get install -y curl                                                                                                                                                                                                                                                                                                                                           0.0s
 => CACHED [base  5/17] RUN apt-get install -y apt-transport-https ca-certificates curl gnupg                                                                                                                                                                                                                                                                                                                   0.0s
 => CACHED [base  6/17] RUN curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg                                                                                                                                                                                                                                                  0.0s
 => CACHED [base  7/17] RUN chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg                                                                                                                                                                                                                                                                                                                              0.0s
 => CACHED [base  8/17] RUN echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list                                                                                                                                                                                                                    0.0s
 => CACHED [base  9/17] RUN chmod 644 /etc/apt/sources.list.d/kubernetes.list                                                                                                                                                                                                                                                                                                                                   0.0s
 => CACHED [base 10/17] RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg                                                                                                                                                                                                                                                                  0.0s
 => CACHED [base 11/17] RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list                                                                                                                                                                                                             0.0s
 => CACHED [base 12/17] RUN apt-get update                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => CACHED [base 13/17] RUN apt-get install -y kubectl google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin awscli                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [base 14/17] RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3                                                                                                                                                                                                                                                                                       0.0s
 => CACHED [base 15/17] RUN chmod 700 get_helm.sh                                                                                                                                                                                                                                                                                                                                                               0.0s
 => CACHED [base 16/17] RUN ./get_helm.sh                                                                                                                                                                                                                                                                                                                                                                       0.0s
 => CACHED [base 17/17] RUN rm get_helm.sh                                                                                                                                                                                                                                                                                                                                                                      0.0s
 => CACHED [release 1/3] RUN useradd -m appuser && chown -R appuser /usr/local/app                                                                                                                                                                                                                                                                                                                              0.0s
 => CACHED [release 2/3] RUN npm install --only=production                                                                                                                                                                                                                                                                                                                                                      0.0s
 => CACHED [dependencies 1/4] RUN npm install                                                                                                                                                                                                                                                                                                                                                                   0.0s
 => CACHED [dependencies 2/4] COPY tsconfig.json .                                                                                                                                                                                                                                                                                                                                                              0.0s
 => CACHED [dependencies 3/4] COPY src ./src                                                                                                                                                                                                                                                                                                                                                                    0.0s
 => CACHED [dependencies 4/4] RUN npm run build                                                                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [release 3/3] COPY --from=dependencies /usr/local/app/dist ./dist                                                                                                                                                                                                                                                                                                                                    0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                                                          0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                                                         0.0s
 => => writing image sha256:9c0ee018e7b4bca8299134471f58b5c1da731e132b4ff2ed5c18afbb1606aed3                                                                                                                                                                                                                                                                                                                    0.0s
 => => naming to docker.io/library/check                                                                                                                                                                                                                                                                                                                                                                        0.0s
 => => naming to docker.io/mcp/kubernetes                                                                                                                                                                                                                                                                                                                                                                       0.0s

22 tools found.

-----------------------------------------

✅ Image built as mcp/kubernetes
```

```
$ task catalog -- kubernetes
task: [catalog] go run ./cmd/catalog kubernetes
Catalog written to catalogs/kubernetes/catalog.yaml
$ docker mcp catalog import catalogs/kubernetes/catalog.yaml
$ cat ~/.docker/mcp/config.yaml 
kubernetes:
  kubeconfig: /home/qasim/.kube/config
  container_user: "1000"
```

```
→ docker mcp tools call kubectl_get resourceType=pods
Tool call took: 1.83201394s
{
  "items": [
    {
      "name": "dns-request-pod",
      "namespace": "default",
      "kind": "Pod",
      "status": "Running",
      "createdAt": "2025-09-22T09:35:57Z"
    }
  ]
}
```

## w/o this change

```
→ docker mcp tools call kubectl_get resourceType=pods
calling tool: calling "tools/call": calling "tools/call": MCP error -32603: Failed to execute kubectl get command: MCP error -32603: Failed to get resource: Command failed: kubectl get pods -n default -o json
E0922 17:02:58.353181      19 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E0922 17:02:58.354920      19 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E0922 17:02:58.356916      19 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E0922 17:02:58.358894      19 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
E0922 17:02:58.360883      19 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"http://localhost:8080/api?timeout=32s\": dial tcp [::1]:8080: connect: connection refused"
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```