### PR TITLE
Add Mimer SQL MCP server

### DIFF
--- a/servers/mimersql/server.yaml
+++ b/servers/mimersql/server.yaml
@@ -1,0 +1,84 @@
+name: mimersql
+image: mcp/mimersql
+type: server
+meta:
+  category: database
+  tags:
+    - database
+    - mimersql
+about:
+  title: Mimer SQL
+  icon: https://www.google.com/s2/favicons?domain=mimer.com&sz=64
+  description: Integrate Mimer SQL database connectivity into AI applications
+source:
+  project: https://github.com/mimersql/mimer-mcp
+  commit: b6959af85d8648a3b89dbfbe23ef1a6e84f2aaf8
+config:
+  description: Configure the connection to Mimer SQL
+  secrets:
+    - name: mimersql.DB_PASSWORD
+      env: DB_PASSWORD
+      example: <DB_PASSWORD>
+  env:
+    - name: DB_DSN
+      example: mimerdb
+      value: "{{mimersql.db_dsn}}"
+    - name: DB_USER
+      example: MIMER_STORE
+      value: "{{mimersql.db_user}}"
+    - name: DB_HOST
+      example: host.docker.internal
+      value: "{{mimersql.db_host}}"
+    - name: DB_PORT
+      example: "1360"
+      value: "{{mimersql.db_port}}"
+    - name: DB_PROTOCOL
+      example: tcp
+      value: "{{mimersql.db_protocol}}"
+    - name: DB_POOL_INITIAL_CON
+      example: "0"
+      value: "{{mimersql.db_pool_initial_con}}"
+    - name: DB_POOL_MAX_UNUSED
+      example: "0"
+      value: "{{mimersql.db_pool_max_unused}}"
+    - name: DB_POOL_MAX_CON
+      example: "0"
+      value: "{{mimersql.db_pool_max_con}}"
+    - name: DB_POOL_BLOCK
+      example: "true"
+      value: "{{mimersql.db_pool_block}}"
+    - name: DB_POOL_DEEP_HEALTH_CHECK
+      example: "false"
+      value: "{{mimersql.db_pool_deep_health_check}}"
+    - name: MCP_LOG_LEVEL
+      example: INFO
+      value: "{{mimersql.mcp_log_level}}"
+  parameters:
+    type: object
+    properties:
+      dbdsn:
+        type: string
+      dbuser:
+        type: string
+      dbhost:
+        type: string
+      dbport:
+        type: integer
+      dbprotocol:
+        type: string
+      dbpoolinitialcon:
+        type: integer
+      dbpoolmaxunused:
+        type: integer
+      dbpoolmaxcon:
+        type: integer
+      dbpoolblock:
+        type: boolean
+      dbpooldeephealthcheck:
+        type: boolean
+      mcploglevel:
+        type: string
+    required:
+      - dbdsn
+      - dbuser
+      - dbhost

--- a/servers/mimersql/tools.json
+++ b/servers/mimersql/tools.json
@@ -1,0 +1,113 @@
+[
+  {
+    "name": "list_schemas",
+    "description": "List all available schemas in the database",
+    "arguments": []
+  },
+  {
+    "name": "list_table_names",
+    "description": "List table names from the specified schema",
+    "arguments": [
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema name to filter tables"
+      }
+    ]
+  },
+  {
+    "name": "get_table_info",
+    "description": "Get detailed table schemas and sample rows",
+    "arguments": [
+      {
+        "name": "table_names",
+        "type": "array",
+        "desc": "Names of the tables"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Schema name"
+      },
+      {
+        "name": "sample_size",
+        "type": "number",
+        "desc": "Number of sample rows to include (default: 3)"
+      }
+    ]
+  },
+  {
+    "name": "execute_query",
+    "description": "Execute a SQL SELECT query and return the results as a list of dictionaries",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "SQL query to execute"
+      },
+      {
+        "name": "params",
+        "type": "array",
+        "desc": "Parameters for the SQL query (default: [])"
+      }
+    ]
+  },
+  {
+    "name": "list_stored_procedures",
+    "description": "List all stored procedures in the database",
+    "arguments": []
+  },
+  {
+    "name": "get_stored_procedure_definition",
+    "description": "Get the definition of a stored procedure",
+    "arguments": [
+      {
+        "name": "procedure_schema",
+        "type": "string",
+        "desc": "Schema name of the stored procedure"
+      },
+      {
+        "name": "procedure_name",
+        "type": "string",
+        "desc": "Name of the stored procedure"
+      }
+    ]
+  },
+  {
+    "name": "get_stored_procedure_parameters",
+    "description": "Get the parameters of a stored procedure",
+    "arguments": [
+      {
+        "name": "procedure_schema",
+        "type": "string",
+        "desc": "Schema name of the stored procedure"
+      },
+      {
+        "name": "procedure_name",
+        "type": "string",
+        "desc": "Name of the stored procedure"
+      }
+    ]
+  },
+  {
+    "name": "execute_stored_procedure",
+    "description": "Execute a stored procedure in the database. Call this tool with the appropriate stored procedure name and parameters based on what procedures are available (use list_stored_procedures first if unsure).",
+    "arguments": [
+      {
+        "name": "procedure_schema",
+        "type": "string",
+        "desc": "Schema name of the stored procedure"
+      },
+      {
+        "name": "procedure_name",
+        "type": "string",
+        "desc": "Name of the stored procedure"
+      },
+      {
+        "name": "parameters",
+        "type": "string",
+        "desc": "JSON string of parameters for the stored procedure mapping parameter names to values"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Mimer SQL
**Repository URL:**  https://github.com/mimersql/mimer-mcp
**Brief Description:** Integrate Mimer SQL database connectivity into AI applications

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mimersql`
- [x] I have built the MCP Server using `task build -- --tools mimersql`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)