### PR TITLE
chore: update atlan server to v0.2.11

### DIFF
--- a/servers/atlan/server.yaml
+++ b/servers/atlan/server.yaml
@@ -13,7 +13,7 @@ about:
 source:
   project: https://github.com/atlanhq/agent-toolkit
   branch: main
-  commit: d5856cf0e7b331dda6e35850bc6a2f62673cf621
+  commit: c9c53685adf7f61881b36360de341f5c075a38ec
   directory: modelcontextprotocol
 config:
   description: Configure the connection to Atlan


### PR DESCRIPTION
## MCP Server Information

**Server Name:Atlan**
**Repository URL:https://github.com/atlanhq/agent-toolkit/**
**Brief Description:Updating the atlan server image to the latest release on docker hub**

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
