### PR TITLE
Add GitLab Documentation MCP Server

### DIFF
--- a/servers/gitlab-docs/readme.md
+++ b/servers/gitlab-docs/readme.md
@@ -1,0 +1,22 @@
+# GitLab Documentation MCP Server
+
+Search and browse GitLab's official documentation with 2,494+ pages covering CI/CD, API, administration, development, security, and operations.
+
+## Documentation
+
+For detailed documentation, installation instructions, and usage examples, visit:
+
+https://github.com/ozanmutlu/Gitlab-Docs-MCP/blob/master/README.md
+
+## Available Tools
+
+- **searchGitLabDocs**: Search across 2,494+ GitLab documentation pages with intelligent ranking
+- **getDocPage**: Retrieve complete content of specific documentation pages
+- **listDocSections**: Browse available documentation sections and structure
+
+## Features
+
+- Pre-built documentation index for fast searches
+- No authentication required
+- Covers all major GitLab topics: CI/CD, API, administration, development, security, operations, and integrations
+- Compatible with GitHub Copilot, Claude Desktop, Docker Desktop, and other MCP clients

--- a/servers/gitlab-docs/server.yaml
+++ b/servers/gitlab-docs/server.yaml
@@ -1,0 +1,19 @@
+name: gitlab-docs
+image: mcp/gitlab-docs
+type: server
+meta:
+  category: documentation
+  tags:
+    - documentation
+    - gitlab
+    - search
+    - ai-assistant
+    - mcp
+about:
+  title: GitLab Documentation
+  description: Search and browse GitLab's official documentation with 2,494+ pages covering CI/CD, API, administration, development, security, and operations
+  icon: https://about.gitlab.com/images/press/logo/png/gitlab-icon-rgb.png
+source:
+  project: https://github.com/ozanmutlu/Gitlab-Docs-MCP
+  branch: master
+  commit: 8c8d40e15d0e2c7c4211885df198cc271cc624eb

--- a/servers/gitlab-docs/tools.json
+++ b/servers/gitlab-docs/tools.json
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "searchGitLabDocs",
+    "description": "Search across GitLab's official documentation with intelligent ranking. Covers 2,494+ pages including CI/CD, API, administration, development, security, and operations.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Search query to find relevant GitLab documentation"
+      },
+      {
+        "name": "maxResults",
+        "type": "number",
+        "desc": "Maximum number of results to return (default: 10, max: 50)"
+      },
+      {
+        "name": "section",
+        "type": "string",
+        "desc": "Filter by documentation section: ci, api, user, admin, development, security, operations, integrations"
+      }
+    ]
+  },
+  {
+    "name": "getDocPage",
+    "description": "Retrieve the complete content of a specific GitLab documentation page including detailed configuration examples, code snippets, and step-by-step guides",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Document path (e.g., 'ci/yaml/README.md')"
+      }
+    ]
+  },
+  {
+    "name": "listDocSections",
+    "description": "Browse available GitLab documentation sections and their hierarchical structure",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
- Category: documentation
- Provides search across 2,494+ GitLab documentation pages
- Covers CI/CD, API, administration, development, security, and operations
- No authentication required
- Includes pre-built documentation index for fast searches
- Compatible with GitHub Copilot, Claude Desktop, and other MCP clients

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
