### PR TITLE
Update LinkedIn MCP server entry

### DIFF
--- a/servers/linkedin-mcp-server/readme.md
+++ b/servers/linkedin-mcp-server/readme.md
@@ -1,0 +1,24 @@
+# LinkedIn
+
+Give MCP clients access to LinkedIn profiles, companies, jobs and messages through your own logged-in browser session.
+
+## Sign in
+
+Create the persistent session volume and sign in once:
+
+```bash
+docker volume create linkedin-mcp-server-session
+docker run -it --rm \
+  -v linkedin-mcp-server-session:/home/pwuser/.linkedin-mcp \
+  -p 127.0.0.1:6080:6080 \
+  mcp/linkedin-mcp-server \
+  --login --login-viewer
+```
+
+Open the full URL printed by the command and complete the sign-in. Let the command exit on its own so the session is stored completely. Docker MCP reuses the same named volume when it starts the server.
+
+Repeat the login command when the session expires. To remove the stored session, disable the server and run `docker volume rm linkedin-mcp-server-session`.
+
+Docker MCP does not currently expose the server’s optional proxy settings. If your network requires a proxy, use the [direct Docker setup](https://github.com/stickerdaniel/linkedin-mcp-server#docker-setup).
+
+For configuration and troubleshooting, see the [project documentation](https://github.com/stickerdaniel/linkedin-mcp-server#docker-setup).

--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/stickerdaniel/linkedin-mcp-server
   branch: docker-release
-  commit: 99f84daeedda8f3e573ebfe8b37d717bbb1d3f50
+  commit: 8a2c1fb5c6655e91f745166d5091d0c353e5f434
 run:
   volumes:
     - linkedin-mcp-server-session:/home/pwuser/.linkedin-mcp

--- a/servers/linkedin-mcp-server/server.yaml
+++ b/servers/linkedin-mcp-server/server.yaml
@@ -1,36 +1,24 @@
 name: linkedin-mcp-server
-image: stickerdaniel/linkedin-mcp-server:1.4.0
+image: mcp/linkedin-mcp-server
 type: server
+longLived: true
 meta:
   category: business
   tags:
     - linkedin
     - business
-    - scraping
     - profiles
     - jobs
+    - messaging
     - networking
 about:
   title: LinkedIn
-  description: This MCP server allows Claude and other AI assistants to access your LinkedIn. Scrape LinkedIn profiles and companies, get your recommended jobs, and perform job searches. Set your li_at LinkedIn cookie to use this server.
-  icon: https://raw.githubusercontent.com/stickerdaniel/linkedin-mcp-server/main/assets/icons/linkedin.svg
+  description: Give Claude and other MCP clients access to LinkedIn profiles, companies, jobs and messages through your own logged-in browser session. Sign in once, then reuse the session stored in Docker.
+  icon: https://raw.githubusercontent.com/stickerdaniel/linkedin-mcp-server/main/assets/icons/icon.png
 source:
   project: https://github.com/stickerdaniel/linkedin-mcp-server
-  commit: c54e3fa518d2b5cd827262159771b9d85a6eae13
-config:
-  description: Configure LinkedIn authentication and optional user agent
-  secrets:
-    - name: linkedin-mcp-server.cookie
-      env: LINKEDIN_COOKIE
-      example: AQETADxR7bsCqpZlAAACm-lNHKAAA...
-      description: See the [Getting the LinkedIn Cookie](https://github.com/stickerdaniel/linkedin-mcp-server?tab=readme-ov-file#getting-the-linkedin-cookie) section in the documentation
-  env:
-    - name: USER_AGENT
-      example: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
-      value: "{{linkedin-mcp-server.user_agent}}"
-  parameters:
-    type: object
-    properties:
-      user_agent:
-        type: string
-        description: Custom user agent string (optional, helps avoid detection and cookie login issues)
+  branch: docker-release
+  commit: 99f84daeedda8f3e573ebfe8b37d717bbb1d3f50
+run:
+  volumes:
+    - linkedin-mcp-server-session:/home/pwuser/.linkedin-mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** `linkedin-mcp-server`  
**Repository URL:** https://github.com/stickerdaniel/linkedin-mcp-server  
**Brief Description:** Moves the entry to Dockerʼs managed image pipeline and replaces obsolete cookie and user-agent settings with a persistent browser session.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP
- [x] **Active Development**: Maintained
- [x] **Docker Artifact**: Multi-platform Dockerfile
- [x] **Documentation**: Catalog login and session-removal instructions
- [x] **Security Contact**: GitHub private vulnerability reporting

## Submitter Checklist

- [x] This server meets the basic requirements
- [x] I understand this will undergo automated and manual review
- [x] `task validate -- --name linkedin-mcp-server` passes
- [x] `task build -- --tools linkedin-mcp-server` builds the pinned source and discovers 19 tools
- [x] No shared credentials are required; users sign in through their own browser session

The release-only `docker-release` branch lets Dockerʼs pin bot update the entry without publishing unreleased `main` commits.

The source pin is the verified v4.24.4 release commit. The shared `longLived` catalog conversion fix is tracked separately in #4889 and #4890.
