### PR TITLE
Update n8n MCP server to v2.31.3

### DIFF
--- a/servers/n8n/server.yaml
+++ b/servers/n8n/server.yaml
@@ -13,7 +13,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=n8n.io&sz=64
 source:
   project: https://github.com/czlonkowski/n8n-mcp
-  commit: 1bbfaabbc20f4989d81bc8a2cfc9f16795134ed8
+  commit: 808088f25eccf3cf73a90017af9f5abdd1893886
 run:
   env:
     MCP_MODE: stdio


### PR DESCRIPTION
## Summary

Updates the n8n-mcp server from v2.22.17 to v2.31.3.

## Changes

- Updated `source.commit` to `808088f25eccf3cf73a90017af9f5abdd1893886` (latest main commit)

## Source

- Package: https://www.npmjs.com/package/n8n-mcp
- Repository: https://github.com/czlonkowski/n8n-mcp
- Version changelog: v2.22.17 → v2.31.3

## Related Issue

Closes #913