### PR TITLE
Add VictoriaMetrics MCP Server

### DIFF
--- a/servers/mcp-victoriametrics/server.yaml
+++ b/servers/mcp-victoriametrics/server.yaml
@@ -18,6 +18,7 @@ about:
     icon: "https://github.com/user-attachments/assets/1c060750-370a-4440-b619-78b78c7abd7a"
 source:
     project: "https://github.com/VictoriaMetrics-Community/mcp-victoriametrics"
+    commit: "4db876ab9d9c09bb24035bc709988cb691ad8626"
 config:
     description: "Configure the connection to VictoriaMetrics MCP Server"
     secrets:


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "VictoriaMetrics MCP Server"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** VictoriaMetrics MCP Server
**Repository URL:** https://github.com/VictoriaMetrics-Community/mcp-victoriametrics
**Brief Description:** Provides access to your [VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/) instance and seamless integration with VictoriaMetrics APIs and documentation. It can give you a comprehensive interface for monitoring, observability, and debugging tasks related to your VictoriaMetrics instances, enable advanced automation and interaction capabilities for engineers and tools.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
