### PR TITLE
Update SonarQube configuration and tools

### DIFF
--- a/servers/sonarqube/server.yaml
+++ b/servers/sonarqube/server.yaml
@@ -12,13 +12,13 @@ about:
 source:
   project: https://github.com/SonarSource/sonarqube-mcp-server
   branch: master
-  commit: 6f1cf9eebf593c01844e5fc3f04ac2de49233ab3
+  commit: 029fc71c1dba8bc100d54a76a3b5785c7df41723
 config:
   description: Configure the connection to SonarQube
   secrets:
     - name: sonarqube.token
       env: SONARQUBE_TOKEN
-      example: YOUR_SONARQUBE_TOKEN
+      example: YOUR_SONARQUBE_USER_TOKEN
   env:
     - name: SONARQUBE_URL
       example: https://my-sonarqube.com

--- a/servers/sonarqube/tools.json
+++ b/servers/sonarqube/tools.json
@@ -1,0 +1,397 @@
+[
+  {
+    "name": "analyze_code_snippet",
+    "description": "Analyze a file or code snippet with SonarQube analyzers to identify code quality and security issues",
+    "arguments": [
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Language of the code snippet"
+      },
+      {
+        "name": "code_snippet",
+        "type": "string",
+        "desc": "Code snippet to analyze"
+      }
+    ]
+  },
+  {
+    "name": "analyze_file_list",
+    "description": "Analyze files in the current working directory using SonarQube for IDE",
+    "arguments": [
+      {
+        "name": "file_absolute_paths",
+        "type": "array",
+        "desc": "List of absolute file paths to analyze"
+      }
+    ]
+  },
+  {
+    "name": "toggle_automatic_analysis",
+    "description": "Enable or disable SonarQube for IDE automatic analysis",
+    "arguments": [
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Enable or disable the automatic analysis"
+      }
+    ]
+  },
+  {
+    "name": "search_sonar_issues_in_projects",
+    "description": "Search for SonarQube issues in my organization's projects",
+    "arguments": [
+      {
+        "name": "projects",
+        "type": "array",
+        "desc": "An optional list of Sonar projects to look in"
+      },
+      {
+        "name": "pullRequestId",
+        "type": "string",
+        "desc": "The identifier of the Pull Request to look in"
+      },
+      {
+        "name": "severities",
+        "type": "string",
+        "desc": "An optional list of severities to filter by, separated by a comma. Possible values: INFO, LOW, MEDIUM, HIGH, BLOCKER"
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": "An optional page number. Defaults to 1"
+      },
+      {
+        "name": "pageSize",
+        "type": "number",
+        "desc": "An optional page size. Must be greater than 0 and less than or equal to 500. Defaults to 100"
+      }
+    ]
+  },
+  {
+    "name": "change_sonar_issue_status",
+    "description": "Change the status of a SonarQube issue",
+    "arguments": [
+      {
+        "name": "issue_key",
+        "type": "string",
+        "desc": "Key of the issue to modify"
+      },
+      {
+        "name": "transition",
+        "type": "string",
+        "desc": "Transition to apply to the issue"
+      }
+    ]
+  },
+  {
+    "name": "search_my_sonarqube_projects",
+    "description": "Find SonarQube projects. The response is paginated",
+    "arguments": [
+      {
+        "name": "page",
+        "type": "string",
+        "desc": "An optional page number. Defaults to 1"
+      }
+    ]
+  },
+  {
+    "name": "list_quality_gates",
+    "description": "List all quality gates in my SonarQube",
+    "arguments": []
+  },
+  {
+    "name": "get_project_quality_gate_status",
+    "description": "Get the quality gate status for a project",
+    "arguments": [
+      {
+        "name": "analysisId",
+        "type": "string",
+        "desc": "The optional analysis ID to get the status for"
+      },
+      {
+        "name": "branch",
+        "type": "string",
+        "desc": "The optional branch key to get the status for"
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": "The optional project ID"
+      },
+      {
+        "name": "projectKey",
+        "type": "string",
+        "desc": "The optional project key to get the status for"
+      },
+      {
+        "name": "pullRequest",
+        "type": "string",
+        "desc": "The optional pull request ID to get the status for"
+      }
+    ]
+  },
+  {
+    "name": "show_rule",
+    "description": "Shows detailed information about a SonarQube rule",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "Rule key"
+      }
+    ]
+  },
+  {
+    "name": "list_rule_repositories",
+    "description": "List rule repositories available in SonarQube",
+    "arguments": [
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Optional language key to filter repositories"
+      },
+      {
+        "name": "q",
+        "type": "string",
+        "desc": "Optional search query to filter repositories by name or key"
+      }
+    ]
+  },
+  {
+    "name": "list_languages",
+    "description": "List all programming languages supported in this SonarQube instance",
+    "arguments": [
+      {
+        "name": "q",
+        "type": "string",
+        "desc": "Optional pattern to match language keys/names against"
+      }
+    ]
+  },
+  {
+    "name": "get_component_measures",
+    "description": "Get SonarQube measures for a project, such as ncloc, complexity, violations, coverage, etc",
+    "arguments": [
+      {
+        "name": "projectKey",
+        "type": "string",
+        "desc": "The project key"
+      },
+      {
+        "name": "branch",
+        "type": "string",
+        "desc": "The branch to analyze for measures"
+      },
+      {
+        "name": "metricKeys",
+        "type": "array",
+        "desc": "The metric keys to retrieve"
+      },
+      {
+        "name": "pullRequest",
+        "type": "string",
+        "desc": "The pull request identifier to analyze for measures"
+      }
+    ]
+  },
+  {
+    "name": "search_metrics",
+    "description": "Search for SonarQube metrics",
+    "arguments": [
+      {
+        "name": "page",
+        "type": "number",
+        "desc": "1-based page number (default: 1)"
+      },
+      {
+        "name": "pageSize",
+        "type": "number",
+        "desc": "Page size. Must be greater than 0 and less than or equal to 500 (default: 100)"
+      }
+    ]
+  },
+  {
+    "name": "get_raw_source",
+    "description": "Get source code as raw text from SonarQube. Require 'See Source Code' permission on file",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "File key"
+      },
+      {
+        "name": "branch",
+        "type": "string",
+        "desc": "Branch key"
+      },
+      {
+        "name": "pullRequest",
+        "type": "string",
+        "desc": "Pull request id"
+      }
+    ]
+  },
+  {
+    "name": "get_scm_info",
+    "description": "Get SCM information of SonarQube source files. Require See Source Code permission on file's project",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "File key"
+      },
+      {
+        "name": "commitsByLine",
+        "type": "boolean",
+        "desc": "Group lines by SCM commit if value is false, else display commits for each line"
+      },
+      {
+        "name": "from",
+        "type": "number",
+        "desc": "First line to return. Starts at 1"
+      },
+      {
+        "name": "to",
+        "type": "number",
+        "desc": "Last line to return (inclusive)"
+      }
+    ]
+  },
+  {
+    "name": "get_system_health",
+    "description": "Get the health status of SonarQube Server instance. Returns GREEN, YELLOW, or RED",
+    "arguments": []
+  },
+  {
+    "name": "get_system_status",
+    "description": "Get state information about SonarQube Server. Returns status, version, and id",
+    "arguments": []
+  },
+  {
+    "name": "get_system_logs",
+    "description": "Get SonarQube Server system logs in plain-text format. Requires system administration permission",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the logs to get. Possible values: access, app, ce, deprecation, es, web. Default: app"
+      }
+    ]
+  },
+  {
+    "name": "ping_system",
+    "description": "Ping the SonarQube Server system to check if it's alive. Returns 'pong' as plain text",
+    "arguments": []
+  },
+  {
+    "name": "get_system_info",
+    "description": "Get detailed information about SonarQube Server system configuration including JVM state, database, search indexes, and settings. Requires 'Administer' permissions",
+    "arguments": []
+  },
+  {
+    "name": "create_webhook",
+    "description": "Create a new webhook for the SonarQube organization or project. Requires 'Administer' permission",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the webhook"
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "Server endpoint that will receive the webhook payload"
+      },
+      {
+        "name": "project",
+        "type": "string",
+        "desc": "The key of the project that will own the webhook"
+      },
+      {
+        "name": "secret",
+        "type": "string",
+        "desc": "If provided, secret will be used as the key to generate the HMAC hex digest value"
+      }
+    ]
+  },
+  {
+    "name": "list_webhooks",
+    "description": "List all webhooks for the SonarQube organization or project. Requires 'Administer' permission",
+    "arguments": [
+      {
+        "name": "project",
+        "type": "string",
+        "desc": "Optional project key to list project-specific webhooks"
+      }
+    ]
+  },
+  {
+    "name": "list_portfolios",
+    "description": "List portfolios available in SonarQube with filtering and pagination options",
+    "arguments": [
+      {
+        "name": "enterpriseId",
+        "type": "string",
+        "desc": "Enterprise uuid (SonarQube Cloud only)"
+      },
+      {
+        "name": "q",
+        "type": "string",
+        "desc": "Search query to filter portfolios by name"
+      },
+      {
+        "name": "favorite",
+        "type": "boolean",
+        "desc": "If true, only returns favorite portfolios"
+      },
+      {
+        "name": "draft",
+        "type": "boolean",
+        "desc": "If true, only returns drafts created by the logged-in user (SonarQube Cloud only)"
+      },
+      {
+        "name": "pageIndex",
+        "type": "number",
+        "desc": "Index of the page to fetch (default: 1)"
+      },
+      {
+        "name": "pageSize",
+        "type": "number",
+        "desc": "Size of the page to fetch"
+      }
+    ]
+  },
+  {
+    "name": "list_enterprises",
+    "description": "List the enterprises available in SonarQube Cloud that you have access to",
+    "arguments": [
+      {
+        "name": "enterpriseKey",
+        "type": "string",
+        "desc": "Optional enterprise key to filter results"
+      }
+    ]
+  },
+  {
+    "name": "search_dependency_risks",
+    "description": "Search for software composition analysis issues (dependency risks) of a SonarQube project",
+    "arguments": [
+      {
+        "name": "projectKey",
+        "type": "string",
+        "desc": "Project key"
+      },
+      {
+        "name": "branchKey",
+        "type": "string",
+        "desc": "The branch key"
+      },
+      {
+        "name": "pullRequestKey",
+        "type": "string",
+        "desc": "The pull request key"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Update SonarQube MCP Server configuration:
- Add `tools.json` to avoid failure at start up (configuration is required to list tools)
- Update `SONARQUBE_TOKEN` example to mention that **USER** token type is required
- Update commit SHA