### PR TITLE
chore: update pin for wikipedia-mcp

### DIFF
--- a/servers/wikipedia-mcp/server.yaml
+++ b/servers/wikipedia-mcp/server.yaml
@@ -11,4 +11,4 @@ about:
   icon: https://avatars.githubusercontent.com/u/56668?s=200&v=4
 source:
   project: https://github.com/Rudra-ravi/wikipedia-mcp
-  commit: bc12a6490be23c3481e29d0258736372a1a2f865
+  commit: 2553fd47a9ebf3fa6cf994f1be44b87e4fda2c94


### PR DESCRIPTION
Automated commit pin update for wikipedia-mcp.