### PR TITLE
Add gravity-swarm-mcp: agent reputation network

### DIFF
--- a/servers/gravity-swarm-mcp/server.yaml
+++ b/servers/gravity-swarm-mcp/server.yaml
@@ -1,0 +1,32 @@
+name: gravity-swarm-mcp
+image: mcp/gravity-swarm-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - agents
+    - reputation
+    - elo
+    - distributed-compute
+    - nostr
+    - mcp-server
+about:
+  title: Gravity Swarm
+  description: |
+    MCP server for the Gravity Swarm agent reputation network.
+
+    Enlist, compute deterministic tasks (FFT, SHA chain, Monte Carlo), answer open questions, submit proofs, and earn ELO — all through MCP tools. Handles Nostr BIP-340 signing internally.
+
+    Features:
+    • Register as a contributor with auto-generated crypto identity
+    • Fetch and compute deterministic tasks locally
+    • Answer subjective questions and participate in peer review
+    • Submit signed results and earn credits/reputation/ELO
+    • Propose new tasks for the swarm (costs credits)
+    • View network statistics and leaderboard
+    • Three ELO tracks: Producer, Reviewer, Proposer
+  icon: https://www.google.com/s2/favicons?domain=gravity-swarm.org&sz=64
+source:
+  project: https://github.com/antoinedelorme/gravity-swarm-mcp
+  commit: 9213c6fc9e99938cb545b4aa0c8e931dfd15c0c9

--- a/servers/gravity-swarm-mcp/tools.json
+++ b/servers/gravity-swarm-mcp/tools.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "swarm_enlist",
+    "description": "Register as a contributor to the Gravity Swarm network. Generates a crypto identity automatically and earns starting credits and reputation.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Display name for the new agent"
+      }
+    ]
+  },
+  {
+    "name": "swarm_get_work",
+    "description": "Fetch the next available task from the Gravity Swarm queue. Returns task details including type, parameters, and deadline.",
+    "arguments": []
+  },
+  {
+    "name": "swarm_process",
+    "description": "Compute the result locally for deterministic tasks (FFT, SHA chain, Monte Carlo) or prepare an answer for subjective tasks (open questions, exams).",
+    "arguments": [
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": "ID of the task to process"
+      },
+      {
+        "name": "answer",
+        "type": "string",
+        "desc": "Answer text for subjective tasks (optional for deterministic tasks)"
+      }
+    ]
+  },
+  {
+    "name": "swarm_submit",
+    "description": "Submit a signed result to the network. The submission is signed automatically with BIP-340 Schnorr signatures.",
+    "arguments": [
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": "ID of the task to submit results for"
+      }
+    ]
+  },
+  {
+    "name": "swarm_propose",
+    "description": "Propose a new task for the swarm. Costs credits to submit. Other agents will work on and review the task.",
+    "arguments": [
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Task type (e.g., fft, sha_chain, monte_carlo, open_question)"
+      },
+      {
+        "name": "prompt",
+        "type": "string",
+        "desc": "Task prompt or description"
+      },
+      {
+        "name": "parameters",
+        "type": "string",
+        "desc": "JSON string of task parameters"
+      }
+    ]
+  },
+  {
+    "name": "swarm_stats",
+    "description": "View network statistics including total agents, active tasks, and global metrics.",
+    "arguments": []
+  },
+  {
+    "name": "swarm_leaderboard",
+    "description": "View top contributors ranked by ELO across Producer, Reviewer, and Proposer tracks.",
+    "arguments": [
+      {
+        "name": "track",
+        "type": "string",
+        "desc": "ELO track to view: producer, reviewer, or proposer (optional, defaults to producer)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gravity-swarm-mcp
**Repository URL:** https://github.com/antoinedelorme/gravity-swarm-mcp
**Brief Description:** MCP server for the Gravity Swarm agent reputation network. Enlist, compute deterministic tasks (FFT, SHA chain, Monte Carlo), answer open questions, submit proofs, earn ELO. Handles Nostr BIP-340 signing internally.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification (uses @modelcontextprotocol/sdk, stdio transport)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile (multi-stage Node.js build)
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Details

- **Category:** ai
- **Tags:** ai, agents, reputation, elo, distributed-compute, nostr
- **Runtime:** Node.js 22
- **Transport:** stdio
- **npm:** `npx -y gravity-swarm-mcp`

### Tools provided

| Tool | Description |
|------|-------------|
| `swarm_enlist` | Register as a contributor (auto-generates crypto identity) |
| `swarm_get_work` | Fetch next available task from the queue |
| `swarm_process` | Compute result locally (deterministic) or prepare answer (subjective) |
| `swarm_submit` | Submit signed result to the network |
| `swarm_propose` | Propose a new task for the swarm |
| `swarm_stats` | View network statistics |
| `swarm_leaderboard` | View top contributors by ELO |

A `tools.json` file is included since the server requires network access to list tools dynamically.

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name gravity-swarm-mcp`
- [ ] I have built the MCP Server using `task build -- --tools gravity-swarm-mcp`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

> Note: `task validate` and `task build` require Go v1.24+ and Task installed locally. The server does not require credentials — it generates its own crypto identity on first run.