### PR TITLE
Add Taiga MCP Server - Containerized Agile Project Management

### DIFF
--- a/servers/taiga-mcp/readme.md
+++ b/servers/taiga-mcp/readme.md
@@ -1,0 +1,44 @@
+# Taiga MCP Server
+
+Full documentation: https://github.com/JohnWBlack/taiga-mcp
+
+## Overview
+Taiga MCP Server provides Model Context Protocol access to Taiga.io project management platform. Users deploy their own containerized instance connecting to their Taiga account.
+
+## Deployment
+Users run their own instance using Docker:
+
+```bash
+docker run -d \
+  -e TAIGA_BASE_URL=https://api.taiga.io/api/v1 \
+  -e TAIGA_USERNAME=your-email@example.com \
+  -e TAIGA_PASSWORD=your-password \
+  -e ACTION_PROXY_API_KEY=$(uuidgen) \
+  -p 8000:8000 \
+  ghcr.io/johnwblack/taiga-mcp:latest
+```
+
+Or deploy to Azure Container Apps, Kubernetes, or any container platform.
+
+## Features
+- **Projects**: List and retrieve project details
+- **Epics**: Manage high-level features and initiatives
+- **User Stories**: Create, update, list stories with search/filters
+- **Tasks**: Break down stories into actionable tasks
+- **Milestones**: Track sprints and release cycles
+- **Users**: Find team members and assign work
+
+## Authentication
+Each deployment requires Taiga.io credentials (username/password) and a generated ACTION_PROXY_API_KEY for MCP client authentication.
+
+## Use Cases
+- Agile project management through AI agents
+- DoD/SBIR program tracking automation
+- Sprint planning and story creation
+- Task assignment and status updates
+- Integration with ChatGPT, Claude, and other MCP clients
+
+## Links
+- GitHub: https://github.com/JohnWBlack/taiga-mcp
+- Taiga.io: https://taiga.io
+- Contact: john.black@offset3.com

--- a/servers/taiga-mcp/server.yaml
+++ b/servers/taiga-mcp/server.yaml
@@ -1,0 +1,41 @@
+name: taiga-mcp
+image: ghcr.io/johnwblack/taiga-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - project-management
+    - agile
+    - scrum
+about:
+  title: Taiga Project Management
+  description: Manage Agile projects with Taiga.io - create stories, epics, tasks, and milestones. Users deploy their own instance connecting to their Taiga account.
+  icon: https://www.google.com/s2/favicons?domain=taiga.io&sz=64
+source:
+  project: https://github.com/JohnWBlack/taiga-mcp
+  commit: da2015c27fe4
+config:
+  description: Configure connection to your Taiga.io account
+  secrets:
+    - name: taiga-mcp.taiga_username
+      env: TAIGA_USERNAME
+      example: your-email@example.com
+    - name: taiga-mcp.taiga_password
+      env: TAIGA_PASSWORD
+      example: your-password
+    - name: taiga-mcp.action_proxy_api_key
+      env: ACTION_PROXY_API_KEY
+      example: generate-a-uuid
+  env:
+    - name: TAIGA_BASE_URL
+      example: https://api.taiga.io/api/v1
+      value: '{{taiga-mcp.taiga_base_url}}'
+  parameters:
+    type: object
+    properties:
+      taiga_base_url:
+        type: string
+        default: https://api.taiga.io/api/v1
+    required:
+      - taiga_base_url

