### PR TITLE
feat: Add IMAP MCP Server to Docker MCP Registry

### DIFF
--- a/servers/imap-server/server.yaml
+++ b/servers/imap-server/server.yaml
@@ -1,0 +1,55 @@
+name: imap-server
+image: nikolausm/imap-mcp-server
+type: server
+meta:
+  category: communication
+  tags:
+    - imap
+    - smtp
+    - email
+    - communication
+    - productivity
+    - oauth
+    - encryption
+    - multi-provider
+about:
+  title: IMAP MCP Server
+  description: A powerful Model Context Protocol (MCP) server for IMAP email integration with secure account management, connection pooling, and support for 15+ email providers. Features encrypted credential storage, advanced search capabilities, and comprehensive email operations including sending, replying, and forwarding with SMTP support.
+  icon: https://raw.githubusercontent.com/nikolausm/imap-mcp-server/main/public/images/logo.png
+source:
+  project: https://github.com/nikolausm/imap-mcp-server
+config:
+  description: Configure IMAP/SMTP access with multiple account support and encrypted credentials
+  secrets:
+    - name: imap-server.master_password
+      env: MASTER_PASSWORD
+      example: <your-master-encryption-password>
+  env:
+    - name: NODE_ENV
+      example: production
+      value: production
+    - name: CONFIG_PATH
+      example: /config
+      value: /config
+    - name: ACCOUNTS_FILE
+      example: /config/accounts.json
+      value: /config/accounts.json
+    - name: PORT
+      example: "3001"
+      value: "3001"
+    - name: ENABLE_WEB_UI
+      example: "false"
+      value: "false"
+  parameters:
+    type: object
+    properties:
+      master_password:
+        type: string
+        description: Master password for encrypting stored credentials (AES-256)
+        format: password
+    required:
+      - master_password
+  volumes:
+    - name: config
+      description: Persistent storage for encrypted account configurations
+      path: /config

--- a/servers/imap-server/tools.json
+++ b/servers/imap-server/tools.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "imap_add_account",
+    "description": "Add a new IMAP account configuration with encrypted credential storage"
+  },
+  {
+    "name": "imap_list_accounts", 
+    "description": "List all configured IMAP accounts"
+  },
+  {
+    "name": "imap_remove_account",
+    "description": "Remove an IMAP account configuration"
+  },
+  {
+    "name": "imap_connect",
+    "description": "Connect to an IMAP account"
+  },
+  {
+    "name": "imap_disconnect",
+    "description": "Disconnect from an IMAP account"
+  },
+  {
+    "name": "imap_search_emails",
+    "description": "Search for emails in a folder with advanced filtering options"
+  },
+  {
+    "name": "imap_get_email",
+    "description": "Get the full content of an email including attachments"
+  },
+  {
+    "name": "imap_mark_as_read",
+    "description": "Mark an email as read"
+  },
+  {
+    "name": "imap_mark_as_unread",
+    "description": "Mark an email as unread"
+  },
+  {
+    "name": "imap_delete_email",
+    "description": "Delete an email (moves to trash or expunges)"
+  },
+  {
+    "name": "imap_get_latest_emails",
+    "description": "Get the latest emails from a folder"
+  },
+  {
+    "name": "imap_send_email",
+    "description": "Send an email using SMTP with support for attachments"
+  },
+  {
+    "name": "imap_reply_to_email",
+    "description": "Reply to an existing email with SMTP support"
+  },
+  {
+    "name": "imap_forward_email",
+    "description": "Forward an existing email to other recipients"
+  },
+  {
+    "name": "imap_list_folders",
+    "description": "List all folders/mailboxes in an IMAP account"
+  },
+  {
+    "name": "imap_folder_status",
+    "description": "Get status information about a folder including message counts"
+  },
+  {
+    "name": "imap_get_unread_count",
+    "description": "Get the count of unread emails in specified folders"
+  }
+]


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information
**Server Name:** imap-server
**Repository URL:** https://github.com/nikolausm/imap-mcp-server
**Brief Description:** A powerful Model Context Protocol (MCP) server for IMAP email integration with secure account management, connection pooling, and support for 15+ email providers. Features encrypted credential storage, advanced search capabilities, and comprehensive email operations including sending, replying, and forwarding with SMTP support.

## Basic Requirements
- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist
- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name imap-server`
- [ ] I have built the MCP Server using `task build -- --tools imap-server`