### PR TITLE
Add DX MCP Server

### DIFF
--- a/servers/dx-mcp-server/server.yaml
+++ b/servers/dx-mcp-server/server.yaml
@@ -1,0 +1,20 @@
+name: dx-mcp-server
+image: mcp/dx-mcp-server
+type: server
+meta:
+    category: database
+    tags:
+        - database
+about:
+    title: DX MCP Server
+    description: Use natural language to write and execute SQL queries on your organizational data in DX Data Cloud. Query directly from AI applications like Claude Desktop and Cursor.
+    icon: https://avatars.githubusercontent.com/u/77246378?v=4
+source:
+    project: https://github.com/get-dx/dx-mcp-server
+    commit: 77669c9052cef3a973533b29a1435190bcd447e4
+config:
+    description: Configure the connection to DX Data Cloud database
+    secrets:
+        - name: dx-mcp-server.db_url
+          env: DB_URL
+          example: postgresql://username:password@hostname:port/database

--- a/servers/dx-mcp-server/tools.json
+++ b/servers/dx-mcp-server/tools.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "queryData",
+    "description": "Execute a SQL query against the DX Data Cloud PostgreSQL database. Always query from information_schema if you are uncertain about which tables and columns to look at.",
+    "arguments": [
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "SQL query to execute"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Adds the DX MCP Server to the registry, enabling users to execute SQL queries on DX Data Cloud using natural language through MCP clients like Claude Desktop and Cursor.

## Server Details

- **Name**: dx-mcp-server
- **Category**: database
- **Repository**: https://github.com/get-dx/dx-mcp-server
- **Tool**: `queryData` - Execute SQL queries against DX Data Cloud PostgreSQL database

## Configuration

- **Secret**: `DB_URL` - PostgreSQL connection string for DX Data Cloud
- **Example**: `postgresql://username:password@hostname:port/database`

## Testing

- ✅ Image builds successfully (`task build -- --tools dx-mcp-server`)
- ✅ Tool detected from `tools.json` (1 tool found)
- ✅ Catalog generated successfully (`task catalog -- dx-mcp-server`)

## Notes

- Included `tools.json` file since the server requires `DB_URL` to run
- Server provides single tool for SQL query execution
- Users can configure connection via DX's [DB Users settings page](https://app.getdx.com/datacloud/dbusers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)