### PR TITLE
ci: use official Docker actions in security-review workflows

### DIFF
--- a/.github/workflows/security-review-changes.yaml
+++ b/.github/workflows/security-review-changes.yaml
@@ -69,6 +69,15 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - name: Resolve comparison commits
         id: revision
         env:
@@ -351,6 +360,7 @@ jobs:
             gh api repos/$repo/check-runs/$check_id \
               --method PATCH \
               --field status="in_progress" \
+              --field output[title]="Security Review: $server" \
               --field output[summary]="Running $review_type security review..."
 
             # Run the security review.

--- a/.github/workflows/security-review-manual.yaml
+++ b/.github/workflows/security-review-manual.yaml
@@ -48,6 +48,15 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - name: Collect audit targets
         id: collect
         run: |


### PR DESCRIPTION
This PR switches our security-review workflows to use Docker CE and its associated packages.