### PR TITLE
ci: modify CI validation workflow to run tooling from main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,15 +6,37 @@ jobs:
     name: "Code and Server Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout main for tooling
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Needed for diffing
+          ref: main
+          path: main-tooling
+          fetch-depth: 1
 
-      - name: Install Go
+      - name: Install Go for building main tooling
         uses: actions/setup-go@v5
         with:
-          cache-dependency-path: go.sum
-          go-version-file: go.mod
+          go-version-file: main-tooling/go.mod
+
+      - name: Build validation tools from main
+        run: |
+          cd main-tooling
+          mkdir -p ../bin
+          go build -o ../bin/validate ./cmd/validate
+          go build -o ../bin/build ./cmd/build
+          go build -o ../bin/catalog ./cmd/catalog
+          go build -o ../bin/clean ./cmd/clean
+
+      - name: Checkout PR for validation
+        uses: actions/checkout@v4
+        with:
+          path: pr-workspace
+          fetch-depth: 0
+
+      - name: Install Go for PR branch
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: pr-workspace/go.mod
 
       - name: Install Task
         uses: arduino/setup-task@v2
@@ -22,15 +44,32 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run unit tests
-        run: task unittest
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
+      - name: Run unit tests against PR branch
+        run: |
+          cd pr-workspace
+          go test ./...
 
       - name: Get changed servers
         shell: bash
         run: |
+          cd pr-workspace
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          git diff --name-only --diff-filter=AM origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^servers/" > changed-servers.txt || true
+          git diff --name-only --diff-filter=AM origin/${{ github.event.pull_request.base.ref }}...HEAD | grep "^servers/" > ../changed-servers.txt || true
 
       - name: Build and catalog changed servers
         shell: bash
-        run: ./scripts/ci-validation.sh
+        run: |
+          # Use safe validation script from main with safe binaries.
+          "${{ github.workspace }}/main-tooling/scripts/ci-validation.sh" \
+            --bin-dir "${{ github.workspace }}/bin" \
+            --workspace "${{ github.workspace }}/pr-workspace" \
+            --changed-servers "${{ github.workspace }}/changed-servers.txt"

--- a/scripts/ci-validation.sh
+++ b/scripts/ci-validation.sh
@@ -2,11 +2,55 @@
 
 set -o pipefail
 
-# Track overall success/failure and processed servers
+# Parse arguments.
+BIN_DIR=""
+WORKSPACE=""
+CHANGED_SERVERS_FILE="changed-servers.txt"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --bin-dir)
+      BIN_DIR="$2"
+      shift 2
+      ;;
+    --workspace)
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    --changed-servers)
+      CHANGED_SERVERS_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# If workspace is specified, change to it.
+if [ -n "$WORKSPACE" ]; then
+  cd "$WORKSPACE" || exit 1
+fi
+
+# Determine which binaries to use.
+if [ -n "$BIN_DIR" ]; then
+  VALIDATE_BIN="$BIN_DIR/validate"
+  BUILD_BIN="$BIN_DIR/build"
+  CATALOG_BIN="$BIN_DIR/catalog"
+  CLEAN_BIN="$BIN_DIR/clean"
+else
+  VALIDATE_BIN="task validate --"
+  BUILD_BIN="task build --"
+  CATALOG_BIN="task catalog --"
+  CLEAN_BIN="task clean --"
+fi
+
+# Track overall success/failure and processed servers.
 overall_success=true
 processed_servers=""
 
-# Function to process a single server
+# Function to process a single server.
 process_server() {
   local file="$1"
   local dir=$(dirname "$file")
@@ -15,24 +59,24 @@ process_server() {
   echo "Processing server: $name"
   echo "================================"
 
-  # Run each command and check for failures
-  if ! task validate -- --name "$name"; then
+  # Run each command and check for failures.
+  if ! $VALIDATE_BIN --name "$name"; then
     echo "ERROR: Validation failed for $name"
-    task clean -- "$name" >/dev/null 2>&1 || true
+    $CLEAN_BIN "$name" >/dev/null 2>&1 || true
     return 1
   fi
 
-  if ! task build -- --tools --pull-community "$name"; then
+  if ! $BUILD_BIN --tools --pull-community "$name"; then
     echo "ERROR: Build failed for $name"
-    task clean -- "$name" >/dev/null 2>&1 || true
+    $CLEAN_BIN "$name" >/dev/null 2>&1 || true
     return 1
   fi
 
   echo "--------------------------------"
 
-  if ! task catalog -- "$name"; then
+  if ! $CATALOG_BIN "$name"; then
     echo "ERROR: Catalog generation failed for $name"
-    task clean -- "$name" >/dev/null 2>&1 || true
+    $CLEAN_BIN "$name" >/dev/null 2>&1 || true
     return 1
   fi
 
@@ -43,34 +87,35 @@ process_server() {
   echo "--------------------------------"
   echo "Successfully processed: $name"
   echo ""
-  if ! task clean -- "$name"; then
+  if ! $CLEAN_BIN "$name"; then
     echo "WARNING: Cleanup encountered issues for $name"
   fi
 
   return 0
 }
 
-# Main loop - process each file but skip duplicate servers
+# Main loop - process each file but skip duplicate servers.
 while IFS= read -r file; do
   dir=$(dirname "$file")
   name=$(basename "$dir")
 
-  # Skip if we've already processed this server (can happen when more than one file is changed for the same server)
+  # Skip if we've already processed this server (can happen when more than
+  # one file is changed for the same server).
   if [[ "$processed_servers" == *"|$name|"* ]]; then
     echo "Skipping already processed server: $name (from file: $file)"
     continue
   fi
 
-  # Mark this server as processed
+  # Mark this server as processed.
   processed_servers="${processed_servers}|$name|"
 
   if ! process_server "$file"; then
     echo "FAILED: Processing server from file: $file"
     overall_success=false
   fi
-done < changed-servers.txt
+done < "$CHANGED_SERVERS_FILE"
 
-# Exit with appropriate status code
+# Exit with appropriate status code.
 if [ "$overall_success" = true ]; then
   echo "All servers processed successfully!"
   exit 0


### PR DESCRIPTION
As our server definition requirements evolve, we want to make sure whatever is going into main is up-to-date with the latest requirements. In order to accomplish that, we can't run the validation tooling from the PR branch - instead we need to build it from main and then run it on the PR worktree.
