### PR TITLE
servers: rename mcp-victoriametrics to victoriametrics

### DIFF
--- a/servers/victoriametrics/server.yaml
+++ b/servers/victoriametrics/server.yaml
@@ -1,4 +1,4 @@
-name: mcp-victoriametrics
+name: victoriametrics
 image: ghcr.io/victoriametrics-community/mcp-victoriametrics
 type: server
 meta:
@@ -22,35 +22,35 @@ source:
 config:
     description: "Configure the connection to VictoriaMetrics MCP Server"
     secrets:
-        - name: "mcp-victoriametrics.vm_instance_bearer_token"
+        - name: "victoriametrics.vm_instance_bearer_token"
           env: "VM_INSTANCE_BEARER_TOKEN"
           example: "<instance_bearer_token_for_authentication>"
           required: false
     env:
         - name: "VM_INSTANCE_ENTRYPOINT"
           example: "https://play.victoriametrics.com"
-          value: "{{mcp-victoriametrics.vm_instance_entrypoint}}"
+          value: "{{victoriametrics.vm_instance_entrypoint}}"
         - name: "VM_INSTANCE_TYPE"
           example: "cluster"
-          value: "{{mcp-victoriametrics.vm_instance_type}}"
+          value: "{{victoriametrics.vm_instance_type}}"
         - name: "VM_INSTANCE_HEADERS"
           example: "HEADER2=HEADER_VALUE,HEADER2=HEADER_VALUE_2"
-          value: "{{mcp-victoriametrics.vm_instance_headers}}"
+          value: "{{victoriametrics.vm_instance_headers}}"
         - name: "MCP_SERVER_MODE"
           example: "stdio"
-          value: "{{mcp-victoriametrics.mcp_server_mode}}"
+          value: "{{victoriametrics.mcp_server_mode}}"
         - name: "MCP_LISTEN_ADDR"
           example: ":8080"
-          value: "{{mcp-victoriametrics.mcp_listen_addr}}"
+          value: "{{victoriametrics.mcp_listen_addr}}"
         - name: "MCP_DISABLED_TOOLS"
           example: "export,metric_statistics,test_rules"
-          value: "{{mcp-victoriametrics.mcp_disabled_tools}}"
+          value: "{{victoriametrics.mcp_disabled_tools}}"
         - name: "MCP_DISABLE_RESOURCES"
           example: "false"
-          value: "{{mcp-victoriametrics.mcp_disable_resources}}"
+          value: "{{victoriametrics.mcp_disable_resources}}"
         - name: "MCP_HEARTBEAT_INTERVAL"
           example: "30s"
-          value: "{{mcp-victoriametrics.mcp_heartbeat_interval}}"
+          value: "{{victoriametrics.mcp_heartbeat_interval}}"
     parameters:
         type: object
         required:


### PR DESCRIPTION
This PR renames the `mcp-victoriametrics` server to `victoriametrics`.

This hasn't published to the catalog yet.