### PR TITLE
test: enable unit tests and make validate tests flexible in terms of working directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,8 @@ on:
   pull_request:
 
 jobs:
-  validate-servers:
+  validate:
+    name: "Code and Server Validation"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +21,9 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run unit tests
+        run: task unittest
 
       - name: Get changed servers
         shell: bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,3 +34,7 @@ tasks:
     cmds:
       - docker mcp catalog reset
       - docker mcp catalog init
+
+  unittest:
+    desc: Run Go unit tests
+    cmd: go test ./...


### PR DESCRIPTION
This PR modifies the validate unit test to be flexible in its execution, allowing it to run from a top-level `go test ./...` command. It also enables unit tests as part of the CI workflow.