### PR TITLE
Update javadocs MCP server icon to use Oracle docs favicon

### DIFF
--- a/servers/javadocs/server.yaml
+++ b/servers/javadocs/server.yaml
@@ -10,7 +10,7 @@ meta:
 about:
   title: Javadocs
   description: Access to Java, Kotlin, and Scala library documentation.
-  icon: https://www.google.com/s2/favicons?domain=javadocs.dev&sz=64
+  icon: https://www.google.com/s2/favicons?domain=docs.oracle.com&sz=64
 remote:
   transport_type: streamable-http
   url: https://www.javadocs.dev/mcp


### PR DESCRIPTION
## Summary

Updates the Javadocs MCP server icon from javadocs.dev favicon to the official Oracle Java documentation favicon.

## Changes

- Changed icon URL from `https://www.google.com/s2/favicons?domain=javadocs.dev&sz=64` to `https://www.google.com/s2/favicons?domain=docs.oracle.com&sz=64`

## Benefits

- Uses the more authoritative Oracle Java documentation icon
- Better represents the official source of Java documentation
- More recognizable to Java developers

## Testing

- [x] Validated the new icon URL resolves correctly
- [x] Server entry follows registry conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)