### PR TITLE
Add Mackerel MCP Server

### DIFF
--- a/servers/mackerel/server.yaml
+++ b/servers/mackerel/server.yaml
@@ -1,0 +1,20 @@
+name: mackerel
+image: ghcr.io/mackerelio-labs/mcp-server
+type: server
+meta:
+  category: monitoring
+  tags:
+    - monitoring
+about:
+  title: Mackerel
+  description: Official Mackerel MCP Server. Interact with Mackerel over the Mackerel API. Retrieve metrics, traces, alerts and more.
+  icon: https://mackerel.io/assets/images/common/favicons/app-256.png
+source:
+  project: https://github.com/mackerelio-labs/mcp-server
+  commit: 0735a42a0d6443cdf69dbfb95fce23b9b98c3175
+config:
+  description: Configure the connection to Mackerel
+  secrets:
+    - name: mackerel.apikey
+      env: MACKEREL_APIKEY
+      example: <MACKEREL_APIKEY>


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Mackerel MCP Server"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** Mackerel MCP Server
**Repository URL:** https://github.com/mackerelio-labs/mcp-server
**Brief Description:** Official Mackerel MCP Server. Interact with Mackerel over the [Mackerel API](https://mackerel.io/api-docs/) . Retrieve metrics, traces, alerts and more.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commit was created on Nov 28, 2025
- [x] **Docker Artifact**: ghcr.io/mackerelio-labs/mcp-server
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mackerel`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
  - We use ghcr.io, so I confirmed by this command `task build -- --tools --pull-community mackerel`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
