### PR TITLE
ci: enable security-review-changes for PRs

### DIFF
--- a/.github/workflows/security-review-changes.yaml
+++ b/.github/workflows/security-review-changes.yaml
@@ -24,13 +24,13 @@ on:
         required: false
         type: boolean
         default: false
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - synchronize
-  #     - reopened
-  #     - ready_for_review
-  #     - labeled
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
 
 concurrency:
   group: security-review-changes-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
This PR enables the `security-review-changes` workflow on all PRs and PR updates.