--- a/servers/taiga-mcp/tools.json
+++ b/servers/taiga-mcp/tools.json
@@ -1,0 +1,310 @@
+[
+  {
+    "name": "echo",
+    "description": "Echo a message back - diagnostic tool for testing MCP connectivity",
+    "arguments": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "Message to echo back"
+      }
+    ]
+  },
+  {
+    "name": "taiga.projects.list",
+    "description": "List Taiga projects where the authenticated user is a member",
+    "arguments": [
+      {
+        "name": "search",
+        "type": "string",
+        "desc": "Optional case-insensitive search filter"
+      }
+    ]
+  },
+  {
+    "name": "taiga.projects.get",
+    "description": "Get a specific Taiga project by ID or slug",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Numeric project ID"
+      },
+      {
+        "name": "slug",
+        "type": "string",
+        "desc": "Project slug (alternative to project_id)"
+      }
+    ]
+  },
+  {
+    "name": "taiga.epics.list",
+    "description": "List epics for a project",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Project ID"
+      }
+    ]
+  },
+  {
+    "name": "taiga.epics.add_user_story",
+    "description": "Link a user story to an epic",
+    "arguments": [
+      {
+        "name": "epic_id",
+        "type": "number",
+        "desc": "Epic ID"
+      },
+      {
+        "name": "user_story_id",
+        "type": "number",
+        "desc": "User story ID to link"
+      }
+    ]
+  },
+  {
+    "name": "taiga.stories.list",
+    "description": "List user stories for a project with optional filters",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Project ID"
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "desc": "Text search filter"
+      },
+      {
+        "name": "epic_id",
+        "type": "number",
+        "desc": "Filter by epic"
+      },
+      {
+        "name": "tags",
+        "type": "string",
+        "desc": "Comma-separated tags"
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": "Page number for pagination"
+      },
+      {
+        "name": "page_size",
+        "type": "number",
+        "desc": "Items per page"
+      }
+    ]
+  },
+  {
+    "name": "taiga.stories.create",
+    "description": "Create a new user story in a project",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Project ID"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": "Story title/subject"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Story description"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "Status name or ID"
+      },
+      {
+        "name": "tags",
+        "type": "array",
+        "desc": "Tags to apply"
+      },
+      {
+        "name": "assigned_to",
+        "type": "number",
+        "desc": "User ID to assign"
+      }
+    ]
+  },
+  {
+    "name": "taiga.stories.update",
+    "description": "Update an existing user story",
+    "arguments": [
+      {
+        "name": "user_story_id",
+        "type": "number",
+        "desc": "Story ID to update"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": "New subject"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "New description"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "New status"
+      },
+      {
+        "name": "tags",
+        "type": "array",
+        "desc": "New tags"
+      },
+      {
+        "name": "assigned_to",
+        "type": "number",
+        "desc": "New assignee ID"
+      },
+      {
+        "name": "version",
+        "type": "number",
+        "desc": "Version for optimistic locking"
+      }
+    ]
+  },
+  {
+    "name": "taiga.tasks.list",
+    "description": "List tasks with optional filters",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Project ID"
+      },
+      {
+        "name": "user_story_id",
+        "type": "number",
+        "desc": "Filter by user story"
+      },
+      {
+        "name": "assigned_to",
+        "type": "number",
+        "desc": "Filter by assignee"
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "desc": "Text search"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "Filter by status"
+      }
+    ]
+  },
+  {
+    "name": "taiga.tasks.create",
+    "description": "Create a new task under a user story",
+    "arguments": [
+      {
+        "name": "user_story_id",
+        "type": "number",
+        "desc": "Parent story ID"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": "Task subject"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Task description"
+      },
+      {
+        "name": "assigned_to",
+        "type": "number",
+        "desc": "Assignee user ID"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "Status name or ID"
+      },
+      {
+        "name": "tags",
+        "type": "array",
+        "desc": "Tags to apply"
+      }
+    ]
+  },
+  {
+    "name": "taiga.tasks.update",
+    "description": "Update an existing task",
+    "arguments": [
+      {
+        "name": "task_id",
+        "type": "number",
+        "desc": "Task ID"
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": "New subject"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "New description"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "New status"
+      },
+      {
+        "name": "assigned_to",
+        "type": "number",
+        "desc": "New assignee"
+      }
+    ]
+  },
+  {
+    "name": "taiga.users.list",
+    "description": "Find Taiga users by project membership",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Project ID"
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "desc": "Search by name/username/email"
+      }
+    ]
+  },
+  {
+    "name": "taiga.milestones.list",
+    "description": "List milestones/sprints for a project",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "number",
+        "desc": "Project ID"
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "desc": "Filter by name/slug"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds Taiga MCP Server - a containerized MCP server for Taiga.io project management. Users deploy their own instance with their Taiga credentials.

**Server Type**: Local/Containerized (users run their own deployment)

**Details**:
- Docker Image: ghcr.io/johnwblack/taiga-mcp
- GitHub: https://github.com/JohnWBlack/taiga-mcp
- Category: Productivity
- License: MIT

**Features**: Projects, Epics, User Stories, Tasks, Milestones, Users

**14 MCP Tools**:
- taiga.projects.list/get
- taiga.epics.list/add_user_story
- taiga.stories.list/create/update
- taiga.tasks.list/create/update
- taiga.users.list
- taiga.milestones.list
- echo (diagnostic)

**Configuration** (user-provided):
- TAIGA_BASE_URL (default: https://api.taiga.io/api/v1)
- TAIGA_USERNAME
- TAIGA_PASSWORD
- ACTION_PROXY_API_KEY

**Readiness**:
✓ Dockerfile in source repository
✓ Published to GHCR
✓ Complete tools.json with 14 tools
✓ Comprehensive README
✓ Tested with ChatGPT/MCP clients
✓ No secrets in image

**Contact**: John Black (john.black@offset3.com)

Test credentials will be shared via https://forms.gle/6Lw3nsvu2d6nFg8e6