### PR TITLE
add tools.json for apollo mcp server

### DIFF
--- a/servers/apollo-mcp-server/tools.json
+++ b/servers/apollo-mcp-server/tools.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "execute",
+    "description": "Execute a GraphQL operation. Use the `introspect` tool to get information about the GraphQL schema. Always use the schema to create operations - do not try arbitrary operations. If available, first use the `validate` tool to validate operations. DO NOT try to execute introspection queries.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "The GraphQL operation"
+      },
+      {
+        "name": "variables",
+        "type": "string",
+        "desc": "The variable values represented as JSON",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "introspect",
+    "description": "Get information about a given GraphQL type defined in the schema. Instructions: Use this tool to explore the schema by providing specific type names. Start with the root query (Query) or mutation (Mutation) types to discover available fields. If the search tool is also available, use this tool first to get the fields, then use the search tool with relevant field return types and argument input types (ignore default GraphQL scalars) as search terms.",
+    "arguments": [
+      {
+        "name": "type_name",
+        "type": "string",
+        "desc": "The name of the type to get information about."
+      },
+      {
+        "name": "depth",
+        "type": "integer",
+        "desc": "How far to recurse the type hierarchy. Use 0 for no limit. Defaults to 1.",
+        "optional": true
+      }
+    ],
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "search",
+    "description": "Search a GraphQL schema for types matching the provided search terms. Returns complete type definitions including all related types needed to construct GraphQL operations. Instructions: If the introspect tool is also available, you can discover type names by using the introspect tool starting from the root Query or Mutation types. Avoid reusing previously searched terms for more efficient exploration.",
+    "arguments": [
+      {
+        "name": "terms",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "desc": "The search terms"
+      }
+    ],
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "validate",
+    "description": "Validates a GraphQL operation against the schema. Use the `introspect` tool first to get information about the GraphQL schema. Operations should be validated prior to calling the `execute` tool.",
+    "arguments": [
+      {
+        "name": "operation",
+        "type": "string",
+        "desc": "The GraphQL operation"
+      }
+    ],
+    "annotations": {
+      "readOnlyHint": true
+    }
+  }
+]


### PR DESCRIPTION
Fixes #127

## Summary
This PR adds the missing `tools.json` file for the apollo-mcp-server, which is blocking it from appearing in the MCP Catalog.

## Context
- Original PR: #60 (merged on July 18, 2025)
- Issue: #127
- The apollo-mcp-server entry was merged before the `tools.json` requirement was introduced in September
- Without this file, the CI build process fails when trying to list tools, as the server requires configuration (API keys: `APOLLO_KEY` and `APOLLO_GRAPH_REF`) to run

## Changes
- Added `servers/apollo-mcp-server/tools.json` with the 4 core Apollo MCP Server tools:
  - `execute`: Execute GraphQL operations
  - `introspect`: Explore GraphQL schema types
  - `search`: Search for GraphQL types matching search terms
  - `validate`: Validate GraphQL operations against the schema

## MCP Server Information

**Server Name:** Apollo MCP Server
**Repository URL:** https://github.com/apollographql/apollo-mcp-server
**Brief Description:** MCP server that exposes GraphQL operations as tools for AI models.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
