### PR TITLE
Handle both GitHub App and Bot names as author for pin upgrade PRs

### DIFF
--- a/.github/pin-upgrade-auto-merge-helper-scripts/validate-pr.sh
+++ b/.github/pin-upgrade-auto-merge-helper-scripts/validate-pr.sh
@@ -6,8 +6,8 @@ state="$2"
 is_draft="$3"
 labels="$4"
 
-# Check if PR is from mcp-registry-bot
-if [ "$author" != "mcp-registry-bot[bot]" ]; then
+# Check if PR is from mcp-registry-bot (accepts both app/ and [bot] formats)
+if [ "$author" != "app/mcp-registry-bot" ] && [ "$author" != "mcp-registry-bot[bot]" ]; then
   echo "PR is not from mcp-registry-bot. Author: $author. Skipping auto-merge."
   echo "skip=true" >> "$GITHUB_OUTPUT"
   exit 0


### PR DESCRIPTION
Related to https://github.com/docker/mcp-registry/pull/929. It turns out `mcp-registry-bot` is not a bot, but is instead a GitHub app. The `author` field takes different forms for each, i.e. `app/mcp-registry-bot` for the former and `mcp-registry-bot[bot]` as the latter. As a result, the GitHub Action prematurely short-circuits: 

```
PR is not from mcp-registry-bot. Author: app/mcp-registry-bot. Skipping auto-merge.
```

This PR is to handle both scenarios.

## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
