### PR TITLE
chore: update pin for nasdaq-data-link

### DIFF
--- a/servers/nasdaq-data-link/server.yaml
+++ b/servers/nasdaq-data-link/server.yaml
@@ -14,7 +14,7 @@ about:
   icon: https://raw.githubusercontent.com/stefanoamorelli/nasdaq-data-link-mcp/refs/heads/main/nasdaq-mcp-server-logo.png
 source:
   project: https://github.com/stefanoamorelli/nasdaq-data-link-mcp
-  commit: 758499d271b925e4eae510c5b958fa317fce76b0
+  commit: ba0f129f2ef242b7267b5d1916f373cfdd08f32c
 config:
   secrets:
     - name: nasdaq_data_link_api_key


### PR DESCRIPTION
Automated commit pin update for nasdaq-data-link.