### PR TITLE
chore: update pin for securenote-link-mcp-server

### DIFF
--- a/servers/securenote-link-mcp-server/server.yaml
+++ b/servers/securenote-link-mcp-server/server.yaml
@@ -11,5 +11,5 @@ about:
     icon: https://avatars.githubusercontent.com/u/5723207?v=5
 source:
     project: https://github.com/jackalterman/securenote-link-MCP-server
-    commit: a184102de77ebae58533e45b56764d4a5fab0a8a
+    commit: d2ed33f372e3c85047f1c9c85154d20503b1ddc7
 


### PR DESCRIPTION
Automated commit pin update for securenote-link-mcp-server.