### PR TITLE
agents/sec-rev: update default Codex review model to gpt-5.2-codex

### DIFF
--- a/agents/security-reviewer/compose.yml
+++ b/agents/security-reviewer/compose.yml
@@ -23,7 +23,7 @@ services:
       # environment variable.
       CODEX_API_KEY: "sk-compose-clients"
       OPENAI_BASE_URL: "http://proxy:4000/openai"
-      CODEX_REVIEW_MODEL: ${CODEX_REVIEW_MODEL:-gpt-5-codex}
+      CODEX_REVIEW_MODEL: ${CODEX_REVIEW_MODEL:-gpt-5.2-codex}
       REVIEW_AGENT: ${REVIEW_AGENT:-claude}
       REVIEW_HEAD_SHA: ${REVIEW_HEAD_SHA:-}
       REVIEW_BASE_SHA: ${REVIEW_BASE_SHA:-}


### PR DESCRIPTION
This PR updates the review model used in the example open-source reviewer agent.