### PR TITLE
Remove command from definition

### DIFF
--- a/servers/desktop-commander/server.yaml
+++ b/servers/desktop-commander/server.yaml
@@ -23,10 +23,6 @@ source:
   project: https://github.com/wonderwhy-er/DesktopCommanderMCP
   commit: 727dfd407c03677f5732e2d652ea2ecb634a9dd6
 run:
-  command:
-    - npm
-    - run
-    - start
   volumes:
     - "{{desktop-commander.paths|volume|into}}"
 config:


### PR DESCRIPTION
* the current Docker file has an explict CMD (see https://github.com/wonderwhy-er/DesktopCommanderMCP/blob/main/Dockerfile#L26)
* when we run with npm run build, npm writes some messages to stdout which interferes with the stdio transport

I have removed these lines and tested with a local catalog. The problem is fixed.

The catalog build system is using a client that is skipping these extra stdout message so the tests are passing.  However, both the official Node and the official Golang SDKs will not work with the server configured like this.
