### PR TITLE
Add container credential env vars to aws-api MCP server config

### DIFF
--- a/servers/aws-api/server.yaml
+++ b/servers/aws-api/server.yaml
@@ -22,12 +22,6 @@ config:
     - name: aws-api.aws_session_token
       env: AWS_SESSION_TOKEN
       example: your-aws-session-token
-    - name: aws-api.aws_container_authorization_token
-      env: AWS_CONTAINER_AUTHORIZATION_TOKEN
-      example: your-container-authorization-token
-    - name: aws-api.aws_container_credentials_full_uri
-      env: AWS_CONTAINER_CREDENTIALS_FULL_URI
-      example: http://localhost:9911/api/credentials
   env:
     - name: AWS_REGION
       example: us-east-1
@@ -38,6 +32,12 @@ config:
     - name: AWS_ACCESS_KEY_ID
       example: AKIAIOSFODNN7EXAMPLE
       value: "{{aws-api.aws_access_key_id}}"
+    - name: AWS_CONTAINER_AUTHORIZATION_TOKEN
+      example: your-container-authorization-token
+      value: "{{aws-api.aws_container_authorization_token}}"
+    - name: AWS_CONTAINER_CREDENTIALS_FULL_URI
+      example: http://localhost:9911/api/credentials
+      value: "{{aws-api.aws_container_credentials_full_uri}}"
   parameters:
     type: object
     properties:
@@ -48,4 +48,8 @@ config:
         type: string
         default: default
       aws_access_key_id:
+        type: string
+      aws_container_authorization_token:
+        type: string
+      aws_container_credentials_full_uri:
         type: string


### PR DESCRIPTION
## Summary
- Context: https://github.com/docker/mcp-gateway/issues/317
- Add `AWS_CONTAINER_AUTHORIZATION_TOKEN` env var for container authorization
- Add `AWS_CONTAINER_CREDENTIALS_FULL_URI` env var for credential endpoint configuration
- Enables authentication via AWS container credentials provider

These are added as configurable env vars (not secrets) with corresponding parameters.

## Test plan
- [ ] Run `task catalog -- aws-api` to generate the catalog
- [ ] Import with `docker mcp catalog import $PWD/catalogs/aws-api/catalog.yaml`
- [ ] Verify new env vars appear in Docker Desktop MCP Toolkit configuration
- [ ] Test authentication using container credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)