### PR TITLE
Add kenshi-fcs server for Kenshi game modding

### DIFF
--- a/servers/kenshi-fcs/server.yaml
+++ b/servers/kenshi-fcs/server.yaml
@@ -1,0 +1,68 @@
+name: kenshi-fcs
+image: mcp/kenshi-fcs
+type: server
+meta:
+  category: gaming
+  tags:
+    - kenshi
+    - modding
+    - game-development
+    - fcs
+about:
+  title: Kenshi FCS Server
+  description: MCP server for Kenshi game modding - query, modify, and validate mods programmatically using the Forgotten Construction Set (FCS) SDK
+  icon: https://www.google.com/s2/favicons?domain=lofigames.com&sz=64
+source:
+  project: https://github.com/Cabbage125/kenshi-mod-workspace
+  commit: 882951e
+  directory: .claude/mcp-servers/kenshi-fcs-server
+run:
+  volumes:
+    - "{{kenshi-fcs.kenshi_path|volume|into}}"
+    - "{{kenshi-fcs.workshop_path|volume|into}}"
+    - "{{kenshi-fcs.data_path|volume|into}}"
+config:
+  description: Configure Kenshi installation paths and data directories
+  parameters:
+    type: object
+    properties:
+      kenshi_path:
+        type: string
+        description: "Path to Kenshi game installation directory (contains data/ and mods/ folders)"
+        default: "/kenshi"
+      workshop_path:
+        type: string
+        description: "Path to Steam Workshop content directory"
+        default: "/workshop"
+      data_path:
+        type: string
+        description: "Persistent data storage for backups, logs, and database"
+        default: "/data"
+      backup_dir:
+        type: string
+        description: "Directory for mod backups (relative to data_path)"
+        default: "backups"
+      database_path:
+        type: string
+        description: "Path to SQLite database (relative to data_path or absolute)"
+        default: "kenshi_data.db"
+      verbose:
+        type: string
+        description: "Enable verbose logging (1 or 0)"
+        default: "0"
+    required:
+      - kenshi_path
+      - data_path
+  env:
+    - name: KENSHI_PATH
+      value: "{{kenshi-fcs.kenshi_path}}"
+    - name: WORKSHOP_PATH
+      value: "{{kenshi-fcs.workshop_path}}"
+    - name: FCS_BACKUP_DIR
+      value: "{{kenshi-fcs.data_path}}/{{kenshi-fcs.backup_dir}}"
+    - name: FCS_LOG_DIR
+      value: "{{kenshi-fcs.data_path}}/logs"
+    - name: FCS_DATABASE_PATH
+      value: "{{kenshi-fcs.data_path}}/{{kenshi-fcs.database_path}}"
+    - name: FCS_SERVER_VERBOSE
+      value: "{{kenshi-fcs.verbose}}"


### PR DESCRIPTION
## Summary

This PR adds the **kenshi-fcs** MCP server to the registry, enabling programmatic modding for the game Kenshi using the Forgotten Construction Set (FCS) SDK.

## Server Details

- **Category**: Gaming
- **Tags**: kenshi, modding, game-development, fcs
- **Source**: https://github.com/Cabbage125/kenshi-mod-workspace
- **Directory**: .claude/mcp-servers/kenshi-fcs-server

## Capabilities

The kenshi-fcs server provides 23 specialized tools for Kenshi mod development:

### Core Features
- **Database Operations**: Search, query, and analyze 200K+ game items from 800+ mods using indexed SQLite database
- **Mod Management**: Create, merge, validate, and cleanup mods with automatic backups
- **Race Modifications**: Unlock armor restrictions, modify stats, and customize game starts
- **AI Package Creation**: Build production worker AI with scheduled goals for Living Economies mods
- **Conflict Resolution**: Detect and resolve load order conflicts with dependency analysis
- **Item Modification**: Modify weapons, armor, buildings, characters, and other game entities
- **Workshop Integration**: Map and manage Steam Workshop mods

### Key Tools
- `fcs_create_patch` - Create compatibility patches for armor unlocks and stat modifications
- `fcs_create_ai_package` - Build AI packages with production tasks (FILL_MACHINE, COLLECT_OUTPUT_RESOURCE, etc.)
- `fcs_merge_mods` - Merge multiple mods with conflict resolution
- `db_search_items` - Fast indexed search across all items (<100ms)
- `sql_query` - Direct SQL analytics on game database
- `fcs_validate_load_order` - Ensure correct mod loading sequence
- `db_find_conflicts` - Identify breaking conflicts between mods

## Configuration

The server requires three volume mounts:
1. **kenshi_path**: Kenshi game installation directory (contains data/ and mods/)
2. **workshop_path**: Steam Workshop content directory
3. **data_path**: Persistent storage for backups, logs, and database

Environment variables are automatically configured from user parameters.

## License

MIT License - The kenshi-fcs server is open source and freely consumable.

## Testing

This server has been tested locally with:
- 800+ mod installation (767 active mods in load order)
- Living Economies mod creation workflow
- Megamod consolidation operations
- Load order validation with KCF Compatibility Framework

## Implementation Notes

- Uses OpenConstructionSet SDK (C#/.NET) for native Kenshi .mod file I/O
- SQLite database with indexed item data for fast queries
- Automatic backup creation before destructive operations
- Load order validation against 5 critical rules (patches last, dependencies satisfied, etc.)

## Checklist

- [x] Fork and clone docker/mcp-registry
- [x] Add server.yaml in servers/kenshi-fcs/
- [x] Ensure license allows consumption (MIT)
- [x] Test locally with Docker Desktop MCP Toolkit
- [ ] CI passes
- [ ] Docker team review

---

This submission enables AI-assisted Kenshi modding workflows, allowing users to automate tedious FCS operations, resolve conflicts, and build complex production systems like Living Economies.