### PR TITLE
Add *arr Media Management MCP server

### DIFF
--- a/servers/arr/server.yaml
+++ b/servers/arr/server.yaml
@@ -1,0 +1,64 @@
+name: arr
+image: mcp/arr
+type: server
+meta:
+  category: media
+  tags:
+    - sonarr
+    - radarr
+    - lidarr
+    - readarr
+    - prowlarr
+    - media-management
+    - plex
+    - homelab
+    - entertainment
+about:
+  title: "*arr Media Management"
+  description: "MCP server for the *arr media management suite - Sonarr (TV), Radarr (Movies), Lidarr (Music), Readarr (Books), and Prowlarr (Indexers). Manage your media library, search for content, monitor downloads, and get AI-powered configuration recommendations using TRaSH Guides."
+  icon: https://wiki.servarr.com/assets/servarr.png
+source:
+  project: https://github.com/aplaceforallmystuff/mcp-arr
+  commit: 0e596ffc1bb101cff934901698b0f3893a66353e
+config:
+  description: |
+    Configure URLs and API keys for your *arr services. Only configure the services you use -
+    the server automatically detects which are available. Find API keys in each application
+    under Settings > General > Security.
+  env:
+    - name: SONARR_URL
+      description: "Sonarr base URL (e.g., http://localhost:8989 or http://sonarr:8989)"
+      example: "http://localhost:8989"
+    - name: RADARR_URL
+      description: "Radarr base URL (e.g., http://localhost:7878 or http://radarr:7878)"
+      example: "http://localhost:7878"
+    - name: LIDARR_URL
+      description: "Lidarr base URL (e.g., http://localhost:8686 or http://lidarr:8686)"
+      example: "http://localhost:8686"
+    - name: READARR_URL
+      description: "Readarr base URL (e.g., http://localhost:8787 or http://readarr:8787)"
+      example: "http://localhost:8787"
+    - name: PROWLARR_URL
+      description: "Prowlarr base URL (e.g., http://localhost:9696 or http://prowlarr:9696)"
+      example: "http://localhost:9696"
+  secrets:
+    - name: arr.sonarr-api-key
+      env: SONARR_API_KEY
+      description: "Sonarr API key from Settings > General > Security"
+      example: "<your-sonarr-api-key>"
+    - name: arr.radarr-api-key
+      env: RADARR_API_KEY
+      description: "Radarr API key from Settings > General > Security"
+      example: "<your-radarr-api-key>"
+    - name: arr.lidarr-api-key
+      env: LIDARR_API_KEY
+      description: "Lidarr API key from Settings > General > Security"
+      example: "<your-lidarr-api-key>"
+    - name: arr.readarr-api-key
+      env: READARR_API_KEY
+      description: "Readarr API key from Settings > General > Security"
+      example: "<your-readarr-api-key>"
+    - name: arr.prowlarr-api-key
+      env: PROWLARR_API_KEY
+      description: "Prowlarr API key from Settings > General > Security"
+      example: "<your-prowlarr-api-key>"

