### PR TITLE
Use config to mount kubernetes .kube/config

### DIFF
--- a/servers/kubernetes/server.yaml
+++ b/servers/kubernetes/server.yaml
@@ -16,6 +16,7 @@ run:
   volumes:
     - '{{kubernetes.config_path}}:/home/appuser/.kube/config'
 config:
+  description: Configure the location of the host Kubernetes file
   parameters:
     type: object
     properties:


### PR DESCRIPTION
The `mcp/kubernetes` server does not currently support configuration to allow users to specify the host .kube/config.

fixes #276 