### PR TITLE
ci: add clean task and update validation script to use it

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   create:
     desc: Create a new mcp server definition
     cmd: go run ./cmd/create {{.CLI_ARGS}}
-  
+
   build:
     desc: Build a server image
     cmd: go run ./cmd/build {{.CLI_ARGS}}
@@ -12,19 +12,23 @@ tasks:
   catalog:
     desc: Generate a test catalog
     cmd: go run ./cmd/catalog {{.CLI_ARGS}}
-  
+
   wizard:
     desc: Run the wizard
     cmd: go run ./cmd/wizard {{.CLI_ARGS}}
-  
+
   validate:
     desc: Validate a server
     cmd: go run ./cmd/validate {{.CLI_ARGS}}
-  
+
+  clean:
+    desc: Clean build artifacts for servers
+    cmd: go run ./cmd/clean {{.CLI_ARGS}}
+
   import:
     desc: Import a server into the registry
     cmd: docker mcp catalog import ./catalogs/{{.CLI_ARGS}}/catalog.yaml
-  
+
   reset:
     desc: Reset the catalog
     cmds:

--- a/cmd/clean/main.go
+++ b/cmd/clean/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/mcp-registry/pkg/servers"
+)
+
+// main processes the provided server names and cleans build artifacts for each.
+func main() {
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: task clean -- <server> [server...]")
+		os.Exit(1)
+	}
+
+	var failed bool
+	for _, name := range flag.Args() {
+		if err := cleanServer(name); err != nil {
+			fmt.Fprintf(os.Stderr, "cleanup failed for %s: %v\n", name, err)
+			failed = true
+		}
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+}
+
+// cleanServer removes generated artifacts and Docker images for the server.
+func cleanServer(name string) error {
+	serverPath := filepath.Join("servers", name, "server.yaml")
+	server, err := servers.Read(serverPath)
+	if err != nil {
+		return fmt.Errorf("reading server file: %w", err)
+	}
+
+	removeCatalog(name)
+	removeDockerImage(server.Image)
+	removeDockerImage("check")
+	pruneDockerBuilder()
+	pruneDockerImages()
+
+	return nil
+}
+
+// removeCatalog deletes the generated catalog directory if it exists.
+func removeCatalog(name string) {
+	path := filepath.Join("catalogs", name)
+	if err := os.RemoveAll(path); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: removing %s: %v\n", path, err)
+	}
+}
+
+// removeDockerImage removes the specified Docker image, ignoring missing images.
+func removeDockerImage(image string) {
+	if image == "" {
+		return
+	}
+
+	out, err := exec.Command("docker", "image", "rm", "-f", image).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if strings.Contains(msg, "No such image") {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "warning: removing image %s: %v\n%s", image, err, msg)
+	} else {
+		fmt.Print(string(out))
+	}
+}
+
+// pruneDockerBuilder removes unused builder cache entries.
+func pruneDockerBuilder() {
+	cmd := exec.Command("docker", "builder", "prune", "--force")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: pruning builder cache: %v\n", err)
+	}
+}
+
+// pruneDockerImages removes dangling Docker images.
+func pruneDockerImages() {
+	cmd := exec.Command("docker", "image", "prune", "--force")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: pruning images: %v\n", err)
+	}
+}


### PR DESCRIPTION
When modifying large numbers of server definitions (e.g. in #328), the validation step can cause the worker to run out of disk space. This PR adds a new clean command and updates the validation step to use it in every call to `process_server`. This should allow a theoretically unlimited number of validations to occur.
