### PR TITLE
Add the triggercmd mcp server

### DIFF
--- a/servers/triggercmd/server.yaml
+++ b/servers/triggercmd/server.yaml
@@ -1,0 +1,23 @@
+name: triggercmd
+image: mcp/triggercmd
+type: server
+meta:
+  category: productivity
+  tags:
+    - command
+    - productivity
+    - automation
+    - remote
+about:
+  title: triggercmd
+  description: Run commands on your computers remotely via TRIGGERcmd.
+  icon: https://www.google.com/s2/favicons?domain=triggercmd.com&sz=64
+source:
+  project: https://github.com/rvmey/triggercmd-mcp-stdio
+  branch: main
+config:
+  description: Configure the connection to TRIGGERcmd MCP server
+  secrets:
+    - name: triggercmd.token
+      env: TRIGGERCMD_TOKEN
+      example: <TRIGGERCMD_TOKEN>


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "triggercmd"
labels: submission
assignees: ""
---

## MCP Server Information

triggercmd
[**Repository URL:**](https://github.com/rvmey/triggercmd-mcp-stdio)
TriggerCMD is a cloud service that allows users to run commands on their computers remotely.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
