### PR TITLE
Add LiquidSoap MCP Server

### DIFF
--- a/servers/liquidsoap/server.yaml
+++ b/servers/liquidsoap/server.yaml
@@ -1,0 +1,24 @@
+name: liquidsoap
+image: mcp/liquidsoap
+type: server
+meta:
+  category: devops
+  tags:
+    - audio
+    - broadcasting
+    - documentation
+    - liquidsoap
+    - model-context-protocol
+    - radio
+    - streaming
+    - typescript
+    - video
+about:
+  title: LiquidSoap MCP Server
+  description: Version-accurate Liquidsoap 2.4.0 documentation and scripting assistance. Provides AI assistants with official docs, API reference, examples, and script validation to eliminate hallucinations when working with Liquidsoap streaming configurations.
+  icon: https://avatars.githubusercontent.com/u/47437340?v=4
+source:
+  project: https://github.com/splinesreticulating/LiquidSoapMCP
+  commit: 9c485fc96f128fdbe3c581d29e7ada50fe748aae
+config:
+  description: No configuration required - server provides read-only access to Liquidsoap 2.4.0 documentation


### PR DESCRIPTION
## Summary
Add LiquidSoap MCP Server to the Docker MCP registry.

## Server Details
- **Name**: liquidsoap
- **Category**: DevOps
- **License**: MIT
- **Repository**: https://github.com/splinesreticulating/LiquidSoapMCP

## Description
Version-accurate Liquidsoap 2.4.0 documentation and scripting assistance. This MCP server provides AI assistants with official documentation, API references, examples, and script validation to eliminate hallucinations when working with Liquidsoap streaming configurations.

## Features
- Official Liquidsoap 2.4.0 documentation access
- API reference and function search
- Ready-to-use code examples
- Script syntax validation
- Changelog and migration notes
- 7 tools for comprehensive Liquidsoap support

## Testing
- ✅ Docker image builds successfully
- ✅ Server runs correctly in container
- ✅ All 7 tools discovered and validated
- ✅ Catalog generated successfully

## Checklist
- [x] Dockerfile present in source repository
- [x] Server.yaml has no TODOs
- [x] Tested locally with Docker Desktop
- [x] All required fields populated
- [x] MIT License