### PR TITLE
Add 46elks-sms server

### DIFF
--- a/servers/46elks-sms/server.yaml
+++ b/servers/46elks-sms/server.yaml
@@ -1,0 +1,51 @@
+name: 46elks-sms
+image: mcp/46elks-sms
+type: server
+meta:
+  category: communication
+  tags:
+    - sms
+    - sweden
+    - 46elks
+    - telecommunications
+    - messaging
+about:
+  title: 46elks SMS
+  description: Send SMS messages through Swedish 46elks telecommunications infrastructure. OWASP MCP Top 10 compliant with rate limiting, audit logging, and input validation.
+  icon: https://www.google.com/s2/favicons?domain=46elks.com&sz=64
+source:
+  project: https://github.com/palhamel/46elks-mcp-server
+  branch: main
+  commit: b13d9cb8245bf6c728f740799b6dd130c5ffde0a
+config:
+  description: |
+    Requires 46elks API credentials. Sign up at https://46elks.com/ to get your API username, password, and a phone number for sending SMS.
+  secrets:
+    - name: 46elks-sms.api_username
+      env: ELKS_API_USERNAME
+      example: uXXXXXXXXXXXXXXXXXXXXXX
+    - name: 46elks-sms.api_password
+      env: ELKS_API_PASSWORD
+      example: XXXXXXXXXXXXXXXXXXXXXXXX
+    - name: 46elks-sms.phone_number
+      env: ELKS_PHONE_NUMBER
+      example: "+46701234567"
+  env:
+    - name: DRY_RUN
+      example: "false"
+      value: "{{46elks-sms.dry_run}}"
+    - name: RATE_LIMIT_SMS_PER_MINUTE
+      example: "10"
+      value: "{{46elks-sms.rate_limit_sms}}"
+    - name: RATE_LIMIT_QUERIES_PER_MINUTE
+      example: "60"
+      value: "{{46elks-sms.rate_limit_queries}}"
+  parameters:
+    type: object
+    properties:
+      dry_run:
+        type: string
+      rate_limit_sms:
+        type: string
+      rate_limit_queries:
+        type: string

--- a/servers/46elks-sms/tools.json
+++ b/servers/46elks-sms/tools.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "send_sms",
+    "description": "Send SMS message via 46elks Swedish telecommunications",
+    "arguments": [
+      {
+        "name": "to",
+        "type": "string",
+        "desc": "Recipient phone number with country code (e.g., +46XXXXXXXXX)"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "SMS message content (max 160 characters for single SMS)"
+      },
+      {
+        "name": "from",
+        "type": "string",
+        "desc": "Sender phone number or name (optional, uses default if not specified)"
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": "Test mode - verify request without sending actual SMS (optional)"
+      }
+    ]
+  },
+  {
+    "name": "get_sms_messages",
+    "description": "Retrieve SMS message history from 46elks",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "Maximum number of messages to retrieve (default: 10, max: 100)"
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "desc": "Filter messages by direction: inbound, outbound, or both (default: both)"
+      }
+    ]
+  },
+  {
+    "name": "check_sms_status",
+    "description": "Check delivery status and details of a sent SMS",
+    "arguments": [
+      {
+        "name": "message_id",
+        "type": "string",
+        "desc": "46elks message ID returned when SMS was sent"
+      }
+    ]
+  },
+  {
+    "name": "check_account_balance",
+    "description": "Check 46elks account balance and account information",
+    "arguments": []
+  },
+  {
+    "name": "estimate_sms_cost",
+    "description": "Estimate cost and message segments for SMS without sending it",
+    "arguments": [
+      {
+        "name": "to",
+        "type": "string",
+        "desc": "Recipient phone number with country code"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "SMS message content to estimate cost for"
+      }
+    ]
+  },
+  {
+    "name": "get_delivery_statistics",
+    "description": "Get SMS delivery statistics and success rates from recent messages",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "Number of recent messages to analyze (default: 50, max: 100)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** 46elks-sms
**Repository URL:** https://github.com/palhamel/46elks-mcp-server
**Brief Description:** Send SMS messages through Swedish 46elks telecommunications infrastructure. OWASP MCP Top 10 compliant with rate limiting, audit logging, and input validation.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues (SECURITY.md)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name 46elks-sms`
- [x] I have built the MCP Server using `task build -- --tools 46elks-sms`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Testing Instructions

46elks is a Swedish SMS telecom provider (https://46elks.com). Test credentials have been shared via the Google Form.

**To test without sending real SMS or incurring charges:**

1. Set `DRY_RUN=true` - validates API calls without sending actual SMS
2. Use `+46700000000` as recipient - this is 46elks' official test number (no SMS sent to mobile network, no charges)
3. Reference: https://46elks.se/docs/send-sms ("Can I test the API without cost?")

## Additional Context

- **6 MCP tools**: send_sms, get_sms_messages, check_sms_status, check_account_balance, estimate_sms_cost, get_delivery_statistics
- **Security**: OWASP MCP Top 10 compliant, rate limiting, audit logging, credential validation on startup
- **Docker image**: node:22-alpine, npm removed from production (0 HIGH vulnerabilities), non-root user, read-only filesystem
- **148 unit tests** with Vitest