### PR TITLE
Add stock-images-mcp server

### DIFF
--- a/servers/stock-images/server.yaml
+++ b/servers/stock-images/server.yaml
@@ -1,0 +1,30 @@
+name: stock-images
+image: mcp/stock-images
+type: server
+meta:
+  category: media
+  tags:
+    - images
+    - stock
+    - pexels
+    - unsplash
+    - pixabay
+about:
+  title: Stock Images MCP
+  description: Search and download free stock images from Pexels, Unsplash, and Pixabay. Aggregates results from multiple providers with a unified interface.
+  icon: https://avatars.githubusercontent.com/u/8262794?v=4
+source:
+  project: https://github.com/jeanpfs/stock-images-mcp
+  commit: f94feb12e4138285da084e19c9cb4601e84b75b9
+config:
+  description: Configure API keys for stock image providers. At least one API key is required.
+  secrets:
+    - name: PEXELS_API_KEY
+      description: API key from pexels.com/api (free)
+      required: false
+    - name: UNSPLASH_API_KEY
+      description: API key from unsplash.com/developers (free)
+      required: false
+    - name: PIXABAY_API_KEY
+      description: API key from pixabay.com/api/docs (free)
+      required: false

--- a/servers/stock-images/server.yaml
+++ b/servers/stock-images/server.yaml
@@ -12,7 +12,7 @@ meta:
 about:
   title: Stock Images MCP
   description: Search and download free stock images from Pexels, Unsplash, and Pixabay. Aggregates results from multiple providers with a unified interface.
-  icon: https://avatars.githubusercontent.com/u/8262794?v=4
+  icon: https://www.google.com/s2/favicons?domain=pexels.com&sz=64
 source:
   project: https://github.com/jeanpfs/stock-images-mcp
   commit: f94feb12e4138285da084e19c9cb4601e84b75b9


### PR DESCRIPTION
## Summary

Add **stock-images-mcp** - an MCP server for searching and downloading free stock images from multiple providers.

### Features

- **search_images**: Search across Pexels, Unsplash, and Pixabay with unified results
- **download_image**: Download images to local folder

### Providers

| Provider | API | Rate Limits |
|----------|-----|-------------|
| Pexels | Free | 200 req/hour |
| Unsplash | Free | 50 req/hour |
| Pixabay | Free | 100 req/min |

### Configuration

Requires at least one API key (all are free):
- `PEXELS_API_KEY` - from pexels.com/api
- `UNSPLASH_API_KEY` - from unsplash.com/developers
- `PIXABAY_API_KEY` - from pixabay.com/api/docs

### Testing

- [x] Docker image builds successfully
- [x] Catalog generated
- [x] Tools validated (2 tools found)

### Repository

https://github.com/jeanpfs/stock-images-mcp