### PR TITLE
Add 'neo4j' to auto-merge allowlist

### DIFF
--- a/.github/auto-merge-allowlist.yaml
+++ b/.github/auto-merge-allowlist.yaml
@@ -155,6 +155,7 @@ servers:
   - neo4j-cypher
   - neo4j-data-modeling
   - neo4j-memory
+  - neo4j
   - neon
   - notion
   - novita


### PR DESCRIPTION
Just noticed that neo4j wasn't added to the auto-merge allowlist after it was added yesterday.