### PR TITLE
feat: Add API complete prometheus MCP server

### DIFF
--- a/servers/prometheus-mcp-server/server.yaml
+++ b/servers/prometheus-mcp-server/server.yaml
@@ -1,0 +1,17 @@
+name: prometheus-mcp-server
+image: ghcr.io/tjhop/prometheus-mcp-server
+type: server
+meta:
+  category: database
+  tags:
+    - database
+    - metrics
+    - monitoring
+    - observability
+    - prometheus
+about:
+  title: Prometheus MCP server
+  description: "A Prometheus MCP server with full API support for comprehensive management and deep interaction with Prometheus beyond basic query support. Written in go, it is a single binary install that is capable of STDIO, SSE, and HTTP transports for complex deployments."
+  icon: mcp/prometheus-mcp-server
+source:
+  project: https://github.com/tjhop/prometheus-mcp-server


### PR DESCRIPTION
This adds an MCP server entry for Prometheus that is more API/feature
complete than the existing server:

- It has full support for prometheus' v1 API, so beyond querying it can
  dump configuration, flags, view TSDB stats, etc.
- It has full support for prometheus HTTP config files, so beyond basic
  auth and token auth, it can handle proxy configs, oauth, TLS settings,
setting arbitrary headers, etc.
- It supports multi-tenancy in third party Prometheus implementations
  such as Thanos, Mimir, and Cortex (via HTTP headers in the config
file).
- It supports STDIO, SSE, and HTTP transports for more flexible
  deployment patterns/integration setups with other tools.
- It exposes native prometheus metrics for monitoring and uses detailed
  structured logging to operationalize for proper deployment and
management of the mcp server as a service.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
