### PR TITLE
Add gitlab-docs-mcp server

### DIFF
--- a/servers/gitlab-docs-mcp/readme.md
+++ b/servers/gitlab-docs-mcp/readme.md
@@ -1,0 +1,26 @@
+# GitLab Documentation MCP Server
+
+A Model Context Protocol server that provides searchable access to GitLab's official documentation.
+
+## Documentation
+
+For full documentation, installation instructions, and usage examples, see:
+https://github.com/nunolima/gitlab-docs-mcp
+
+## Features
+
+- Full-text search across GitLab documentation using SQLite FTS5
+- Version-specific docs (18.7.x currently indexed)
+- Multiple repositories indexed:
+  - GitLab CE/EE (main application)
+  - GitLab Runner (CI/CD runner)
+  - Omnibus GitLab (installation packages)
+  - Gitaly (Git RPC service)
+  - GitLab Pages (static sites)
+  - GitLab Agent (Kubernetes integration)
+
+## Available Tools
+
+- `search_docs` - Full-text search across all GitLab documentation
+- `get_doc` - Retrieve specific documentation by file path
+- `list_repositories` - List all indexed GitLab repositories

--- a/servers/gitlab-docs-mcp/server.yaml
+++ b/servers/gitlab-docs-mcp/server.yaml
@@ -1,0 +1,16 @@
+name: gitlab-docs-mcp
+image: nunolima/gitlab-docs-mcp:18.7
+type: server
+meta:
+  category: documentation
+  tags:
+    - gitlab
+    - documentation
+    - search
+about:
+  title: GitLab Documentation
+  description: Search and access GitLab's official documentation
+  icon: https://www.google.com/s2/favicons?domain=gitlab.com&sz=64
+source:
+  project: https://github.com/nunolima/gitlab-docs-mcp
+  commit: 0ff535818349e8d8a05134e99702b103fb0bdb4b

--- a/servers/gitlab-docs-mcp/tools.json
+++ b/servers/gitlab-docs-mcp/tools.json
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "search_docs",
+    "description": "Full-text search across GitLab documentation from multiple repositories (GitLab CE/EE, Runner, Omnibus, Gitaly, Pages, Agent)",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Search query string to find relevant documentation"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of results to return (default: 10)"
+      }
+    ]
+  },
+  {
+    "name": "get_doc",
+    "description": "Retrieve specific documentation content by file path",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "File path to the documentation (e.g., 'doc/ci/yaml/index.md')"
+      },
+      {
+        "name": "repository",
+        "type": "string",
+        "desc": "Repository name (gitlab, gitlab-runner, omnibus-gitlab, gitaly, gitlab-pages, gitlab-agent)"
+      }
+    ]
+  },
+  {
+    "name": "list_repositories",
+    "description": "List all indexed GitLab documentation repositories",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gitlab-docs-mcp
**Repository URL:** https://github.com/nunolima/gitlab-docs-mcp
**Brief Description:** Search and access GitLab's official documentation with full-text search across GitLab CE/EE, Runner, Omnibus, Gitaly, Pages, and Agent repositories

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gitlab-docs-mcp`
- [x] I have built the MCP Server (pre-built multi-arch (linux/amd64,linux/arm64) image on Docker Hub)
- [ ] If the server requires credentials to test it, I have shared test credentials using this form