### PR TITLE
arm-mcp is from a known publisher

### DIFF
--- a/.github/auto-merge-allowlist.yaml
+++ b/.github/auto-merge-allowlist.yaml
@@ -91,6 +91,7 @@ servers:
   - aks
   - apify-mcp-server
   - apollo-mcp-server
+  - arm-mcp
   - astra-db
   - atlan
   - atlas-docs


### PR DESCRIPTION
Updating the allowlist of mcp servers for auto-merging pin upgrades with the arm server. I've recently opened a PR to add it to the known publisher list https://github.com/docker/pinata/pull/38963

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
