### PR TITLE
add rust-mcp-filesystem

### DIFF
--- a/servers/rust-mcp-filesystem/server.yaml
+++ b/servers/rust-mcp-filesystem/server.yaml
@@ -1,0 +1,51 @@
+name: rust-mcp-filesystem
+image: mcp/rust-mcp-filesystem
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+about:
+  title: Blazing-fast, asynchronous MCP server for seamless filesystem operations.
+  description: |-
+    The Rust MCP Filesystem is a high-performance, asynchronous, and lightweight Model Context Protocol (MCP) server built in Rust for secure and efficient filesystem operations. Designed with security in mind, it operates in read-only mode by default and restricts clients from updating allowed directories via MCP Roots unless explicitly enabled, ensuring robust protection against unauthorized access. Leveraging asynchronous I/O, it delivers blazingly fast performance with a minimal resource footprint.
+    Optimized for token efficiency, the Rust MCP Filesystem enables large language models (LLMs) to precisely target searches and edits within specific sections of large files and restrict operations by file size range, making it ideal for efficient file exploration, automation, and system integration.
+  icon: https://raw.githubusercontent.com/rust-mcp-stack/rust-mcp-filesystem/refs/heads/main/docs/_media/rust-mcp-filesystem.png
+source:
+  project: https://github.com/rust-mcp-stack/rust-mcp-filesystem
+run:
+  command:
+    - "{{rust-mcp-filesystem.allowed_directories|volume-target|into}}"
+  volumes:
+    - "{{rust-mcp-filesystem.allowed_directories|volume|into}}"
+  disableNetwork: true
+config:
+  description: Configure rust-mcp-filesystem to allow access only to permitted directories.
+  env:
+    - name: ENABLE_ROOTS
+      example: "false"
+      value: "{{rust-mcp-filesystem.enable_roots}}"
+    - name: ALLOW_WRITE
+      example: "false"
+      value: "{{rust-mcp-filesystem.allow_write}}"
+  parameters:
+    type: object
+    properties:
+      allow_write:
+        type: boolean
+        title: Allow Write
+        description: Enable read/write mode. If false, the app operates in read-only mode.
+        default: false
+      enable_roots:
+        type: boolean
+        title: Enable MCP Roots
+        description: Enable dynamic directory access control via MCP client-side Roots.
+        default: false
+      allowed_directories:
+        type: array
+        items:
+          type: string
+        title: Allowed Directories
+        description: List of directories that rust-mcp-filesystem can access.
+        default:
+          - /Users/local-test


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Rust MCP Filesystem"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** Rust MCP Filesystem
**Repository URL:** https://github.com/rust-mcp-stack/rust-mcp-filesystem
**Brief Description:** Blazing-fast, asynchronous MCP server for seamless filesystem operations.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
