### PR TITLE
Add kube-lint-mcp server

### DIFF
--- a/servers/kube-lint-mcp/server.yaml
+++ b/servers/kube-lint-mcp/server.yaml
@@ -1,0 +1,44 @@
+name: kube-lint-mcp
+image: mcp/kube-lint-mcp
+type: server
+
+meta:
+  category: devops
+  tags:
+    - devops
+    - kubernetes
+    - helm
+    - fluxcd
+    - gitops
+    - validation
+
+about:
+  title: Kube Lint MCP
+  description: >-
+    Validate Kubernetes manifests, Helm charts, Kustomize overlays, and FluxCD
+    resources with dry-run checks against a live cluster. Includes offline
+    schema validation via kubeconform. Ships with kubectl, helm, flux, and
+    kubeconform — batteries included.
+  icon: https://raw.githubusercontent.com/sophotechlabs/kube-lint-mcp/main/icon.svg
+
+source:
+  project: https://github.com/sophotechlabs/kube-lint-mcp
+  commit: 8caf93c9ae63e18fff9bcf2a573683f6b634359c
+
+run:
+  command:
+    - --transport=stdio
+  volumes:
+    - "{{kube-lint-mcp.kubeconfig}}:/home/nonroot/.kube/config:ro"
+  user: nonroot
+
+config:
+  description: Mount your kubeconfig to enable cluster validation
+  parameters:
+    type: object
+    properties:
+      kubeconfig:
+        type: string
+        description: Path to your kubeconfig file (e.g. ~/.kube/config)
+    required:
+      - kubeconfig

--- a/servers/kube-lint-mcp/tools.json
+++ b/servers/kube-lint-mcp/tools.json
@@ -1,0 +1,128 @@
+[
+  {
+    "name": "list_kube_contexts",
+    "description": "List available kubectl contexts from the mounted kubeconfig",
+    "annotations": {
+      "title": "List Kube Contexts",
+      "readOnlyHint": true
+    },
+    "arguments": []
+  },
+  {
+    "name": "select_kube_context",
+    "description": "Select the Kubernetes context for all subsequent operations. Context is held in memory only — does not mutate kubeconfig.",
+    "annotations": {
+      "title": "Select Kube Context"
+    },
+    "arguments": [
+      {
+        "name": "context",
+        "type": "string",
+        "description": "Name of the kubectl context to use"
+      }
+    ]
+  },
+  {
+    "name": "flux_dryrun",
+    "description": "Validate FluxCD manifests with kubectl dry-run (client + server). Use before committing Flux YAML to prevent GitOps reconciliation failures.",
+    "annotations": {
+      "title": "Flux Dry-Run",
+      "readOnlyHint": true
+    },
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "description": "Path to YAML file or directory containing manifests"
+      }
+    ]
+  },
+  {
+    "name": "flux_check",
+    "description": "Run 'flux check' to verify Flux installation and components health.",
+    "annotations": {
+      "title": "Flux Check",
+      "readOnlyHint": true
+    },
+    "arguments": []
+  },
+  {
+    "name": "flux_status",
+    "description": "Get Flux reconciliation status for all resources across namespaces.",
+    "annotations": {
+      "title": "Flux Status",
+      "readOnlyHint": true
+    },
+    "arguments": []
+  },
+  {
+    "name": "kustomize_dryrun",
+    "description": "Validate Kustomize overlay by building and running kubectl dry-run (client + server).",
+    "annotations": {
+      "title": "Kustomize Dry-Run",
+      "readOnlyHint": true
+    },
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "description": "Path to directory containing kustomization.yaml"
+      }
+    ]
+  },
+  {
+    "name": "helm_dryrun",
+    "description": "Validate Helm chart by rendering and running kubectl dry-run (client + server).",
+    "annotations": {
+      "title": "Helm Dry-Run",
+      "readOnlyHint": true
+    },
+    "arguments": [
+      {
+        "name": "chart_path",
+        "type": "string",
+        "description": "Path to Helm chart directory"
+      },
+      {
+        "name": "values_file",
+        "type": "string",
+        "description": "Path to values file (optional)"
+      },
+      {
+        "name": "namespace",
+        "type": "string",
+        "description": "Namespace for rendering (optional)"
+      },
+      {
+        "name": "release_name",
+        "type": "string",
+        "description": "Release name for helm template (default: release-name)"
+      }
+    ]
+  },
+  {
+    "name": "kubeconform_validate",
+    "description": "Validate Kubernetes manifests against JSON schemas offline using kubeconform. No cluster connection needed.",
+    "annotations": {
+      "title": "Kubeconform Validate",
+      "readOnlyHint": true
+    },
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "description": "Path to YAML file or directory containing manifests"
+      },
+      {
+        "name": "kubernetes_version",
+        "type": "string",
+        "description": "Kubernetes version for schema lookup (e.g. 1.29.0). Default: master"
+      },
+      {
+        "name": "strict",
+        "type": "boolean",
+        "description": "Reject additional properties not in the schema (default: false)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds kube-lint-mcp — Kubernetes manifest, Helm chart, Kustomize overlay, and FluxCD validation server with offline kubeconform support.
  Batteries included (kubectl, helm, flux, kubeconform bundled).