### PR TITLE
Add mcp-audio-rag: Semantic search over audio transcriptions

### DIFF
--- a/servers/mcp-audio-rag/readme.md
+++ b/servers/mcp-audio-rag/readme.md
@@ -1,0 +1,1 @@
+https://github.com/matheusslg/mcp-audio-rag

--- a/servers/mcp-audio-rag/server.yaml
+++ b/servers/mcp-audio-rag/server.yaml
@@ -1,0 +1,52 @@
+name: mcp-audio-rag
+image: mcp/mcp-audio-rag
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - rag
+    - audio
+    - transcription
+    - semantic-search
+    - gemini
+    - supabase
+    - vector-database
+about:
+  title: Audio RAG
+  description: |
+    Semantic search over audio transcriptions using Google Gemini and Supabase pgvector.
+
+    Features:
+    • Transcribe audio files (mp3, m4a, wav, webm, etc.)
+    • Semantic search through transcriptions
+    • AI-generated summaries of audio content
+    • Full transcript retrieval
+    • Multiple Gemini model support
+
+    Perfect for podcasts, meetings, lectures, and any audio content you want to search through.
+  icon: https://avatars.githubusercontent.com/u/17099918
+source:
+  project: https://github.com/matheusslg/mcp-audio-rag
+  commit: 6b5c70681fe6c3322c921903162d33ca56e82360
+config:
+  description: Configure Gemini API and Supabase connection
+  secrets:
+    - name: mcp-audio-rag.gemini_api_key
+      env: GEMINI_API_KEY
+      example: AIzaSy...
+    - name: mcp-audio-rag.supabase_service_key
+      env: SUPABASE_SERVICE_KEY
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+  env:
+    - name: SUPABASE_URL
+      example: https://your-project.supabase.co
+      value: "{{mcp-audio-rag.supabase_url}}"
+  parameters:
+    type: object
+    properties:
+      supabase_url:
+        type: string
+        description: Your Supabase project URL
+    required:
+      - supabase_url

--- a/servers/mcp-audio-rag/tools.json
+++ b/servers/mcp-audio-rag/tools.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "ingest_audio",
+    "description": "Transcribe an audio file and store it in the knowledge base for later searching.",
+    "arguments": [
+      {
+        "name": "file_path",
+        "type": "string",
+        "desc": "Absolute path to the audio file to transcribe"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Gemini model to use for transcription (optional)"
+      }
+    ]
+  },
+  {
+    "name": "search_transcripts",
+    "description": "Search through audio transcriptions to find specific topics or quotes.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "The topic or question to search for in the audio logs"
+      },
+      {
+        "name": "match_count",
+        "type": "number",
+        "desc": "Number of results to return (default 5)"
+      }
+    ]
+  },
+  {
+    "name": "list_transcripts",
+    "description": "List all audio files that have been transcribed and stored in the knowledge base.",
+    "arguments": []
+  },
+  {
+    "name": "get_full_transcript",
+    "description": "Get the complete transcript text for a specific audio file.",
+    "arguments": [
+      {
+        "name": "source_file",
+        "type": "string",
+        "desc": "Name of the audio file (e.g., 'meeting.mp3')"
+      }
+    ]
+  },
+  {
+    "name": "summarize_audio",
+    "description": "Generate an AI summary of a transcribed audio file.",
+    "arguments": [
+      {
+        "name": "source_file",
+        "type": "string",
+        "desc": "Name of the audio file to summarize (e.g., 'meeting.mp3')"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Gemini model to use (optional)"
+      }
+    ]
+  },
+  {
+    "name": "delete_transcript",
+    "description": "Delete all stored data for a specific audio file from the knowledge base.",
+    "arguments": [
+      {
+        "name": "source_file",
+        "type": "string",
+        "desc": "Name of the audio file to delete (e.g., 'meeting.mp3')"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Adds **mcp-audio-rag**, an MCP server for semantic search over audio transcriptions using Google Gemini and Supabase pgvector.

## Features

- **ingest_audio**: Transcribe audio files and store in vector database
- **search_transcripts**: Semantic search through transcriptions
- **summarize_audio**: AI-generated summaries of audio content
- **get_full_transcript**: Retrieve complete transcript text
- **list_transcripts**: List all transcribed audio files
- **delete_transcript**: Remove transcribed files from database

## Supported Audio Formats

`.mp3` `.mp4` `.m4a` `.wav` `.webm` `.mpeg` `.mpga`

## Configuration

- `GEMINI_API_KEY` (secret): Google Gemini API key for transcription and embeddings
- `SUPABASE_SERVICE_KEY` (secret): Supabase service role key
- `SUPABASE_URL` (env): Supabase project URL

## Links

- Source: https://github.com/matheusslg/mcp-audio-rag
- License: MIT

## Checklist

- [x] Dockerfile included
- [x] tools.json included
- [x] readme.md included
- [x] MIT License