### PR TITLE
Add support for Github Enterprise Servers

### DIFF
--- a/servers/github-enterprise/server.yaml
+++ b/servers/github-enterprise/server.yaml
@@ -1,0 +1,34 @@
+name: github-enterprise
+image: ghcr.io/github/github-mcp-server
+type: server
+meta:
+  category: devops
+  tags:
+    - github
+    - devops
+about:
+  title: GitHub Enterprise
+  description: GitHub Enterprise Configuration for the Official GitHub MCP Server, by GitHub. Provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
+  icon: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+source:
+  project: https://github.com/github/github-mcp-server
+  commit: 23fa0dd1a821d1346c1de2abafe7327d26981606
+run:
+config:
+  description: Configuration for the GitHub Enterprise Server
+  secrets:
+    - name: github-enterprise.personal_access_token
+      env: GITHUB_PERSONAL_ACCESS_TOKEN
+      example: <YOUR_TOKEN>
+  env:
+    - name: GITHUB_HOST
+      example: 'https://<your GHES or ghe.com domain name>'
+      value: "{{github-enterprise.host}}"
+  parameters:
+    type: object
+    properties:
+      host:
+        type: string
+        description: GitHub Enterprise Server URL (e.g. https://ghe.yourdomain.com)
+    required:
+      - host


### PR DESCRIPTION
This PR adds a configuration for Github Enterprise servers. This duplicates the https://github.com/docker/mcp-registry/blob/main/servers/github-official/server.yaml configuration.
It would be better to reuse that configuration instead of duplicating it but there are several issues with that approach:

1. https://github.com/docker/mcp-registry/blob/7cb42c1d2632a8750da847aa3e3e5925c8ba29fc/servers/github-official/server.yaml#L17-L20 would need to be extended by `"{{github-official.host}}:*"`
2. But in the environment variable `GITHUB_HOST` you need the full url: `https://YOURSUBDOMAIN.ghe.co`. So you would need to hardcode `https`. Because if you add another parameter for the scheme, then you need to ensure that `GITHUB_HOST` stays empty by default, therefore mandating the format `value: "{{github-enterprise.scheme}}{{github-enterprise.host}}"` which is not ideal.
3. Another issue is that you then can´t have one MCP server for `github.com` and another one for your enterprise instance

Resolves #162