### PR TITLE
Refactor Hummingbot MCP server configuration 

### DIFF
--- a/servers/hummingbot-mcp/server.yaml
+++ b/servers/hummingbot-mcp/server.yaml
@@ -12,26 +12,6 @@ about:
 source:
   project: https://github.com/hummingbot/mcp
   commit: ad24846aa3d62706265fdb28833e721debdb0df0
-config:
-  description: "Configure the MCP connection to the Hummingbot API"
-  secrets:
-    - name: hummingbot-mcp.username
-      env: HUMMINGBOT_API_USERNAME
-      example: admin
-    - name: hummingbot-mcp.password
-      env: HUMMINGBOT_API_PASSWORD
-      example: password
-  env:
-    - name: HUMMINGBOT_API_URL
-      example: http://localhost:8000
-      value: "{{hummingbot-mcp.api_url}}"
-  parameters:
-    type: object
-    properties:
-      api_url:
-        title: Hummingbot API URL
-        type: string
-        format: uri
-        default: http://localhost:8000
-    required:
-      - api_url
+run:
+    volumes:
+        - '{{hummingbot-mcp.data_volume}}:/root/.hummingbot_mcp'


### PR DESCRIPTION
Removed configuration details for MCP connection and added volume mapping for data storage.

We've introduced a new tool that allows users to add and manage multiple API servers. This enhancement eliminates the need to specify a single Hummingbot API server configuration when the application starts. Instead, we now use volume mapping to store the complete set of user-added API server configurations,
