### PR TITLE
Direct merge from GitHub Action instead of enabling auto-merge

### DIFF
--- a/.github/workflows/auto-merge-pins.yaml
+++ b/.github/workflows/auto-merge-pins.yaml
@@ -108,7 +108,7 @@ jobs:
           pr_number="${{ steps.pr.outputs.pr_number }}"
 
           # Use squash merge to keep history clean
-          gh pr merge "$pr_number" --squash --auto
+          gh pr merge "$pr_number" --squash
 
           echo "Successfully merged PR #$pr_number"
 


### PR DESCRIPTION
Now that we have permissions, we were able to test enabling auto-merge on the PR with `mcp-registry-bot` on the bypass list for rulesets. However, it turns out auto-merge doesn't play nice with ruleset bypasses. Auto-merge will still wait for all checks, including the code review from `ai-tools-team`. Doing a direct merge will follow the ruleset bypass list, which will allow `mcp-registry-bot` to merge without approvals.

Do a direct squash merge from the GitHub Action instead. 

Related to: https://github.com/docker/mcp-registry/pull/929

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
