### PR TITLE
initial server.yaml files for new official Google MCP servers

### DIFF
--- a/servers/com-google-cloud-bigquery-mcp/server.yaml
+++ b/servers/com-google-cloud-bigquery-mcp/server.yaml
@@ -1,4 +1,4 @@
-name: com_google_cloud_bigquery-mcp
+name: com-google-cloud-bigquery-mcp
 remote:
   url: https://bigquery.googleapis.com/mcp
   transport_type: streamable-http
@@ -8,14 +8,14 @@ remote:
 type: remote
 icon: https://cdn.worldvectorlogo.com/logos/google-bigquery-logo-1.svg
 about:
-  title: BigQuery MCP Server
+  title: Google BigQuery
   description: Remote MCP server for BigQuery data analysis, querying, and forecasting via Google Cloud
   icon: https://cdn.worldvectorlogo.com/logos/google-bigquery-logo-1.svg
 config:
   secrets:
-  - name: com_google_cloud_bigquery-mcp.project_id
-    env: PROJECT_ID
-    example: project-1234...
-  - name: com_google_cloud_bigquery-mcp.access_token
-    env: ACCESS_TOKEN
-    example: AIzaSyD...
+    - name: com-google-cloud-bigquery-mcp.project_id
+      env: PROJECT_ID
+      example: project-1234...
+    - name: com-google-cloud-bigquery-mcp.access_token
+      env: ACCESS_TOKEN
+      example: AIzaSyD...

--- a/servers/com-google-cloud-compute-mcp/server.yaml
+++ b/servers/com-google-cloud-compute-mcp/server.yaml
@@ -1,4 +1,4 @@
-name: com_google_cloud_compute-mcp
+name: com-google-cloud-compute-mcp
 remote:
   url: https://compute.googleapis.com/mcp
   transport_type: streamable-http
@@ -13,9 +13,9 @@ about:
   icon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSZEvRLFj7Hnxl-_y2HpRJSDQEIyYITpp_QSA&slj
 config:
   secrets:
-  - name: com_google_cloud_compute-mcp.project_id
-    env: PROJECT_ID
-    example: project-1234...
-  - name: com_google_cloud_compute-mcp.access_token
-    env: ACCESS_TOKEN
-    example: AIzaSyD...
+    - name: com-google-cloud-compute-mcp.project_id
+      env: PROJECT_ID
+      example: project-1234...
+    - name: com-google-cloud-compute-mcp.access_token
+      env: ACCESS_TOKEN
+      example: AIzaSyD...

--- a/servers/com-google-maps-grounding-lite/server.yaml
+++ b/servers/com-google-maps-grounding-lite/server.yaml
@@ -1,4 +1,4 @@
-name: com_google_maps_grounding-lite
+name: com-google-maps-grounding-lite
 remote:
   url: https://mapstools.googleapis.com/mcp
   transport_type: streamable-http
@@ -12,6 +12,6 @@ about:
   icon: https://www.gstatic.com/images/branding/product/2x/maps_48dp.png
 config:
   secrets:
-  - name: com_google_maps_grounding-lite.api_key
-    env: API_KEY
-    example: AIzaSyD...
+    - name: com-google-maps-grounding-lite.api_key
+      env: API_KEY
+      example: AIzaSyD...

--- a/servers/com-googleapis-container-gke/server.yaml
+++ b/servers/com-googleapis-container-gke/server.yaml
@@ -1,4 +1,4 @@
-name: com_googleapis_container_gke
+name: com-googleapis-container-gke
 remote:
   url: https://container.googleapis.com/mcp
   transport_type: streamable-http
@@ -8,14 +8,14 @@ remote:
 type: remote
 icon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRJKUMkuqNwND4ITLcurk8rjF1VgDX0sR5yUw&s
 about:
-  title: Google Kubernetes Engine (GKE) MCP Server
+  title: Google Kubernetes Engine (GKE)
   description: Manage GKE clusters and Kubernetes resources through MCP. Provides tools for cluster operations, node pools, and Kubernetes API interactions.
   icon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRJKUMkuqNwND4ITLcurk8rjF1VgDX0sR5yUw&s
 config:
   secrets:
-  - name: com_googleapis_container_gke.project_id
-    env: PROJECT_ID
-    example: project-1234...
-  - name: com_googleapis_container_gke.access_token
-    env: ACCESS_TOKEN
-    example: AIzaSyD...
+    - name: com-googleapis-container-gke.project_id
+      env: PROJECT_ID
+      example: project-1234...
+    - name: com-googleapis-container-gke.access_token
+      env: ACCESS_TOKEN
+      example: AIzaSyD...


### PR DESCRIPTION
The four servers announced [here](https://cloud.google.com/blog/products/ai-machine-learning/announcing-official-mcp-support-for-google-services) included in this Pull Request.

These are all remote servers.

## MCP Server Information

**BigQuery MCP Server**
**Google Cloud Compute Engine**
**Google Maps AI Grounding Lite**
**Google Kubernetes Engine (GKE) MCP Server**

I have not included OpenSource or license details as each of these is a remote server hosted on  googleapis.com

```
Servers:
  - Type: remote
    Endpoint: https://bigquery.googleapis.com/mcp
  - Type: remote
    Endpoint: https://compute.googleapis.com/mcp
  - Type: remote
    Endpoint: https://mapstools.googleapis.com/mcp
  - Type: remote
    Endpoint: https://container.googleapis.com/mcp
```

## Basic Requirements

- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`

## Security

Three of the servers (gce, gke, and bigquery) could be oauth compatible except they do not support DCR. And we have not given users ways to register their own client-ids with Docker Desktop.  Therefore, these three servers can only be tested today with Application Default Credentials.  
