### PR TITLE
Add database-mcp server

### DIFF
--- a/servers/database-mcp/readme.md
+++ b/servers/database-mcp/readme.md
@@ -1,0 +1,18 @@
+# Database MCP Server
+
+Model Context Protocol server for multi-database access (PostgreSQL, MySQL, SQLite, Snowflake) with comprehensive introspection and analysis tools.
+
+## Documentation
+
+- **GitHub Repository**: https://github.com/nitaiaharoni1/database-mcp
+- **npm Package**: https://www.npmjs.com/package/database-mcp
+- **README**: https://github.com/nitaiaharoni1/database-mcp#readme
+
+## Features
+
+- Multi-database support (PostgreSQL, MySQL, SQLite, Snowflake)
+- Comprehensive database introspection tools
+- Query execution and analysis
+- CSV export capabilities
+- PostgreSQL-specific advanced tools
+

--- a/servers/database-mcp/server.yaml
+++ b/servers/database-mcp/server.yaml
@@ -1,0 +1,32 @@
+name: database-mcp
+image: mcp/database-mcp
+type: server
+meta:
+  category: database
+  tags:
+    - database
+    - postgresql
+    - mysql
+    - sqlite
+    - snowflake
+    - multi-database
+about:
+  title: Database MCP Server
+  description: Model Context Protocol server for multi-database access (PostgreSQL, MySQL, SQLite, Snowflake) with comprehensive introspection and analysis tools
+  icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
+source:
+  project: https://github.com/nitaiaharoni1/database-mcp
+  commit: e9f6f8f856b1133f5b5f877b7ff40aec8ce12bf2
+config:
+  description: Configure the connection to your database
+  secrets:
+    - name: database-mcp.database_url
+      env: DATABASE_URL
+      example: postgresql://user:pass@host:port/db
+  parameters:
+    type: object
+    properties:
+      database_url:
+        type: string
+        description: Database connection string (PostgreSQL, MySQL, SQLite, or Snowflake)
+

