### PR TITLE
Fix Azure MCP server duplicate command arguments

### DIFF
--- a/servers/azure/server.yaml
+++ b/servers/azure/server.yaml
@@ -13,7 +13,3 @@ source:
   project: https://github.com/Azure/azure-mcp
   branch: main
   commit: 1ea702cb489ba95c5d9bea8d41fc18e9343703f8
-run:
-  command:
-    - server
-    - start


### PR DESCRIPTION
## Problem

The Azure MCP server fails to start with error:
```
Can't start azure: failed to connect: calling "initialize": invalid character 'D' looking for beginning of value
```

https://docker.atlassian.net/browse/MCPT-166

## Root Cause

The Azure MCP server Docker image has `ENTRYPOINT ["./server-binary","server","start"]` already configured. The `server.yaml` was adding `["server", "start"]` as command arguments, resulting in duplicate arguments:
```
./server-binary server start server start
```

This caused the server to output help text to stdout instead of running in MCP stdio mode, which interfered with the JSON-RPC protocol.

## Solution

Removed the `run.command` section from `servers/azure/server.yaml` to use the default entrypoint, which already correctly configures the server to run in stdio mode (the default transport).

## Testing

- [x] Validated configuration with `task validate -- --name azure`
- [x] Confirmed Docker image entrypoint is properly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)