### PR TITLE
fix: Revert persistent volumes for Desktop Commander

### DIFF
--- a/servers/desktop-commander/server.yaml
+++ b/servers/desktop-commander/server.yaml
@@ -25,10 +25,6 @@ source:
 run:
   volumes:
     - "{{desktop-commander.paths|volume|into}}"
-    - dc-system:/usr
-    - dc-home:/root
-    - dc-workspace:/workspace
-    - dc-packages:/var
 config:
   description: Configure filesystem access and network permissions for Desktop Commander
   parameters:


### PR DESCRIPTION
This reverts the persistent named volumes added in [#872](https://github.com/docker/mcp-registry/pull/872).

### What happened

The volumes (`dc-system:/usr`, `dc-home:/root`, `dc-workspace:/workspace`, `dc-packages:/var`) are being mounted as read-only by the MCP runtime, which completely breaks Desktop Commander - it can't even write its config file on startup.

### Technical details

The runtime appends `:ro` to all non-templated volumes:
```
dc-home:/root → -v dc-home:/root:ro
```

Even explicitly specifying `:rw` doesn't help - it becomes `:rw:ro`:
```
-v dc-home:/root:rw:ro
```

User-configured volumes using template syntax (`{{desktop-commander.paths|volume|into}}`) stay writable, but hardcoded named volumes get forced read-only.

### Error
```
EROFS: read-only file system, open '/root/.claude-server-commander/config.json'
```

### This PR

- Removes the 4 persistent volumes that break things
- Keeps the icon URL update from #872
- This allows Desktop Commander MCP to work but loose work on docker restarts, its better then completely broken state now

### Next steps
Figure out how to allow persistent volumes that are not read only

---

CC @xenoscopic 