### PR TITLE
Update mcp-python-refactoring description and icon

### DIFF
--- a/servers/mcp-python-refactoring/server.yaml
+++ b/servers/mcp-python-refactoring/server.yaml
@@ -16,19 +16,7 @@ about:
   title: Python Refactoring Assistant
   description: |
     Educational Python refactoring assistant that provides guided suggestions for AI assistants.
-
-    Features:
-    • Step-by-step refactoring instructions without modifying code
-    • Comprehensive code analysis using professional tools (Rope, Radon, Vulture, Jedi, LibCST, Pyrefly)
-    • Educational approach teaching refactoring patterns through guided practice
-    • Support for both guide-only and apply-changes modes
-    • Identifies long functions, high complexity, dead code, and type issues
-    • Provides precise line numbers and specific refactoring instructions
-    • Compatible with all AI assistants (Claude, GPT, Cursor, Continue, etc.)
-
-    Perfect for developers learning refactoring patterns while maintaining full control over code changes.
-    Acts as a refactoring mentor rather than an automated code modifier.
-  icon: https://avatars.githubusercontent.com/u/2664231?s=200&v=4
+  icon: https://www.google.com/s2/favicons?domain=python.org&sz=64
 source:
   project: https://github.com/slamer59/mcp-python-refactoring
   commit: b66781d58674cd066e4ed8786215ab44ecc0b14b


### PR DESCRIPTION
## Summary

Updates the mcp-python-refactoring server metadata with a cleaner, more concise description and official Python icon.

## Changes

### Description
- Simplified from verbose multi-paragraph description with bullet points to a single concise line
- Maintains the core value proposition: "Educational Python refactoring assistant that provides guided suggestions for AI assistants"
- Removed detailed feature list that's better suited for the project's README

### Icon
- Changed from `https://avatars.githubusercontent.com/u/2664231?s=200&v=4` (GitHub avatar)
- To `https://www.google.com/s2/favicons?domain=python.org&sz=64` (Official Python.org favicon)

## Benefits

- **Cleaner catalog presentation**: Concise descriptions are easier to scan in the MCP catalog
- **Better icon**: Official Python icon is more recognizable and appropriate for a Python-focused tool
- **Consistency**: Aligns with best practices for server catalog entries
- **Focus**: Users interested in details can visit the project repository

## Testing

- [x] Validated the new icon URL resolves correctly
- [x] Server entry follows registry conventions
- [x] Description accurately represents the server's purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)