### PR TITLE
Add gemini-api-docs MCP server

### DIFF
--- a/servers/gemini-api-docs/server.yaml
+++ b/servers/gemini-api-docs/server.yaml
@@ -1,0 +1,14 @@
+name: gemini-api-docs
+image: mcp/gemini-api-docs-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+about:
+  title: Gemini API Docs
+  description: Provides tools to search and retrieve Google Gemini API documentation.
+  icon: https://www.google.com/s2/favicons?domain=gemini.google.com&sz=64
+source:
+  project: https://github.com/kgprs/gemini-api-docs-mcp
+  commit: 8e8aa1543e1cb5f0bc0b1d5056da48f07a8e6332


### PR DESCRIPTION
This uses a forked version of the repo as the main one doesn't have a Dockerfile 
PR to merge the Dockerfile into the main repo: https://github.com/philschmid/gemini-api-docs-mcp/pull/1/files

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
