### PR TITLE
Re-enable auto-merge after making mcp-registry-bot exempt

### DIFF
--- a/.github/workflows/auto-merge-pins.yaml
+++ b/.github/workflows/auto-merge-pins.yaml
@@ -108,7 +108,7 @@ jobs:
           pr_number="${{ steps.pr.outputs.pr_number }}"
 
           # Use squash merge to keep history clean
-          gh pr merge "$pr_number" --squash
+          gh pr merge "$pr_number" --squash --auto
 
           echo "Successfully merged PR #$pr_number"
 


### PR DESCRIPTION
We can re-enable auto-merge now after updating the GitHub ruleset to make mcp-registry-bot exempt.

<img width="676" height="276" alt="Screenshot 2026-01-16 at 7 14 49 PM" src="https://github.com/user-attachments/assets/8e8e07d3-2a07-4c99-8c74-ec14b0435bd1" />

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