--- a/servers/database-mcp/tools.json
+++ b/servers/database-mcp/tools.json
@@ -1,0 +1,186 @@
+[
+  {
+    "name": "query_database",
+    "description": "Execute a SQL query on the database. Supports PostgreSQL, MySQL, and SQLite. Allows SELECT, INSERT, UPDATE, ALTER, and CREATE operations. Destructive operations (DROP, DELETE, TRUNCATE) are blocked for safety.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "SQL query to execute (SELECT, INSERT, UPDATE, ALTER, CREATE statements allowed). Do not include SQL comments - provide clean SQL only."
+      }
+    ]
+  },
+  {
+    "name": "explain_query",
+    "description": "Get the execution plan for a SQL query without executing it. Supports PostgreSQL, MySQL, and SQLite.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "SQL query to explain (SELECT, INSERT, UPDATE, ALTER, CREATE statements allowed). Do not include SQL comments - provide clean SQL only."
+      },
+      {
+        "name": "analyze",
+        "type": "boolean",
+        "desc": "Whether to include actual execution statistics (WARNING: this executes the query). Not supported for SQLite."
+      }
+    ]
+  },
+  {
+    "name": "export_to_csv",
+    "description": "Execute a SQL query and export the results to a CSV file. Supports PostgreSQL, MySQL, and SQLite. The CSV file will include column headers by default and will be created with proper formatting. If only a filename is provided, the file will be saved to the user's Desktop.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "SQL SELECT query to execute and export results. Only SELECT statements are recommended for CSV export."
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": "Path where the CSV file should be created. Can be full absolute path, relative path, or just filename (will be saved to Desktop)."
+      },
+      {
+        "name": "include_headers",
+        "type": "boolean",
+        "desc": "Whether to include column headers in the CSV file. Defaults to true."
+      }
+    ]
+  },
+  {
+    "name": "list_schemas",
+    "description": "List all available schemas/databases. Works with PostgreSQL, MySQL, and SQLite."
+  },
+  {
+    "name": "list_tables",
+    "description": "List tables and views with details. Works with PostgreSQL, MySQL, and SQLite."
+  },
+  {
+    "name": "describe_table",
+    "description": "Get detailed table structure and column information. Works with PostgreSQL, MySQL, and SQLite.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Name of the table to describe"
+      }
+    ]
+  },
+  {
+    "name": "list_indexes",
+    "description": "List all indexes and their properties. Works with PostgreSQL, MySQL, and SQLite.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Optional table name to filter indexes"
+      }
+    ]
+  },
+  {
+    "name": "get_foreign_keys",
+    "description": "Discover foreign key relationships. Works with PostgreSQL and MySQL.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Optional table name to filter foreign keys"
+      }
+    ]
+  },
+  {
+    "name": "list_functions",
+    "description": "List stored procedures and functions. Works with PostgreSQL, MySQL, and SQLite."
+  },
+  {
+    "name": "get_table_stats",
+    "description": "Get table statistics (row counts, sizes). Works with PostgreSQL, MySQL, and SQLite.",
+    "arguments": [
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Schema name to analyze (defaults to public schema)"
+      }
+    ]
+  },
+  {
+    "name": "get_database_info",
+    "description": "Get database version and configuration. Works with PostgreSQL, MySQL, and SQLite."
+  },
+  {
+    "name": "analyze_column",
+    "description": "Analyze column data distribution and statistics. Works with PostgreSQL, MySQL, and SQLite.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Name of the table containing the column"
+      },
+      {
+        "name": "column_name",
+        "type": "string",
+        "desc": "Name of the column to analyze"
+      }
+    ]
+  },
+  {
+    "name": "search_tables",
+    "description": "Search for tables and columns by name patterns. Works with PostgreSQL, MySQL, and SQLite.",
+    "arguments": [
+      {
+        "name": "pattern",
+        "type": "string",
+        "desc": "Search pattern for table or column names"
+      }
+    ]
+  },
+  {
+    "name": "get_connection_info",
+    "description": "Check connection status and database details. Works with PostgreSQL, MySQL, and SQLite."
+  },
+  {
+    "name": "postgres_catalog_query",
+    "description": "Execute PostgreSQL system catalog queries for advanced database introspection. Supports queries on pg_constraint, pg_indexes, pg_class, and other system catalogs. Only SELECT queries are allowed for safety.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "PostgreSQL system catalog query (SELECT statements only)"
+      }
+    ]
+  },
+  {
+    "name": "get_table_constraints",
+    "description": "Get detailed constraint information for a PostgreSQL table including CHECK, FOREIGN KEY, PRIMARY KEY, UNIQUE, and EXCLUDE constraints.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Name of the table to get constraints for"
+      }
+    ]
+  },
+  {
+    "name": "get_table_indexes",
+    "description": "Get detailed index information for a PostgreSQL table including index definitions, types, and scope.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Name of the table to get indexes for"
+      }
+    ]
+  },
+  {
+    "name": "analyze_index_patterns",
+    "description": "Analyze index usage patterns in PostgreSQL to identify potential optimization opportunities.",
+    "arguments": [
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Schema name to analyze (defaults to public schema)"
+      }
+    ]
+  }
+]
+


### PR DESCRIPTION
## Description
Adds database-mcp server to the Docker MCP Registry.

## Features
- Multi-database support (PostgreSQL, MySQL, SQLite, Snowflake)
- 18 comprehensive database tools including:
  - Query execution and analysis
  - Schema introspection
  - CSV export
  - PostgreSQL-specific advanced tools
- Comprehensive database introspection capabilities

## Repository
- GitHub: https://github.com/nitaiaharoni1/database-mcp
- npm: https://www.npmjs.com/package/database-mcp

## Testing
- ✅ Dockerfile created and tested locally
- ✅ tools.json includes all 18 tools
- ✅ Server configuration validated