### PR TITLE
Add yandex-direct-metrica-mcp

### DIFF
--- a/servers/yandex-direct-metrica-mcp/server.yaml
+++ b/servers/yandex-direct-metrica-mcp/server.yaml
@@ -28,8 +28,14 @@ run:
 config:
   description: Configure the Yandex OAuth token and local state folder for accounts.json and dashboard artifacts.
   secrets:
-    - name: yandex.oauth_token
+    - name: yandex-direct-metrica-mcp.yandex_access_token
       env: YANDEX_ACCESS_TOKEN
+      example: ya29.****
+    - name: yandex-direct-metrica-mcp.yandex_wordstat_access_token
+      env: YANDEX_WORDSTAT_ACCESS_TOKEN
+      example: ya29.****
+    - name: yandex-direct-metrica-mcp.yandex_audience_access_token
+      env: YANDEX_AUDIENCE_ACCESS_TOKEN
       example: ya29.****
   env:
     - name: YANDEX_DIRECT_CLIENT_LOGIN


### PR DESCRIPTION
## Summary
- Add yandex-direct-metrica-mcp as a local MCP server (Docker-built image in the Docker Hub `mcp/` namespace).
- Public read-only analytics for Yandex Direct/Metrica/Wordstat/Audience with joins and dashboards.

## Notes
- Upstream source: https://github.com/georgy-agaev/yandex-direct-metrica-mcp (pinned commit).
- Image is intended to be safe-by-default public read-only.

## Testing
- Not run locally (Go/Task tooling unavailable in this environment); relying on registry CI validation/build.
