### PR TITLE
chore: update pin for rust-mcp-filesystem

### DIFF
--- a/servers/rust-mcp-filesystem/server.yaml
+++ b/servers/rust-mcp-filesystem/server.yaml
@@ -13,7 +13,7 @@ about:
   icon: https://raw.githubusercontent.com/rust-mcp-stack/rust-mcp-filesystem/refs/heads/main/docs/_media/rust-mcp-filesystem.png
 source:
   project: https://github.com/rust-mcp-stack/rust-mcp-filesystem
-  commit: b3c000a03dd8d70795335c291cb46866f5f42fd3
+  commit: 45e85194cb4b43b0b2f584e65302001b8feb4e25
 run:
   command:
     - "{{rust-mcp-filesystem.allowed_directories|volume-target|into}}"


### PR DESCRIPTION
Automated commit pin update for rust-mcp-filesystem.