### PR TITLE
Add step to have mcp-registry-bot approve pin upgrade PR

### DIFF
--- a/.github/workflows/auto-merge-pins.yaml
+++ b/.github/workflows/auto-merge-pins.yaml
@@ -90,13 +90,6 @@ jobs:
             "${{ steps.pr.outputs.pr_number }}" \
             "${{ github.repository }}"
 
-      - name: Approve PR
-        if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true' && steps.allowlist.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
-        run: |
-          gh pr review "${{ steps.pr.outputs.pr_number }}" --approve --body "All checks passed and server is in allowlist. Auto-approving for merge."
-
       - name: Comment on PR before merging
         if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true' && steps.allowlist.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
         env:
@@ -107,17 +100,24 @@ jobs:
             "${{ steps.pr.outputs.pr_number }}" \
             "${{ steps.extract.outputs.server }}"
 
-      - name: Merge PR
+      - name: Enable auto-merge
         if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true' && steps.allowlist.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
         run: |
           pr_number="${{ steps.pr.outputs.pr_number }}"
 
-          # Use squash merge with auto flag to queue for merge after requirements met
+          # Enable auto-merge - PR will merge automatically once all requirements are met
           gh pr merge "$pr_number" --squash --auto
 
           echo "Successfully enabled auto-merge for PR #$pr_number"
+
+      - name: Approve PR
+        if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true' && steps.allowlist.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
+        run: |
+          gh pr review "${{ steps.pr.outputs.pr_number }}" --approve --body "All checks passed and server is in allowlist. Auto-approving for merge."
 
       - name: Handle merge failure
         if: failure() && steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true'


### PR DESCRIPTION
Try having `mcp-registry-bot` self-approve the pin upgrade PR to satisfy the merge conditions. NOTE: we will need to add `mcp-registry-bot` to the `ai-tools-team` GitHub team. The PR is approved after auto-merge is enabled.

Also, re-enabling `--auto` merge flag due to the following and use the above approach instead:

```
Run pr_number="943"
X Pull request docker/mcp-registry#943 is not mergeable: the base branch policy prohibits the merge.
To have the pull request merged after all the requirements have been met, add the `--auto` flag.
To use administrator privileges to immediately merge the pull request, add the `--admin` flag.
```

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
