### PR TITLE
Add html-to-markdown-mcp server

### DIFF
--- a/servers/html-to-markdown-mcp/readme.md
+++ b/servers/html-to-markdown-mcp/readme.md
@@ -1,0 +1,1 @@
+See [HTML to Markdown MCP documentation](https://github.com/levz0r/html-to-markdown-mcp#readme)

--- a/servers/html-to-markdown-mcp/server.yaml
+++ b/servers/html-to-markdown-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: html-to-markdown-mcp
+image: mcp/html-to-markdown-mcp
+type: server
+meta:
+  category: utilities
+  tags:
+    - html
+    - markdown
+    - converter
+    - web-scraping
+    - utilities
+about:
+  title: HTML to Markdown
+  description: Fetch HTML from any URL and convert it to clean, formatted Markdown using Turndown.js. Preserves headers, links, code blocks, lists, and tables.
+  icon: https://avatars.githubusercontent.com/u/4631498?v=4
+source:
+  project: https://github.com/levz0r/html-to-markdown-mcp
+  commit: d8411d1b4a663a524bcf1633f10edc40b5b75874

--- a/servers/html-to-markdown-mcp/tools.json
+++ b/servers/html-to-markdown-mcp/tools.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "html_to_markdown",
+    "description": "Fetch HTML from a URL or convert provided HTML content to Markdown format. Automatically extracts and converts web pages to clean, readable Markdown. Use this whenever you need to fetch and extract information from a webpage.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "URL to fetch HTML from. If provided, the HTML will be automatically fetched and converted. Either 'url' or 'html' must be provided."
+      },
+      {
+        "name": "html",
+        "type": "string",
+        "desc": "Raw HTML content to convert to Markdown. Use this if you already have HTML content. Either 'url' or 'html' must be provided."
+      },
+      {
+        "name": "includeMetadata",
+        "type": "boolean",
+        "desc": "Include metadata header (source URL, title, and timestamp) in the output"
+      },
+      {
+        "name": "maxLength",
+        "type": "number",
+        "desc": "Maximum length of the returned markdown content in characters. If the content exceeds this length, it will be truncated with a message indicating the truncation."
+      },
+      {
+        "name": "saveToFile",
+        "type": "string",
+        "desc": "Optional file path to save the full markdown content to. When specified, the full content is saved to the file and a summary is returned instead of the full content."
+      }
+    ]
+  },
+  {
+    "name": "save_markdown",
+    "description": "Save markdown content to a file. Use this to persist converted HTML to a markdown file on disk.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "The markdown content to save"
+      },
+      {
+        "name": "filePath",
+        "type": "string",
+        "desc": "The file path where the markdown should be saved (can be relative or absolute)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Adds **html-to-markdown-mcp** - an MCP server that fetches HTML from any URL and converts it to clean, formatted Markdown using Turndown.js.

### Features
- Fetch and convert web pages to Markdown
- Preserves formatting (headers, links, code blocks, lists, tables)
- Automatically removes unwanted elements (scripts, styles, etc.)
- Auto-extracts page titles and metadata
- Save markdown content to files

### Tools
- `html_to_markdown` - Fetch URL or convert HTML to Markdown
- `save_markdown` - Save markdown content to a file

### Links
- **Repository**: https://github.com/levz0r/html-to-markdown-mcp
- **npm**: https://www.npmjs.com/package/html-to-markdown-mcp
- **License**: MIT

### Checklist
- [x] MIT License
- [x] Dockerfile included
- [x] server.yaml created
- [x] tools.json included
- [x] readme.md with documentation link