### PR TITLE
Add EU Regulations MCP server

### DIFF
--- a/servers/eu-regulations-mcp/server.yaml
+++ b/servers/eu-regulations-mcp/server.yaml
@@ -1,0 +1,21 @@
+name: eu-regulations-mcp
+image: mcp/eu-regulations-mcp
+type: server
+meta:
+  category: legal
+  tags:
+    - legal
+    - compliance
+    - gdpr
+    - nis2
+    - dora
+    - ai-act
+    - cybersecurity
+    - european-union
+about:
+  title: EU Regulations MCP
+  description: "Query DORA, NIS2, GDPR, EU AI Act, Cyber Resilience Act, and EU Cybersecurity Act directly from Claude. Full-text search, article retrieval, cross-framework comparison, and ISO 27001 control mapping."
+  icon: https://avatars.githubusercontent.com/u/195753936?v=4
+source:
+  project: https://github.com/Ansvar-Systems/EU_compliance_MCP
+  commit: f09a3fba89817b177f42fd98efa51911f81cc320

--- a/servers/eu-regulations-mcp/tools.json
+++ b/servers/eu-regulations-mcp/tools.json
@@ -1,0 +1,129 @@
+[
+    {
+        "name": "search_regulations",
+        "description": "Search across all EU regulations for articles matching a query. Returns relevant articles with snippets highlighting matches.",
+        "arguments": [
+            {
+                "name": "query",
+                "type": "string",
+                "desc": "Search query (e.g., 'incident reporting', 'personal data breach')"
+            },
+            {
+                "name": "regulations",
+                "type": "array",
+                "desc": "Optional: filter to specific regulations (e.g., ['GDPR', 'NIS2'])"
+            },
+            {
+                "name": "limit",
+                "type": "number",
+                "desc": "Maximum results to return (default: 10)"
+            }
+        ]
+    },
+    {
+        "name": "get_article",
+        "description": "Retrieve the full text of a specific article from a regulation.",
+        "arguments": [
+            {
+                "name": "regulation",
+                "type": "string",
+                "desc": "Regulation ID (e.g., 'GDPR', 'NIS2', 'DORA')"
+            },
+            {
+                "name": "article",
+                "type": "string",
+                "desc": "Article number (e.g., '17', '23')"
+            }
+        ]
+    },
+    {
+        "name": "list_regulations",
+        "description": "List available regulations and their structure. Without parameters, lists all regulations. With a regulation specified, shows chapters and articles.",
+        "arguments": [
+            {
+                "name": "regulation",
+                "type": "string",
+                "desc": "Optional: specific regulation to get detailed structure for"
+            }
+        ]
+    },
+    {
+        "name": "compare_requirements",
+        "description": "Compare requirements across multiple regulations on a specific topic. Useful for understanding differences in how regulations address similar concerns.",
+        "arguments": [
+            {
+                "name": "topic",
+                "type": "string",
+                "desc": "Topic to compare (e.g., 'incident reporting', 'risk assessment')"
+            },
+            {
+                "name": "regulations",
+                "type": "array",
+                "desc": "Regulations to compare (e.g., ['DORA', 'NIS2'])"
+            }
+        ]
+    },
+    {
+        "name": "map_controls",
+        "description": "Map ISO 27001:2022 controls to EU regulation requirements. Shows which articles satisfy specific security controls.",
+        "arguments": [
+            {
+                "name": "framework",
+                "type": "string",
+                "desc": "Control framework (currently only 'ISO27001' supported)"
+            },
+            {
+                "name": "control",
+                "type": "string",
+                "desc": "Optional: specific control ID (e.g., 'A.5.1', 'A.6.8')"
+            },
+            {
+                "name": "regulation",
+                "type": "string",
+                "desc": "Optional: filter mappings to specific regulation"
+            }
+        ]
+    },
+    {
+        "name": "check_applicability",
+        "description": "Determine which EU regulations apply to an organization based on sector and characteristics.",
+        "arguments": [
+            {
+                "name": "sector",
+                "type": "string",
+                "desc": "Organization sector: financial, healthcare, energy, transport, digital_infrastructure, public_administration, manufacturing, other"
+            },
+            {
+                "name": "subsector",
+                "type": "string",
+                "desc": "Optional: more specific subsector (e.g., 'bank', 'insurance' for financial)"
+            },
+            {
+                "name": "member_state",
+                "type": "string",
+                "desc": "Optional: EU member state (ISO country code)"
+            },
+            {
+                "name": "size",
+                "type": "string",
+                "desc": "Optional: organization size ('sme' or 'large')"
+            }
+        ]
+    },
+    {
+        "name": "get_definitions",
+        "description": "Look up official definitions of terms from EU regulations. Terms are defined in each regulation's definitions article.",
+        "arguments": [
+            {
+                "name": "term",
+                "type": "string",
+                "desc": "Term to look up (e.g., 'personal data', 'incident', 'processing')"
+            },
+            {
+                "name": "regulation",
+                "type": "string",
+                "desc": "Optional: filter to specific regulation"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Summary

Adds the EU Regulations MCP server to the registry - the first open-source MCP server for European cybersecurity regulations.

### What it does

Query DORA, NIS2, GDPR, EU AI Act, Cyber Resilience Act, and EU Cybersecurity Act directly from Claude or any MCP-compatible client.

### Coverage

| Regulation | Articles | Definitions |
|------------|----------|-------------|
| DORA | 64 | 65 |
| NIS2 | 46 | 41 |
| GDPR | 99 | 26 |
| EU AI Act | 113 | 68 |
| Cyber Resilience Act | 71 | 51 |
| EU Cybersecurity Act | 69 | 22 |

**Total: 462 articles, 273 definitions**

### Tools provided

- `search_regulations` - Full-text search across all regulations
- `get_article` - Retrieve specific articles with full text
- `list_regulations` - List available regulations and structure
- `compare_requirements` - Side-by-side framework comparison
- `map_controls` - Map ISO 27001 controls to requirements
- `check_applicability` - Determine which regulations apply
- `get_definitions` - Look up official definitions

### Installation

```bash
npx -y @ansvar/eu-regulations-mcp
```

### Links

- **Source**: https://github.com/Ansvar-Systems/EU_compliance_MCP
- **npm**: https://www.npmjs.com/package/@ansvar/eu-regulations-mcp
- **License**: Apache-2.0

Built by [Ansvar Systems](https://ansvar.ai) - Stockholm, Sweden