### PR TITLE
Add Todoist MCP Server

### DIFF
--- a/servers/todoist-mcp/server.yaml
+++ b/servers/todoist-mcp/server.yaml
@@ -1,0 +1,24 @@
+name: todoist-mcp
+image: mcp/todoist-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - task-management
+    - todoist
+    - project-management
+about:
+  title: Todoist
+  description: Complete CRUD operations for Todoist tasks, projects, comments, and labels
+  icon: https://www.google.com/s2/favicons?domain=todoist.com&sz=64
+source:
+  project: https://github.com/strangetoucan/mcp-todoist-mcp
+  branch: main
+  commit: b71a8cafc0dc2f448e534f5b1336c356da368bdc
+config:
+  description: Configure the connection to Todoist
+  secrets:
+    - name: todoist-mcp.api_token
+      env: TODOIST_API_TOKEN
+      example: <YOUR_TODOIST_API_TOKEN>


### PR DESCRIPTION
This commit adds the Todoist MCP server to the registry, providing complete CRUD operations for Todoist tasks, projects, comments, and labels.

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Todoist MCP"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** Todoist MCP
**Repository URL:** https://github.com/strangetoucan/mcp-todoist-mcp.git
**Brief Description:** Automates CRUD Operations for Todoist for projects, tasks and comments

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [x] If the server requires credentials to test it, I have shared the instructions to obtain it for free
