### PR TITLE
Add Supabase MCP Server

### DIFF
--- a/servers/supabase-mcp-server/README.md
+++ b/servers/supabase-mcp-server/README.md
@@ -1,0 +1,81 @@
+# Supabase MCP Server
+
+Connect your Supabase projects to AI assistants like Claude, Cursor, and Windsurf through the Model Context Protocol (MCP).
+
+## Overview
+
+The Supabase MCP Server standardizes how Large Language Models (LLMs) interact with Supabase services. It provides AI assistants with direct access to your Supabase project, enabling them to:
+
+- Manage database tables and schemas
+- Execute SQL queries and migrations
+- Deploy and manage Edge Functions
+- Access project configuration and logs
+- Generate TypeScript types from your schema
+- Work with development branches
+- Search Supabase documentation
+
+## Features
+
+### Database Management
+- List tables, extensions, and migrations
+- Execute SQL queries (read-only mode available)
+- Apply database migrations with automatic tracking
+- Generate TypeScript types from your database schema
+
+### Edge Functions
+- List and inspect Edge Functions
+- Deploy new functions or update existing ones
+- Access function source code
+
+### Development & Debugging
+- Get project URLs and API keys
+- View service logs (API, Postgres, Auth, Storage, Realtime)
+- Check security and performance advisories
+- Work with development branches (paid plans)
+
+### Knowledge Base
+- Search Supabase documentation for up-to-date information
+
+## Configuration
+
+### Required
+- **SUPABASE_ACCESS_TOKEN**: Your Supabase access token (get from [Supabase Dashboard](https://supabase.com/dashboard/account/tokens))
+
+### Optional
+- **PROJECT_REF**: Scope to a specific project (recommended for security)
+- **API_URL**: Custom Supabase API URL (defaults to https://api.supabase.com)
+- **READ_ONLY**: Set to `true` to restrict to read-only operations (recommended)
+
+## Security Best Practices
+
+⚠️ **Important Security Considerations:**
+
+1. **Use Read-Only Mode**: Enable read-only mode by default to prevent accidental data modifications
+2. **Project Scoping**: Limit access to a specific project using PROJECT_REF
+3. **Development Environment**: Use with development projects, not production
+4. **Review Tool Calls**: Always review and approve tool calls before execution
+5. **Feature Groups**: Enable only the tool groups you need
+
+## Usage
+
+The MCP server provides the following tool groups:
+
+- **account**: Project and organization management
+- **docs**: Documentation search
+- **database**: Schema and data management
+- **debugging**: Logs and advisories
+- **development**: Project configuration
+- **functions**: Edge Functions deployment
+- **branching**: Development branch management (experimental)
+- **storage**: Storage bucket configuration
+
+## Links
+
+- [Supabase MCP Documentation](https://supabase.com/docs/guides/getting-started/mcp)
+- [Source Repository](https://github.com/Sixteen-Digits/supabase-mcp)
+- [Supabase Documentation](https://supabase.com/docs)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+
+## License
+
+Apache 2.0

--- a/servers/supabase-mcp-server/server.yaml
+++ b/servers/supabase-mcp-server/server.yaml
@@ -1,0 +1,40 @@
+name: supabase-mcp-server
+image: mcp/supabase-mcp-server
+type: server
+meta:
+  category: database
+  tags:
+    - database
+    - backend
+    - postgresql
+about:
+  title: Supabase MCP Server
+  description: Connect your Supabase projects to AI assistants. The Model Context Protocol (MCP) standardizes how Large Language Models (LLMs) talk to external services like Supabase. It connects AI assistants directly with your Supabase project and allows them to perform tasks like managing tables, fetching config, and querying data.
+  icon: https://www.google.com/s2/favicons?domain=supabase.com&sz=64
+source:
+  project: https://github.com/david16Digits/supabase-mcp-docker
+  branch: master
+config:
+  description: Configure the connection to Supabase
+  secrets:
+    - name: supabase-mcp-server.access_token
+      env: SUPABASE_ACCESS_TOKEN
+      example: sbp_abc123def456
+  env:
+    - name: PROJECT_REF
+      example: abcdefghijklmnop
+      value: "{{supabase-mcp-server.project_ref}}"
+    - name: API_URL
+      example: https://api.supabase.com
+      value: "{{supabase-mcp-server.api_url}}"
+  parameters:
+    type: object
+    properties:
+      project_ref:
+        type: string
+        description: Your Supabase project reference ID
+      api_url:
+        type: string
+        description: Supabase API URL (default https://api.supabase.com)
+    required:
+      - project_ref

--- a/servers/supabase-mcp-server/tools.json
+++ b/servers/supabase-mcp-server/tools.json
@@ -1,0 +1,130 @@
+[
+  {
+    "name": "search_docs",
+    "description": "Searches the Supabase documentation for up-to-date information",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "The search query"
+      }
+    ]
+  },
+  {
+    "name": "list_tables",
+    "description": "Lists all tables within the specified schemas",
+    "arguments": [
+      {
+        "name": "schemas",
+        "type": "array",
+        "desc": "List of schemas to include"
+      }
+    ]
+  },
+  {
+    "name": "list_extensions",
+    "description": "Lists all extensions in the database",
+    "arguments": []
+  },
+  {
+    "name": "list_migrations",
+    "description": "Lists all migrations in the database",
+    "arguments": []
+  },
+  {
+    "name": "apply_migration",
+    "description": "Applies a SQL migration to the database",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the migration"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "The SQL query to apply"
+      }
+    ]
+  },
+  {
+    "name": "execute_sql",
+    "description": "Executes raw SQL in the database",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "The SQL query to execute"
+      }
+    ]
+  },
+  {
+    "name": "get_logs",
+    "description": "Gets logs for a Supabase project by service type",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": "The service to fetch logs for (api, postgres, edge-function, auth, storage, realtime)"
+      }
+    ]
+  },
+  {
+    "name": "get_advisors",
+    "description": "Gets a list of advisory notices for the Supabase project",
+    "arguments": [
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "The type of advisors to fetch (security or performance)"
+      }
+    ]
+  },
+  {
+    "name": "get_project_url",
+    "description": "Gets the API URL for a project",
+    "arguments": []
+  },
+  {
+    "name": "get_anon_key",
+    "description": "Gets the anonymous API key for a project",
+    "arguments": []
+  },
+  {
+    "name": "generate_typescript_types",
+    "description": "Generates TypeScript types based on the database schema",
+    "arguments": []
+  },
+  {
+    "name": "list_edge_functions",
+    "description": "Lists all Edge Functions in a Supabase project",
+    "arguments": []
+  },
+  {
+    "name": "get_edge_function",
+    "description": "Retrieves file contents for an Edge Function",
+    "arguments": [
+      {
+        "name": "function_slug",
+        "type": "string",
+        "desc": "The slug of the edge function"
+      }
+    ]
+  },
+  {
+    "name": "deploy_edge_function",
+    "description": "Deploys a new Edge Function to a Supabase project",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the function"
+      },
+      {
+        "name": "files",
+        "type": "array",
+        "desc": "The files to upload"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds the Supabase MCP Server to the Docker MCP Registry.

## What is Supabase MCP Server?

The Supabase MCP Server allows AI assistants to interact with Supabase projects through the Model Context Protocol, enabling database management, Edge Functions deployment, TypeScript type generation, and more.

## Features

- **Database Management**: List tables, execute SQL queries, apply migrations
- **Edge Functions**: Deploy and manage Supabase Edge Functions  
- **Development Tools**: Generate TypeScript types, access project configuration
- **Debugging**: View service logs and security/performance advisories
- **Documentation Search**: Query Supabase docs for up-to-date information
- **Branching**: Work with development branches (experimental, paid plans)

## Testing

- ✅ Dockerfile builds successfully from https://github.com/david16Digits/supabase-mcp-docker
- ✅ Server starts and lists 14 tools correctly
- ✅ License: Apache 2.0 (compatible with Docker MCP Registry)
- ✅ tools.json provided to prevent build failures

## Security

The server supports multiple security features:
- Read-only mode for safe database access
- Project scoping to limit access to specific projects
- Properly configured secrets (SUPABASE_ACCESS_TOKEN)
- Environment variable configuration

## Links

- Docker Repository: https://github.com/david16Digits/supabase-mcp-docker
- Official Supabase MCP: https://github.com/Sixteen-Digits/supabase-mcp
- Documentation: https://supabase.com/docs/guides/getting-started/mcp