### PR TITLE
ci: enable the update-pins workflow to run nightly

### DIFF
--- a/.github/workflows/update-pins.yaml
+++ b/.github/workflows/update-pins.yaml
@@ -1,8 +1,8 @@
 name: Update MCP Server Version Pins
 
 on:
-  # schedule:
-  #   - cron: "0 5 * * *"
+  schedule:
+    - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       max_new_prs:


### PR DESCRIPTION
It's time to let this run nightly.