### PR TITLE
Add railway server

### DIFF
--- a/servers/railway/server.yaml
+++ b/servers/railway/server.yaml
@@ -1,0 +1,24 @@
+name: railway
+image: mcp/railway
+type: server
+meta:
+  category: cloud
+  tags:
+    - cloud
+    - deployment
+    - infrastructure
+    - railway
+    - paas
+about:
+  title: Railway MCP
+  description: Deploy and manage Railway platform projects, services, environments, and deployments through an MCP interface
+  icon: https://railway.app/brand/logo-light.svg
+source:
+  project: https://github.com/MehdiZare/railway-docker-mcp
+  commit: 78170b78ddd4ea1fc251fe0c6971be041b76920d
+config:
+  description: Configure Railway API authentication
+  secrets:
+    - name: railway.railway_token
+      env: RAILWAY_TOKEN
+      example: <YOUR_RAILWAY_API_TOKEN>

--- a/servers/railway/tools.json
+++ b/servers/railway/tools.json
@@ -1,0 +1,280 @@
+[
+  {
+    "name": "check_railway_status",
+    "description": "Verify API access and authentication. Returns the current user's information if authenticated."
+  },
+  {
+    "name": "list_projects",
+    "description": "List all accessible Railway projects with their environments and services."
+  },
+  {
+    "name": "create_project_and_link",
+    "description": "Create a new Railway project with optional description and default environment name.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Project name"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Optional project description",
+        "optional": true
+      },
+      {
+        "name": "default_environment_name",
+        "type": "string",
+        "desc": "Name for the default environment (defaults to 'production')",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_services",
+    "description": "List services in a Railway project.",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID"
+      }
+    ]
+  },
+  {
+    "name": "link_service",
+    "description": "Get service details for context/linking.",
+    "arguments": [
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": "Service ID to link"
+      }
+    ]
+  },
+  {
+    "name": "deploy",
+    "description": "Trigger deployment for a service in a specific environment.",
+    "arguments": [
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": "Service ID to deploy"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID to deploy to"
+      }
+    ]
+  },
+  {
+    "name": "list_deployments",
+    "description": "List deployments for a service with status and metadata.",
+    "arguments": [
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": "Service ID"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID"
+      },
+      {
+        "name": "limit",
+        "type": "string",
+        "desc": "Maximum number of deployments to return (default: 10)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_logs",
+    "description": "Retrieve build or deployment logs for a specific deployment.",
+    "arguments": [
+      {
+        "name": "deployment_id",
+        "type": "string",
+        "desc": "Deployment ID"
+      },
+      {
+        "name": "log_type",
+        "type": "string",
+        "desc": "Type of logs to retrieve ('build' or 'deployment')",
+        "optional": true
+      },
+      {
+        "name": "limit",
+        "type": "string",
+        "desc": "Maximum number of log entries (default: 100)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_environments",
+    "description": "List environments in a Railway project.",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID"
+      }
+    ]
+  },
+  {
+    "name": "create_environment",
+    "description": "Create a new environment in a Railway project.",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Environment name"
+      }
+    ]
+  },
+  {
+    "name": "link_environment",
+    "description": "Get environment details for context/linking.",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID (for validation)"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID to link"
+      }
+    ]
+  },
+  {
+    "name": "list_variables",
+    "description": "List environment variables for a project, environment, or service. Values are masked by default for security.",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID"
+      },
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": "Optional service ID (for service-specific variables)",
+        "optional": true
+      },
+      {
+        "name": "include_values",
+        "type": "string",
+        "desc": "If true, return actual values; if false, return masked values (default: false)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "set_variables",
+    "description": "Set environment variables for a project, environment, or service.",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID"
+      },
+      {
+        "name": "variables",
+        "type": "string",
+        "desc": "Dictionary of variable names and values to set"
+      },
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": "Optional service ID (for service-specific variables)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "generate_domain",
+    "description": "Generate a railway.app domain for a service.",
+    "arguments": [
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": "Service ID"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID"
+      }
+    ]
+  },
+  {
+    "name": "deploy_template",
+    "description": "Deploy from Railway Template Library (e.g., redis, postgres, mysql).",
+    "arguments": [
+      {
+        "name": "project_id",
+        "type": "string",
+        "desc": "Project ID to deploy to"
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Environment ID to deploy to"
+      },
+      {
+        "name": "template_code",
+        "type": "string",
+        "desc": "Template code (e.g., 'redis', 'postgres')"
+      },
+      {
+        "name": "services",
+        "type": "string",
+        "desc": "Optional list of service configurations",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_templates",
+    "description": "List available templates from Railway Template Library.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "string",
+        "desc": "Maximum number of templates to return (default: 50)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_template",
+    "description": "Get template details including services configuration.",
+    "arguments": [
+      {
+        "name": "code",
+        "type": "string",
+        "desc": "Template code (e.g., 'redis', 'postgres')"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Adds Railway MCP server for deploying and managing Railway platform projects, services, environments, and deployments.

- **Name**: railway
- **Category**: cloud
- **Source**: https://github.com/MehdiZare/railway-docker-mcp

## Tools Included (17 total)
- Project: check_railway_status, list_projects, create_project_and_link
- Service: list_services, link_service, deploy
- Deployment: list_deployments, get_logs
- Environment: list_environments, create_environment, link_environment
- Variables: list_variables, set_variables
- Domain: generate_domain
- Templates: list_templates, get_template, deploy_template

## Configuration
Requires: `RAILWAY_TOKEN` - Railway API token

🤖 Generated with [Claude Code](https://claude.com/claude-code)