### PR TITLE
Add server definition for Home Assistant MCP (ha-mcp)

### DIFF
--- a/servers/homeassistant-mcp-server/server.yaml
+++ b/servers/homeassistant-mcp-server/server.yaml
@@ -1,0 +1,33 @@
+name: homeassistant-mcp-server
+image: ghcr.io/homeassistant-ai/ha-mcp:latest
+type: server
+meta:
+  category: home-automation
+  tags:
+    - home-assistant
+    - smart-home
+    - iot
+about:
+  title: Home Assistant MCP
+  description: MCP server that allows AI assistants to interact with a Home Assistant instance, control devices, and read state.
+  icon: https://www.google.com/s2/favicons?domain=home-assistant.io&sz=64
+source:
+  project: https://github.com/homeassistant-ai/ha-mcp
+  branch: master
+  commit: ""
+config:
+  description: Configure connection to your Home Assistant MCP server
+  secrets:
+    - name: homeassistant-mcp-server.token
+      env: HOME_ASSISTANT_TOKEN
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...   # nur Beispiel, kein echter Token
+  env:
+    - name: HOME_ASSISTANT_URL
+      example: http://homeassistant.local:8123
+      value: "{{homeassistant-mcp-server.url}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        description: Base URL of your Home Assistant instance

--- a/servers/homeassistant/server.yaml
+++ b/servers/homeassistant/server.yaml
@@ -1,0 +1,33 @@
+name: homeassistant-mcp-server
+image: ghcr.io/homeassistant-ai/ha-mcp:latest
+type: server
+meta:
+  category: home-automation
+  tags:
+    - home-assistant
+    - smart-home
+    - iot
+about:
+  title: Home Assistant MCP
+  description: MCP server that allows AI assistants to interact with a Home Assistant instance, control devices, and read state.
+  icon: https://www.google.com/s2/favicons?domain=home-assistant.io&sz=64
+source:
+  project: https://github.com/homeassistant-ai/ha-mcp
+  branch: master
+  commit: ""
+config:
+  description: Configure connection to your Home Assistant MCP server
+  secrets:
+    - name: homeassistant-mcp-server.token
+      env: HOME_ASSISTANT_TOKEN
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...   # nur Beispiel, kein echter Token
+  env:
+    - name: HOME_ASSISTANT_URL
+      example: http://homeassistant.local:8123
+      value: "{{homeassistant-mcp-server.url}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        description: Base URL of your Home Assistant instance


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** Home Assistant MCP (ha-mcp)
**Repository URL:** https://github.com/homeassistant-ai/ha-mcp
**Brief Description:** Unofficial but feature-rich MCP server that allows AI assistants to interact with a Home Assistant instance: control devices, query states, manage automations, dashboards, and more.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
