### PR TITLE
Fix browserbase icon

### DIFF
--- a/servers/browserbase/server.yaml
+++ b/servers/browserbase/server.yaml
@@ -11,7 +11,7 @@ meta:
 about:
   title: Browserbase
   description: Allow LLMs to control a browser with Browserbase and Stagehand for AI-powered web automation, intelligent data extraction, and screenshot capture.
-  icon: https://avatars.githubusercontent.com/u/189776885?s=200&v=4
+  icon: https://avatars.githubusercontent.com/u/158221360?s=200&v=4
 source:
   project: https://github.com/browserbase/mcp-server-browserbase
   commit: b7ec6f6cf0b2224a3ca9952ac158eaa8e600f929


### PR DESCRIPTION
PR fixes wrong Browserbase icon. For some reason it was Hyperbrowser (bottom right).

<img width="1455" height="521" alt="image" src="https://github.com/user-attachments/assets/ff2e6051-736f-4458-9447-8191b4fabe5a" />

The main icon is also wrong, but the format of the server.yaml seems correct, so this is probably a issue on DockerHub side?