### PR TITLE
Add Amplitude Analytics MCP server

### DIFF
--- a/servers/amplitude-analytics/server.yaml
+++ b/servers/amplitude-analytics/server.yaml
@@ -1,0 +1,25 @@
+name: amplitude-analytics
+image: mcp/amplitude-analytics
+type: server
+meta:
+  category: analytics
+  tags:
+    - analytics
+    - tracking
+    - amplitude
+    - events
+    - user-behavior
+about:
+  title: Amplitude Analytics
+  description: Provides AI assistants with the ability to track events, pageviews, signups, user properties, and revenue in Amplitude Analytics. Enables automated tracking and user behavior analysis through natural language requests.
+  icon: https://www.google.com/s2/favicons?domain=amplitude.com&sz=64
+source:
+  project: https://github.com/moonbirdai/amplitude-mcp-server
+  branch: main
+  commit: c07c296d0ab6f7758776e458d62e253cfbb299d4
+config:
+  description: Configure the connection to Amplitude Analytics
+  secrets:
+    - name: amplitude-analytics.api_key
+      env: AMPLITUDE_API_KEY
+      example: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6


### PR DESCRIPTION
## Summary
- Adds Amplitude Analytics MCP server to the catalog
- Enables AI assistants to track events, pageviews, signups, user properties, and revenue in Amplitude

## Tools provided
- `amplitude_track_event` - Track custom events
- `amplitude_track_pageview` - Log page views
- `amplitude_track_signup` - Create user profiles and track signups
- `amplitude_set_user_properties` - Update user profile attributes
- `amplitude_track_revenue` - Record purchases and transactions

## Source
https://github.com/moonbirdai/amplitude-mcp-server

## Test plan
- [x] Built and tested Docker image locally
- [x] Verified MCP protocol initialization
- [x] Confirmed all 5 tools are registered
- [x] Successfully tracked test event with real API key