### PR TITLE
neo4j aura manager - add stateless flag

### DIFF
--- a/servers/neo4j-cloud-aura-api/server.yaml
+++ b/servers/neo4j-cloud-aura-api/server.yaml
@@ -42,6 +42,9 @@ config:
     - name: NEO4J_MCP_SERVER_ALLOWED_HOSTS
       example: "localhost,127.0.0.1"
       value: "{{neo4j-cloud-aura-api.server_allowed_hosts}}"
+    - name: NEO4J_MCP_SERVER_STATELESS
+      example: "false"
+      value: "{{neo4j-cloud-aura-api.server_stateless}}"
   parameters:
     type: object
     properties:
@@ -59,6 +62,8 @@ config:
         type: string
       server_allowed_hosts:
         type: string
+      server_stateless:
+        type: boolean
     required:
       - client_id
 requirement: neo4j


### PR DESCRIPTION
---
name: Update MCP Server
about: add stateless config
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** neo4j-aura-manager
**Repository URL:** https://github.com/neo4j-contrib/mcp-neo4j/tree/main/servers/mcp-neo4j-cloud-aura-api
**Brief Description:** MCP Neo4j Aura Database Instance Manager

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