--- a/servers/arr/tools.json
+++ b/servers/arr/tools.json
@@ -1,0 +1,783 @@
+[
+  {
+    "name": "arr_status",
+    "description": "Get status of all configured *arr services (Sonarr, Radarr, Lidarr, Readarr, Prowlarr)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "arr_search_all",
+    "description": "Search across all configured *arr services for any media",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "Search term"
+        }
+      },
+      "required": ["term"]
+    }
+  },
+  {
+    "name": "sonarr_get_series",
+    "description": "Get all TV series in Sonarr library",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_search",
+    "description": "Search for TV series to add to Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "Search term (show name)"
+        }
+      },
+      "required": ["term"]
+    }
+  },
+  {
+    "name": "sonarr_get_queue",
+    "description": "Get Sonarr download queue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_calendar",
+    "description": "Get upcoming TV episodes from Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "number",
+          "description": "Number of days to look ahead (default: 7)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_episodes",
+    "description": "Get episodes for a TV series. Shows which episodes are available and which are missing.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "seriesId": {
+          "type": "number",
+          "description": "Series ID to get episodes for"
+        },
+        "seasonNumber": {
+          "type": "number",
+          "description": "Optional: filter to a specific season"
+        }
+      },
+      "required": ["seriesId"]
+    }
+  },
+  {
+    "name": "sonarr_search_missing",
+    "description": "Trigger a search for all missing episodes in a series",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "seriesId": {
+          "type": "number",
+          "description": "Series ID to search for missing episodes"
+        }
+      },
+      "required": ["seriesId"]
+    }
+  },
+  {
+    "name": "sonarr_search_episode",
+    "description": "Trigger a search for specific episode(s)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "episodeIds": {
+          "type": "array",
+          "items": { "type": "number" },
+          "description": "Episode ID(s) to search for"
+        }
+      },
+      "required": ["episodeIds"]
+    }
+  },
+  {
+    "name": "sonarr_get_quality_profiles",
+    "description": "Get detailed quality profiles from Sonarr. Shows allowed qualities, upgrade settings, and custom format scores.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_health",
+    "description": "Get health check warnings and issues from Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_root_folders",
+    "description": "Get root folders and storage info from Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_download_clients",
+    "description": "Get download client configurations from Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_naming",
+    "description": "Get file naming configuration from Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_get_tags",
+    "description": "Get all tags defined in Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "sonarr_review_setup",
+    "description": "Get comprehensive configuration review for Sonarr. Returns all settings for AI-assisted analysis.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_movies",
+    "description": "Get all movies in Radarr library",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_search",
+    "description": "Search for movies to add to Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "Search term (movie name)"
+        }
+      },
+      "required": ["term"]
+    }
+  },
+  {
+    "name": "radarr_get_queue",
+    "description": "Get Radarr download queue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_calendar",
+    "description": "Get upcoming movie releases from Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "number",
+          "description": "Number of days to look ahead (default: 30)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_search_movie",
+    "description": "Trigger a search to download a movie that's already in your library",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "movieId": {
+          "type": "number",
+          "description": "Movie ID to search for"
+        }
+      },
+      "required": ["movieId"]
+    }
+  },
+  {
+    "name": "radarr_get_quality_profiles",
+    "description": "Get detailed quality profiles from Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_health",
+    "description": "Get health check warnings and issues from Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_root_folders",
+    "description": "Get root folders and storage info from Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_download_clients",
+    "description": "Get download client configurations from Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_naming",
+    "description": "Get file naming configuration from Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_get_tags",
+    "description": "Get all tags defined in Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "radarr_review_setup",
+    "description": "Get comprehensive configuration review for Radarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_artists",
+    "description": "Get all artists in Lidarr library",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_search",
+    "description": "Search for artists to add to Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "Search term (artist name)"
+        }
+      },
+      "required": ["term"]
+    }
+  },
+  {
+    "name": "lidarr_get_queue",
+    "description": "Get Lidarr download queue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_albums",
+    "description": "Get albums for an artist in Lidarr. Shows which albums are available and which are missing.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "artistId": {
+          "type": "number",
+          "description": "Artist ID to get albums for"
+        }
+      },
+      "required": ["artistId"]
+    }
+  },
+  {
+    "name": "lidarr_search_album",
+    "description": "Trigger a search for a specific album to download",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "albumId": {
+          "type": "number",
+          "description": "Album ID to search for"
+        }
+      },
+      "required": ["albumId"]
+    }
+  },
+  {
+    "name": "lidarr_search_missing",
+    "description": "Trigger a search for all missing albums for an artist",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "artistId": {
+          "type": "number",
+          "description": "Artist ID to search missing albums for"
+        }
+      },
+      "required": ["artistId"]
+    }
+  },
+  {
+    "name": "lidarr_get_calendar",
+    "description": "Get upcoming album releases from Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "number",
+          "description": "Number of days to look ahead (default: 30)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_quality_profiles",
+    "description": "Get detailed quality profiles from Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_health",
+    "description": "Get health check warnings and issues from Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_root_folders",
+    "description": "Get root folders and storage info from Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_download_clients",
+    "description": "Get download client configurations from Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_naming",
+    "description": "Get file naming configuration from Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_get_tags",
+    "description": "Get all tags defined in Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "lidarr_review_setup",
+    "description": "Get comprehensive configuration review for Lidarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_authors",
+    "description": "Get all authors in Readarr library",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_search",
+    "description": "Search for authors to add to Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "term": {
+          "type": "string",
+          "description": "Search term (author name)"
+        }
+      },
+      "required": ["term"]
+    }
+  },
+  {
+    "name": "readarr_get_queue",
+    "description": "Get Readarr download queue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_books",
+    "description": "Get books for an author in Readarr. Shows which books are available and which are missing.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "authorId": {
+          "type": "number",
+          "description": "Author ID to get books for"
+        }
+      },
+      "required": ["authorId"]
+    }
+  },
+  {
+    "name": "readarr_search_book",
+    "description": "Trigger a search for a specific book to download",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "bookIds": {
+          "type": "array",
+          "items": { "type": "number" },
+          "description": "Book ID(s) to search for"
+        }
+      },
+      "required": ["bookIds"]
+    }
+  },
+  {
+    "name": "readarr_search_missing",
+    "description": "Trigger a search for all missing books for an author",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "authorId": {
+          "type": "number",
+          "description": "Author ID to search missing books for"
+        }
+      },
+      "required": ["authorId"]
+    }
+  },
+  {
+    "name": "readarr_get_calendar",
+    "description": "Get upcoming book releases from Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "number",
+          "description": "Number of days to look ahead (default: 30)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_quality_profiles",
+    "description": "Get detailed quality profiles from Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_health",
+    "description": "Get health check warnings and issues from Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_root_folders",
+    "description": "Get root folders and storage info from Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_download_clients",
+    "description": "Get download client configurations from Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_naming",
+    "description": "Get file naming configuration from Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_get_tags",
+    "description": "Get all tags defined in Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "readarr_review_setup",
+    "description": "Get comprehensive configuration review for Readarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "prowlarr_get_indexers",
+    "description": "Get all configured indexers in Prowlarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "prowlarr_search",
+    "description": "Search across all Prowlarr indexers",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search query"
+        }
+      },
+      "required": ["query"]
+    }
+  },
+  {
+    "name": "prowlarr_test_indexers",
+    "description": "Test all indexers and return their health status",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "prowlarr_get_stats",
+    "description": "Get indexer statistics (queries, grabs, failures)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "trash_list_profiles",
+    "description": "List available TRaSH Guides quality profiles for Radarr or Sonarr",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service to get profiles for"
+        }
+      },
+      "required": ["service"]
+    }
+  },
+  {
+    "name": "trash_get_profile",
+    "description": "Get a specific TRaSH Guides quality profile with all custom format scores and settings",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service"
+        },
+        "profile": {
+          "type": "string",
+          "description": "Profile name (e.g., 'remux-web-1080p', 'uhd-bluray-web')"
+        }
+      },
+      "required": ["service", "profile"]
+    }
+  },
+  {
+    "name": "trash_list_custom_formats",
+    "description": "List available TRaSH Guides custom formats with optional category filter",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service"
+        },
+        "category": {
+          "type": "string",
+          "description": "Optional filter: hdr, audio, resolution, source, streaming, anime, unwanted, release, language"
+        }
+      },
+      "required": ["service"]
+    }
+  },
+  {
+    "name": "trash_get_naming",
+    "description": "Get TRaSH Guides recommended naming conventions for your media server",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service"
+        },
+        "mediaServer": {
+          "type": "string",
+          "enum": ["plex", "emby", "jellyfin", "standard"],
+          "description": "Which media server you use"
+        }
+      },
+      "required": ["service", "mediaServer"]
+    }
+  },
+  {
+    "name": "trash_get_quality_sizes",
+    "description": "Get TRaSH Guides recommended min/max/preferred sizes for each quality level",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service"
+        },
+        "type": {
+          "type": "string",
+          "description": "Content type: 'movie', 'anime' for Radarr; 'series', 'anime' for Sonarr"
+        }
+      },
+      "required": ["service"]
+    }
+  },
+  {
+    "name": "trash_compare_profile",
+    "description": "Compare your quality profile against TRaSH Guides recommendations",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service"
+        },
+        "profileId": {
+          "type": "number",
+          "description": "Your quality profile ID to compare"
+        },
+        "trashProfile": {
+          "type": "string",
+          "description": "TRaSH profile name to compare against"
+        }
+      },
+      "required": ["service", "profileId", "trashProfile"]
+    }
+  },
+  {
+    "name": "trash_compare_naming",
+    "description": "Compare your naming configuration against TRaSH Guides recommendations",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "string",
+          "enum": ["radarr", "sonarr"],
+          "description": "Which service"
+        },
+        "mediaServer": {
+          "type": "string",
+          "enum": ["plex", "emby", "jellyfin", "standard"],
+          "description": "Which media server you use"
+        }
+      },
+      "required": ["service", "mediaServer"]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Adds MCP server for the *arr media management suite (Sonarr, Radarr, Lidarr, Readarr, Prowlarr)
- 63 tools for library management, search, downloads, and configuration review
- TRaSH Guides integration for quality profile recommendations

## Features
- **Unified media management** - Control all *arr applications from one interface
- **Natural language queries** - Ask about your library in plain English
- **Cross-service search** - Find content across TV, movies, music, and books
- **Download monitoring** - Check queue status and progress
- **Configuration review** - AI-powered suggestions for setup optimization
- **TRaSH Guides** - Reference community-curated quality profiles

## Configuration
Requires URL and API key for each *arr service (only configure services you use):
- `SONARR_URL` / `SONARR_API_KEY`
- `RADARR_URL` / `RADARR_API_KEY`
- `LIDARR_URL` / `LIDARR_API_KEY`
- `READARR_URL` / `READARR_API_KEY`
- `PROWLARR_URL` / `PROWLARR_API_KEY`

## Testing
- Docker image builds successfully
- Server starts and lists tools correctly
- Tested with multiple *arr service configurations

## Links
- [GitHub Repository](https://github.com/aplaceforallmystuff/mcp-arr)
- [npm Package](https://www.npmjs.com/package/mcp-arr-server)
- [Servarr Wiki](https://wiki.servarr.com/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)