### PR TITLE
feat: just-mcp

### DIFF
--- a/servers/just-mcp/server.yaml
+++ b/servers/just-mcp/server.yaml
@@ -1,0 +1,14 @@
+name: just-mcp
+image: mcp/just-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+about:
+  title: Just Command Runner
+  description: "https://just.systems/ provides just, a lightweight command runner using a justfile (like a Makefile) with parameters, macros, and modules. Commands run with just <task>, and an LLM can mount a justfile inside a Docker sandbox to execute them. This is ideal for spec-driven development: agents can memoize tasks like just build, turning the justfile into persistent, version-controlled tribal knowledge. Just also integrates with GitHub Actions, VSCode, and other editors. Using just-mcp reduces context waste because the LLM doesn’t need to read the file—just -l lists available commands—allowing agents to run high-level tasks (build, test, release, commit) and update the justfile when errors occur."
+  icon: https://images.emojiterra.com/google/noto-emoji/unicode-16.0/color/svg/1f916.svg
+source:
+  project: https://github.com/promptexecution/just-mcp
+  commit: c5308cb0700e6c34a784dff3d8d86c2a6449bbe9


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: just-mcp
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name: just-mcp**
**Repository URL: http://github.com/promptexecution/just-mcp**
**Brief Description: see https://medium.com/@brianhorakh/just-mcp-to-reduce-context-waste-in-spec-driven-development-3935922da5cf**

## Basic Requirements

- [x ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ x] **MCP Compliant**: Implements MCP API specification
- [x ] **Active Development**: Recent commits and maintained
- [x ] **Docker Artifact**: Dockerfile
- [x ] **Documentation**: Basic README and setup instructions
- [x ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ x] This server meets the basic requirements listed above
- [ x] I understand this will undergo automated and manual review.
- [ x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
