### PR TITLE
fix: update dateAdded to use UTC format in ToTile function

### DIFF
--- a/pkg/catalog/tile.go
+++ b/pkg/catalog/tile.go
@@ -166,7 +166,7 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 		}
 	}
 
-	dateAdded := time.Now().Format(time.RFC3339)
+	dateAdded := time.Now().UTC().Format(time.RFC3339)
 
 	var remote Remote
 	if server.Remote.URL != "" {


### PR DESCRIPTION
Hello, 

I am working on submitting a new mcp server but ran into issues with local testing. Docker Desktop’s MCP Toolkit chokes on dateAdded values that carry an explicit offset (e.g. 2025-11-10T22:50:31-05:00). Even though that’s valid RFC 3339, the UI currently requires the canonical Z-suffix. By forcing the timestamp to UTC before formatting, we get values like 2025-11-10T22:50:31Z, which parse cleanly. The upstream code emits local time, so on any machine outside UTC the Desktop UI will reject the generated tiles.

## Summary
- ensure `pkg/catalog/tile.go` uses `time.Now().UTC()` before formatting `dateAdded`
- prevents catalog tiles from carrying timezone offsets in their metadata

## Problem
Docker Desktop rejects tiles whose `dateAdded` includes a numeric timezone offset.
Steps to reproduce on current `main`:
1. Run `task catalog -- <server>` for any server (e.g. `NewServer`) and import it with `docker mcp catalog import`.
2. Open the Desktop MCP Toolkit; the server fails to render, and `~/Library/Containers/com.docker.docker/Data/log/host/electron-*.log` records  
   `registry.<server>.dateAdded - Invalid datetime`.
```
Could not parse the MCP server "SSH Orchestrator" schema.
registry.NewServer.dateAdded – Invalid datetime
```

## Fix
- normalized the timestamp to UTC before calling `Format(time.RFC3339)`, producing the `...Z` form Desktop expects.

## Testing
- `task catalog -- NewServer`
- `docker mcp catalog import $PWD/catalogs/NewServer/catalog.yaml`
- Confirmed Desktop UI loads the tile and logs contain no invalid datetime errors.

### Environment

- **Hardware:** Apple silicon notebook (Model MRX33LL/A, Apple M3 Pro 11‑core), 18 GB unified memory  
- **Operating System:** macOS 15.7 (24G222)  
- **Docker Desktop:** 4.50.0 (209931)  
  - Engine 28.5.1 (API 1.51)  
  - containerd 1.7.27 / runc 1.2.5 / docker-init 0.19.0  
- **Docker MCP Toolkit:** `docker mcp --version` → v0.26.0  
- **git:** 2.39.5 (Apple Git-154)  
- **Go:** go1.24.0 darwin/arm64

I think this is a bug worth reporting, please review. 

Thank you 

Sammy