### PR TITLE
Add MediaWiki MCP Server to registry

### DIFF
--- a/servers/mediawiki/server.yaml
+++ b/servers/mediawiki/server.yaml
@@ -1,0 +1,19 @@
+name: mediawiki
+image: mcp/mediawiki
+type: server
+meta:
+  category: knowledge
+  tags:
+    - mediawiki
+    - wiki
+    - documentation
+about:
+  title: MediaWiki
+  description: Interacts with any MediaWiki wiki, including Wikipedia. Supports reading, writing, and managing wiki pages, files, and categories.
+  icon: https://www.google.com/s2/favicons?domain=professional.wiki&sz=64
+source:
+  project: https://github.com/ProfessionalWiki/MediaWiki-MCP-Server
+  commit: fe37283a18267e2819bc51aff1d965e387eed8b2
+run:
+  env:
+    MCP_TRANSPORT: stdio

--- a/servers/mediawiki/server.yaml
+++ b/servers/mediawiki/server.yaml
@@ -13,7 +13,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=professional.wiki&sz=64
 source:
   project: https://github.com/ProfessionalWiki/MediaWiki-MCP-Server
-  commit: fe37283a18267e2819bc51aff1d965e387eed8b2
+  commit: 6324b4d733367f0ed430074a62d258ee46175b83
 run:
   env:
     MCP_TRANSPORT: stdio


### PR DESCRIPTION
## MCP Server Information

**Server Name:** MediaWiki MCP Server
**Repository URL:** https://github.com/ProfessionalWiki/MediaWiki-MCP-Server
**Brief Description:** Model Context Protocol (MCP) Server that enables interaction with any MediaWiki wiki, including Wikipedia. Supports reading, writing, and managing wiki pages, files, and categories.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `go run ./cmd/validate --name mediawiki`
- [x] I have built the MCP Server using `go run ./cmd/build --tools mediawiki`