### PR TITLE
Add wannaflow-tools MCP server

### DIFF
--- a/servers/wannaflow-tools/server.yaml
+++ b/servers/wannaflow-tools/server.yaml
@@ -1,0 +1,61 @@
+name: wannaflow-tools
+image: wannacrea/mcp-tools
+type: server
+meta:
+  category: development
+  tags:
+    - testing
+    - typescript
+    - validation
+    - memory
+    - cost-optimization
+    - development
+    - ai-tools
+    - token-savings
+about:
+  title: WannaFlow Tools
+  description: |
+    Standalone MCP tools for AI-assisted development workflows. Optimized for token efficiency with zero external dependencies.
+
+    **Tools included:**
+
+    • **auto_test** - Automated testing and validation for TypeScript/JavaScript
+      - Actions: run (jest/vitest/mocha), validate (type-check), full (lint + tests)
+      - Auto-detects test framework
+      - Returns structured results with file:line references
+
+    • **project_memory** - Persistent context storage between sessions
+      - Categories: decision, pattern, issue, context, preference
+      - SQLite-based persistence (no external DB required)
+      - Token savings: 30-50% by avoiding repetitive explanations
+
+    • **cost_analyzer** - Token cost prediction and optimization
+      - Actions: predict, compare, budget_check, optimize
+      - Supports 19+ models (local, deepseek, gemini, claude, gpt-4)
+      - All calculations local - no API required
+
+    Perfect for developers who want to optimize their AI-assisted workflow costs and maintain context between sessions.
+  icon: https://avatars.githubusercontent.com/u/wannacrea
+source:
+  project: https://github.com/wannacrea/mcp-tools
+run:
+  volumes:
+    - "{{wannaflow-tools.workspace_path}}:/workspace"
+    - "wannaflow-mcp-data:/data"
+config:
+  description: Configure workspace path and persistent storage for WannaFlow MCP Tools
+  env:
+    - name: WORKSPACE_PATH
+      example: /workspace
+      value: "/workspace"
+    - name: MCP_DATA_DIR
+      example: /data
+      value: "/data"
+  parameters:
+    type: object
+    properties:
+      workspace_path:
+        type: string
+        description: Path to your project workspace to analyze and test
+        default: /workspace
+    required: []


### PR DESCRIPTION
Standalone MCP tools for AI-assisted development workflows:
- auto_test: Automated testing and validation (jest/vitest/mocha)
- project_memory: Persistent context storage (SQLite-based)
- cost_analyzer: Token cost prediction for 19+ models

Docker image: wannacrea/mcp-tools
Token savings: 30-95% depending on tool usage

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
