### PR TITLE
chore/aks: Use new url for icon

### DIFF
--- a/servers/aks/server.yaml
+++ b/servers/aks/server.yaml
@@ -11,7 +11,7 @@ meta:
 about:
   title: Azure Kubernetes Service (AKS)
   description: Azure Kubernetes Service (AKS) official MCP server
-  icon: https://raw.githubusercontent.com/Azure/AKS/master/blog/assets/images/400x400.png
+  icon: https://raw.githubusercontent.com/Azure/AKS/d2f04fd814f3dc5757996db3e3dfdb4eec1cd599/website/static/img/logo.png
 source:
   project: https://github.com/Azure/aks-mcp
 run:


### PR DESCRIPTION
## Before this change:

```
✅ Name is valid                                                                                                                                                                                                                                                                                                                                                                                                      
✅ Directory is valid
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
🛑 Icon could not be fetched, status code: 404, url: https://raw.githubusercontent.com/Azure/AKS/master/blog/assets/images/400x400.png
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid
```

## After this change:

```
→ task validate -- --name aks
task: [validate] go run ./cmd/validate --name aks
✅ Name is valid                                                                                                                                                                                                                                                                                                                                                                                                      
✅ Directory is valid
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid
```