### PR TITLE
Update Zen server description and icon

### DIFF
--- a/servers/zen/server.yaml
+++ b/servers/zen/server.yaml
@@ -10,8 +10,8 @@ meta:
     - devops
 about:
   title: Zen
-  description: Model Context Protocol server that bridges multiple AI models and CLIs, enabling orchestrated workflows across Claude Code, Gemini CLI, Codex CLI, and other AI development tools.
-  icon: https://avatars.githubusercontent.com/u/92374028?s=200&v=4
+  description: Bridges multiple AI models and CLIs, enabling orchestrated workflows across Claude Code, Gemini CLI, Codex CLI, and other AI development tools.
+  icon: https://avatars.githubusercontent.com/u/26299964?s=200&v=4
 source:
   project: https://github.com/beehiveinnovations/zen-mcp-server
   commit: 4d3d177d91370097ca7ac4f922fa3a8b69ce3250


### PR DESCRIPTION
## Summary
- Shortened Zen server description to remove redundant prefix
- Updated icon URL to correct organization avatar

## Changes
- Description: Removed "Model Context Protocol server that" prefix for consistency
- Icon: Updated to https://avatars.githubusercontent.com/u/26299964?s=200&v=4

Minor cleanup to improve consistency across server entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)