### PR TITLE
Add mysql-mcp: Enterprise MySQL MCP Server

### DIFF
--- a/servers/mysql-mcp/readme.md
+++ b/servers/mysql-mcp/readme.md
@@ -1,0 +1,1 @@
+For documentation, visit [mysql-mcp GitHub Wiki](https://github.com/neverinfamous/mysql-mcp/wiki).

--- a/servers/mysql-mcp/server.yaml
+++ b/servers/mysql-mcp/server.yaml
@@ -1,0 +1,41 @@
+name: mysql-mcp
+image: mcp/mysql-mcp
+type: server
+meta:
+  category: database
+  tags:
+    - mysql
+    - database
+    - sql
+about:
+  title: MySQL MCP Server
+  description: Enterprise-grade MySQL MCP Server with 106 specialized tools for database operations, JSON, text search, performance analysis, replication, and administration.
+  icon: https://avatars.githubusercontent.com/u/2452804?s=200&v=4
+source:
+  project: https://github.com/neverinfamous/mysql-mcp
+  branch: main
+  commit: c76e40070e7d65cb2fe97126bc5bfaa62d589f73
+run:
+  command:
+    - --transport
+    - stdio
+    - --mysql
+    - $MYSQL_URL
+config:
+  description: Configure MySQL database connection
+  secrets:
+    - name: mysql-mcp.mysql_url
+      env: MYSQL_URL
+      example: mysql://user:password@host.docker.internal:3306/database
+      description: MySQL connection URL (use host.docker.internal for local MySQL)
+  env:
+    - name: MYSQL_POOL_SIZE
+      example: "10"
+      value: "{{mysql-mcp.pool_size}}"
+  parameters:
+    type: object
+    properties:
+      pool_size:
+        type: string
+        description: Connection pool size (default 10)
+        

--- a/servers/mysql-mcp/tools.json
+++ b/servers/mysql-mcp/tools.json
@@ -1,0 +1,426 @@
+[
+    {
+        "name": "mysql_read_query",
+        "description": "Execute a read-only SQL query (SELECT). Uses prepared statements for safety."
+    },
+    {
+        "name": "mysql_write_query",
+        "description": "Execute a write SQL query (INSERT, UPDATE, DELETE). Uses prepared statements for safety."
+    },
+    {
+        "name": "mysql_list_tables",
+        "description": "List all tables and views in the database with metadata."
+    },
+    {
+        "name": "mysql_describe_table",
+        "description": "Get detailed information about a table's structure including columns, types, and constraints."
+    },
+    {
+        "name": "mysql_create_table",
+        "description": "Create a new table with specified columns, engine, and charset."
+    },
+    {
+        "name": "mysql_drop_table",
+        "description": "Drop (delete) a table from the database."
+    },
+    {
+        "name": "mysql_get_indexes",
+        "description": "Get all indexes for a table including type, columns, and cardinality."
+    },
+    {
+        "name": "mysql_create_index",
+        "description": "Create an index on a table. Supports BTREE, HASH, FULLTEXT, and SPATIAL index types."
+    },
+    {
+        "name": "mysql_transaction_begin",
+        "description": "Start a new database transaction."
+    },
+    {
+        "name": "mysql_transaction_commit",
+        "description": "Commit the current transaction."
+    },
+    {
+        "name": "mysql_transaction_rollback",
+        "description": "Rollback the current transaction."
+    },
+    {
+        "name": "mysql_transaction_savepoint",
+        "description": "Create a savepoint within the current transaction."
+    },
+    {
+        "name": "mysql_transaction_release",
+        "description": "Release a savepoint within the current transaction."
+    },
+    {
+        "name": "mysql_transaction_rollback_to",
+        "description": "Rollback to a savepoint within the current transaction."
+    },
+    {
+        "name": "mysql_transaction_execute",
+        "description": "Execute a callback within a transaction with automatic commit/rollback."
+    },
+    {
+        "name": "mysql_json_get",
+        "description": "Extract a JSON value from a column using JSONPath."
+    },
+    {
+        "name": "mysql_json_set",
+        "description": "Set a value at a JSONPath in a JSON column."
+    },
+    {
+        "name": "mysql_json_insert",
+        "description": "Insert a value at a JSONPath if it doesn't exist."
+    },
+    {
+        "name": "mysql_json_replace",
+        "description": "Replace a value at a JSONPath if it exists."
+    },
+    {
+        "name": "mysql_json_remove",
+        "description": "Remove a value at a JSONPath from a JSON column."
+    },
+    {
+        "name": "mysql_json_contains",
+        "description": "Check if a JSON column contains a value."
+    },
+    {
+        "name": "mysql_json_search",
+        "description": "Search for a value in a JSON column."
+    },
+    {
+        "name": "mysql_json_keys",
+        "description": "Get all keys from a JSON object."
+    },
+    {
+        "name": "mysql_json_array_append",
+        "description": "Append a value to a JSON array."
+    },
+    {
+        "name": "mysql_json_update",
+        "description": "Update a JSON column with new values."
+    },
+    {
+        "name": "mysql_json_extract",
+        "description": "Extract multiple values from a JSON column."
+    },
+    {
+        "name": "mysql_json_validate",
+        "description": "Validate if a string is valid JSON."
+    },
+    {
+        "name": "mysql_regexp_match",
+        "description": "Find rows matching a regular expression pattern."
+    },
+    {
+        "name": "mysql_like_search",
+        "description": "Find rows matching a LIKE pattern with wildcards."
+    },
+    {
+        "name": "mysql_soundex",
+        "description": "Find rows matching phonetically using SOUNDEX."
+    },
+    {
+        "name": "mysql_substring",
+        "description": "Extract a substring from a column."
+    },
+    {
+        "name": "mysql_concat",
+        "description": "Concatenate multiple columns or values."
+    },
+    {
+        "name": "mysql_collation_convert",
+        "description": "Convert a column to a different collation."
+    },
+    {
+        "name": "mysql_fulltext_create",
+        "description": "Create a FULLTEXT index on text columns."
+    },
+    {
+        "name": "mysql_fulltext_search",
+        "description": "Search using FULLTEXT index with natural language mode."
+    },
+    {
+        "name": "mysql_fulltext_boolean",
+        "description": "Search using FULLTEXT index with boolean mode."
+    },
+    {
+        "name": "mysql_fulltext_expand",
+        "description": "Search using FULLTEXT index with query expansion."
+    },
+    {
+        "name": "mysql_explain",
+        "description": "Get the execution plan for a query."
+    },
+    {
+        "name": "mysql_explain_analyze",
+        "description": "Get the execution plan with actual execution statistics."
+    },
+    {
+        "name": "mysql_slow_queries",
+        "description": "Get slow query log entries."
+    },
+    {
+        "name": "mysql_query_stats",
+        "description": "Get query performance statistics from performance_schema."
+    },
+    {
+        "name": "mysql_optimizer_trace",
+        "description": "Get the optimizer trace for a query."
+    },
+    {
+        "name": "mysql_table_stats",
+        "description": "Get table statistics including row count and size."
+    },
+    {
+        "name": "mysql_index_usage",
+        "description": "Get index usage statistics."
+    },
+    {
+        "name": "mysql_buffer_pool_stats",
+        "description": "Get InnoDB buffer pool statistics."
+    },
+    {
+        "name": "mysql_force_index",
+        "description": "Execute a query forcing use of a specific index."
+    },
+    {
+        "name": "mysql_query_rewrite",
+        "description": "Suggest query rewrites for optimization."
+    },
+    {
+        "name": "mysql_index_recommendation",
+        "description": "Recommend indexes for a query."
+    },
+    {
+        "name": "mysql_innodb_status",
+        "description": "Get InnoDB engine status information."
+    },
+    {
+        "name": "mysql_analyze_table",
+        "description": "Analyze table to update index statistics."
+    },
+    {
+        "name": "mysql_optimize_table",
+        "description": "Optimize table to reclaim space and defragment."
+    },
+    {
+        "name": "mysql_check_table",
+        "description": "Check table for errors."
+    },
+    {
+        "name": "mysql_repair_table",
+        "description": "Repair a corrupted table."
+    },
+    {
+        "name": "mysql_flush_tables",
+        "description": "Flush table cache to free resources."
+    },
+    {
+        "name": "mysql_kill_query",
+        "description": "Kill a running query by its process ID."
+    },
+    {
+        "name": "mysql_show_processlist",
+        "description": "Show all running processes and queries."
+    },
+    {
+        "name": "mysql_show_status",
+        "description": "Show server status variables."
+    },
+    {
+        "name": "mysql_show_variables",
+        "description": "Show server configuration variables."
+    },
+    {
+        "name": "mysql_thread_stats",
+        "description": "Get thread statistics from performance_schema."
+    },
+    {
+        "name": "mysql_pool_stats",
+        "description": "Get connection pool statistics."
+    },
+    {
+        "name": "mysql_server_health",
+        "description": "Get overall server health metrics."
+    },
+    {
+        "name": "mysql_replication_status",
+        "description": "Get replication status information."
+    },
+    {
+        "name": "mysql_create_dump",
+        "description": "Create a database dump using mysqldump."
+    },
+    {
+        "name": "mysql_restore_dump",
+        "description": "Restore a database from a dump file."
+    },
+    {
+        "name": "mysql_export_table",
+        "description": "Export a table to CSV format."
+    },
+    {
+        "name": "mysql_import_data",
+        "description": "Import data from a CSV file."
+    },
+    {
+        "name": "mysql_master_status",
+        "description": "Get master/source status for replication."
+    },
+    {
+        "name": "mysql_slave_status",
+        "description": "Get slave/replica status for replication."
+    },
+    {
+        "name": "mysql_binlog_events",
+        "description": "Get binary log events."
+    },
+    {
+        "name": "mysql_gtid_status",
+        "description": "Get GTID replication status."
+    },
+    {
+        "name": "mysql_replication_lag",
+        "description": "Get replication lag in seconds."
+    },
+    {
+        "name": "mysql_partition_info",
+        "description": "Get partition information for a table."
+    },
+    {
+        "name": "mysql_add_partition",
+        "description": "Add a new partition to a partitioned table."
+    },
+    {
+        "name": "mysql_drop_partition",
+        "description": "Drop a partition from a partitioned table."
+    },
+    {
+        "name": "mysql_reorganize_partition",
+        "description": "Reorganize partitions in a partitioned table."
+    },
+    {
+        "name": "mysql_router_status",
+        "description": "Get MySQL Router status information."
+    },
+    {
+        "name": "mysql_router_routes",
+        "description": "Get all routes configured in MySQL Router."
+    },
+    {
+        "name": "mysql_router_route_status",
+        "description": "Get status for a specific route."
+    },
+    {
+        "name": "mysql_router_route_health",
+        "description": "Get health information for a route."
+    },
+    {
+        "name": "mysql_router_route_connections",
+        "description": "Get active connections for a route."
+    },
+    {
+        "name": "mysql_router_route_destinations",
+        "description": "Get destination servers for a route."
+    },
+    {
+        "name": "mysql_router_route_blocked_hosts",
+        "description": "Get blocked hosts for a route."
+    },
+    {
+        "name": "mysql_router_metadata_status",
+        "description": "Get InnoDB Cluster metadata status."
+    },
+    {
+        "name": "mysql_router_pool_status",
+        "description": "Get Router connection pool status."
+    },
+    {
+        "name": "proxysql_status",
+        "description": "Get ProxySQL status information."
+    },
+    {
+        "name": "proxysql_runtime_status",
+        "description": "Get ProxySQL runtime configuration status."
+    },
+    {
+        "name": "proxysql_servers",
+        "description": "Get configured backend MySQL servers."
+    },
+    {
+        "name": "proxysql_hostgroups",
+        "description": "Get hostgroup configuration."
+    },
+    {
+        "name": "proxysql_users",
+        "description": "Get configured ProxySQL users."
+    },
+    {
+        "name": "proxysql_query_rules",
+        "description": "Get query routing rules."
+    },
+    {
+        "name": "proxysql_global_variables",
+        "description": "Get ProxySQL global variables."
+    },
+    {
+        "name": "proxysql_connection_pool",
+        "description": "Get connection pool statistics."
+    },
+    {
+        "name": "proxysql_query_digest",
+        "description": "Get query digest statistics."
+    },
+    {
+        "name": "proxysql_process_list",
+        "description": "Get active ProxySQL processes."
+    },
+    {
+        "name": "proxysql_memory_stats",
+        "description": "Get ProxySQL memory usage statistics."
+    },
+    {
+        "name": "proxysql_commands",
+        "description": "Get ProxySQL command statistics."
+    },
+    {
+        "name": "mysqlsh_version",
+        "description": "Get MySQL Shell version information."
+    },
+    {
+        "name": "mysqlsh_check_upgrade",
+        "description": "Check database for upgrade compatibility."
+    },
+    {
+        "name": "mysqlsh_export_table",
+        "description": "Export a table using MySQL Shell parallel export."
+    },
+    {
+        "name": "mysqlsh_import_table",
+        "description": "Import data using MySQL Shell parallel import."
+    },
+    {
+        "name": "mysqlsh_import_json",
+        "description": "Import JSON data into a collection or table."
+    },
+    {
+        "name": "mysqlsh_dump_instance",
+        "description": "Dump entire MySQL instance using MySQL Shell."
+    },
+    {
+        "name": "mysqlsh_dump_schemas",
+        "description": "Dump specific schemas using MySQL Shell."
+    },
+    {
+        "name": "mysqlsh_dump_tables",
+        "description": "Dump specific tables using MySQL Shell."
+    },
+    {
+        "name": "mysqlsh_load_dump",
+        "description": "Load a MySQL Shell dump into the database."
+    },
+    {
+        "name": "mysqlsh_run_script",
+        "description": "Execute a JavaScript or Python script in MySQL Shell."
+    }
+]


### PR DESCRIPTION
## Summary
Adds mysql-mcp, an enterprise-grade MySQL MCP Server with 106 specialized tools.

## Features
- **106 tools** across 15 categories (Core, JSON, Transactions, Performance, Router, ProxySQL, Shell, etc.)
- MySQL 5.7+ and 8.0+ support
- Connection pooling
- OAuth 2.0 authentication
- Tool filtering for AI IDE compatibility

## Server Configuration
- **Image**: `mcp/mysql-mcp` (Docker-built)
- **Category**: database
- **License**: MIT

## Documentation
- **GitHub**: https://github.com/neverinfamous/mysql-mcp
- **Wiki**: https://github.com/neverinfamous/mysql-mcp/wiki
- **Docker Hub**: https://hub.docker.com/r/writenotenow/mysql-mcp

## Files Included
- `server.yaml` - Server configuration
- `tools.json` - Complete tool manifest (bypasses automated discovery)
- `readme.md` - Documentation link

## Checklist
- [x] MIT License
- [x] Dockerfile in source repo
- [x] tools.json provided (bypasses automated discovery)
- [x] readme.md with documentation link