### PR TITLE
Add Supabase MCP Server

### DIFF
--- a/servers/supabase/server.yaml
+++ b/servers/supabase/server.yaml
@@ -1,0 +1,38 @@
+name: supabase
+image: mcp/supabase
+type: server
+meta:
+  category: database
+  tags:
+    - supabase
+    - database
+    - postgres
+    - storage
+about:
+  title: Supabase
+  description: Connect to Supabase databases with full read/write capabilities. Query tables, insert/update/delete rows, execute SQL, list storage buckets and files.
+  icon: https://avatars.githubusercontent.com/u/54469796?s=200&v=4
+source:
+  project: https://github.com/jefflitt1/supabase-mcp-server
+  commit: f6419d5ad44042ce28dbab2d9ab9962ae0805bd1
+config:
+  description: Configure connection to your Supabase project. Find your URL and service key in Supabase Dashboard > Project Settings > API.
+  env:
+    - name: SUPABASE_URL
+      example: https://xxxxx.supabase.co
+      value: "{{supabase.url}}"
+    - name: SUPABASE_SERVICE_KEY
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+      value: "{{supabase.service_key}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        description: Your Supabase project URL (e.g., https://xxxxx.supabase.co)
+      service_key:
+        type: string
+        description: Supabase service role key (found in Project Settings > API)
+    required:
+      - url
+      - service_key

--- a/servers/supabase/tools.json
+++ b/servers/supabase/tools.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "list_tables",
+    "description": "List all tables in the Supabase database"
+  },
+  {
+    "name": "describe_table",
+    "description": "Get the schema/structure of a specific table"
+  },
+  {
+    "name": "query_table",
+    "description": "Query data from a table with filters, ordering, and limits"
+  },
+  {
+    "name": "insert_row",
+    "description": "Insert a new row into a table"
+  },
+  {
+    "name": "update_rows",
+    "description": "Update rows that match specified filters"
+  },
+  {
+    "name": "delete_rows",
+    "description": "Delete rows that match specified filters"
+  },
+  {
+    "name": "execute_sql",
+    "description": "Execute a raw SQL query"
+  },
+  {
+    "name": "list_buckets",
+    "description": "List all storage buckets"
+  },
+  {
+    "name": "list_files",
+    "description": "List files in a storage bucket"
+  }
+]


### PR DESCRIPTION
## Summary

This PR adds a new Supabase MCP server to the catalog, providing full read/write access to Supabase databases.

### Features
- **Database Operations**: List tables, describe schemas, query data with filters
- **CRUD Operations**: Insert, update, and delete rows
- **Raw SQL**: Execute arbitrary SQL queries
- **Storage**: List buckets and files

### Tools Included
1. `list_tables` - List all tables in the database
2. `describe_table` - Get schema/structure of a specific table
3. `query_table` - Query data with filters, ordering, and limits
4. `insert_row` - Insert a new row into a table
5. `update_rows` - Update rows matching filters
6. `delete_rows` - Delete rows matching filters
7. `execute_sql` - Execute raw SQL queries
8. `list_buckets` - List all storage buckets
9. `list_files` - List files in a storage bucket

### Configuration
Requires two environment variables:
- `SUPABASE_URL` - The Supabase project URL
- `SUPABASE_SERVICE_KEY` - The service role key for full access

### Source
- **Repository**: https://github.com/jefflitt1/supabase-mcp-server
- **Docker Image**: Available on Docker Hub as `jglitt/supabase-mcp-server`
- **License**: MIT

### Testing
The server has been tested with:
- Listing tables from a production Supabase database
- Querying data with filters
- Insert/update/delete operations
- Raw SQL execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)