### PR TITLE
Add Pexels MCP Server entry

### DIFF
--- a/servers/pexels-mcp-server/server.yaml
+++ b/servers/pexels-mcp-server/server.yaml
@@ -11,7 +11,6 @@ meta:
 about:
   title: Pexels MCP Server
   description: Search and retrieve free stock photos and videos from Pexels using their official API.
-  icon: https://raw.githubusercontent.com/madebyaram2024/pexels-mcp-server/main/icon.png
 source:
   project: https://github.com/madebyaram2024/pexels-mcp-server
   commit: 5c0dcf77ffe7d604f9ad4c5ee1082818721e005b


### PR DESCRIPTION
This PR adds a new MCP server for the Pexels API.

The server allows users to search for and retrieve free stock photos and videos. It is containerized and ready to be used with the Docker MCP Toolkit.

Source repository: https://github.com/madebyaram2024/pexels-mcp-server
