### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-merge-pins.yaml
+++ b/.github/workflows/auto-merge-pins.yaml
@@ -45,7 +45,7 @@ jobs:
             mcp-registry
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get PR number and details
         id: pr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main for tooling
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           path: main-tooling
           fetch-depth: 1
 
       - name: Install Go for building main tooling
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: main-tooling/go.mod
 
@@ -28,13 +28,13 @@ jobs:
           go build -o ../bin/clean ./cmd/clean
 
       - name: Checkout PR for validation
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: pr-workspace
           fetch-depth: 0
 
       - name: Install Go for PR branch
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: pr-workspace/go.mod
 

--- a/.github/workflows/update-pins.yaml
+++ b/.github/workflows/update-pins.yaml
@@ -33,7 +33,7 @@ jobs:
             mcp-registry
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
@@ -44,7 +44,7 @@ jobs:
           git config user.email "mcp-registry-bot@users.noreply.github.com"
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | auto-merge-pins.yaml, ci.yaml, update-pins.yaml |
| `actions/setup-go` | [`v5`](https://github.com/actions/setup-go/releases/tag/v5) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Release](https://github.com/actions/setup-go/releases/tag/v6) | ci.yaml, update-pins.yaml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
