### PR TITLE
fix(redis): align server.yaml with upstream redis/mcp-redis config

### DIFF
--- a/servers/redis/server.yaml
+++ b/servers/redis/server.yaml
@@ -7,8 +7,8 @@ meta:
     - redis
     - database
 about:
-  title: Redis
-  description: Access to Redis database operations.
+  title: Redis MCP Server
+  description: Natural language interface designed for agentic applications to manage and search data in Redis.
   icon: https://avatars.githubusercontent.com/u/1529926?v=4
 source:
   project: https://github.com/redis/mcp-redis
@@ -25,27 +25,30 @@ config:
     - name: REDIS_PORT
       example: "6379"
       value: "{{redis.port}}"
+    - name: REDIS_DB
+      example: "0"
+      value: "{{redis.db}}"
     - name: REDIS_USERNAME
       example: default
       value: "{{redis.username}}"
     - name: REDIS_SSL
       example: "False"
       value: "{{redis.ssl}}"
-    - name: REDIS_CA_PATH
+    - name: REDIS_SSL_CA_PATH
       example: ""
-      value: "{{redis.ca_path}}"
+      value: "{{redis.ssl_ca_path}}"
     - name: REDIS_SSL_KEYFILE
       example: ""
       value: "{{redis.ssl_keyfile}}"
     - name: REDIS_SSL_CERTFILE
       example: ""
       value: "{{redis.ssl_certfile}}"
-    - name: REDIS_CERT_REQS
+    - name: REDIS_SSL_CERT_REQS
       example: required
-      value: "{{redis.cert_reqs}}"
-    - name: REDIS_CA_CERTS
+      value: "{{redis.ssl_cert_reqs}}"
+    - name: REDIS_SSL_CA_CERTS
       example: ""
-      value: "{{redis.ca_certs}}"
+      value: "{{redis.ssl_ca_certs}}"
     - name: REDIS_CLUSTER_MODE
       example: "False"
       value: "{{redis.cluster_mode}}"
@@ -56,19 +59,21 @@ config:
         type: string
       port:
         type: integer
+      db:
+        type: integer
       username:
         type: string
       ssl:
         type: boolean
-      ca_path:
+      ssl_ca_path:
         type: string
       ssl_keyfile:
         type: string
       ssl_certfile:
         type: string
-      cert_reqs:
+      ssl_cert_reqs:
         type: string
-      ca_certs:
+      ssl_ca_certs:
         type: string
       cluster_mode:
         type: boolean


### PR DESCRIPTION
## Summary

Update the existing Redis MCP server entry to match `redis/mcp-redis` at commit `e6b17ce78fd19a7c021935c027db15c29e7be1a6` (version 0.3.6).

## Changes

- Sync `about.title` and `about.description` with upstream `server.json`.
- Add `REDIS_DB` env and `db` parameter.
- Rename SSL-related env vars to match `.env.example`:
  - `REDIS_SSL_CA_PATH`
  - `REDIS_SSL_CERT_REQS`
  - `REDIS_SSL_CA_CERTS`

## Notes

No new MCP server is added; this PR only corrects the existing `servers/redis/server.yaml` entry.
