### PR TITLE
Add Databricks SDK MCP Server

### DIFF
--- a/servers/databricks-sdk-mcp/server.yaml
+++ b/servers/databricks-sdk-mcp/server.yaml
@@ -1,0 +1,54 @@
+name: databricks-sdk-mcp
+image: mcp/databricks-sdk-mcp
+type: server
+
+meta:
+  category: cloud
+  tags:
+    - databricks
+    - cloud
+    - data
+    - sql
+    - mlops
+    - unity-catalog
+    - spark
+    - lakehouse
+
+about:
+  title: Databricks SDK MCP Server
+  description: >
+    Comprehensive SDK-first MCP server for Databricks providing 263 tools
+    across 28 service domains including Unity Catalog, SQL, Compute, Jobs,
+    Pipelines, Serving Endpoints, Vector Search, Apps, Lakebase, Dashboards,
+    Genie, Secrets, IAM, Experiments, and Delta Sharing. Includes 8 prompt
+    templates and role-based tool presets.
+  icon: https://avatars.githubusercontent.com/u/4998052?s=200&v=4
+
+source:
+  project: https://github.com/pramodbhatofficial/databricks-mcp-server
+  commit: bc922cba4847f60c0b0e6f66ac1b3b5f2dc5f8fc
+
+config:
+  description: Configure connection to your Databricks workspace
+  secrets:
+    - name: databricks-sdk-mcp.databricks_token
+      env: DATABRICKS_TOKEN
+      example: dapi1234567890abcdef
+  env:
+    - name: DATABRICKS_HOST
+      example: https://your-workspace.databricks.com
+      value: "{{databricks-sdk-mcp.databricks_host}}"
+    - name: DATABRICKS_MCP_TOOLS_INCLUDE
+      example: unity_catalog,sql,compute,jobs
+      value: "{{databricks-sdk-mcp.tools_include}}"
+  parameters:
+    type: object
+    properties:
+      databricks_host:
+        type: string
+        description: Your Databricks workspace URL
+      tools_include:
+        type: string
+        description: Comma-separated tool modules to load (leave empty for all 263 tools)
+    required:
+      - databricks_host

--- a/servers/databricks-sdk-mcp/tools.json
+++ b/servers/databricks-sdk-mcp/tools.json
@@ -1,0 +1,3903 @@
+[
+  {
+    "name": "databricks_list_apps",
+    "description": "List all Databricks Apps in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_app",
+    "description": "Get detailed information about a specific Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app. Must be a lowercase alphanumeric string"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_app",
+    "description": "Create a new Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app. Must contain only lowercase alphanumeric"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Optional human-readable description of the app's purpose."
+      }
+    ]
+  },
+  {
+    "name": "databricks_deploy_app",
+    "description": "Deploy source code to a Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app to deploy to."
+      },
+      {
+        "name": "source_code_path",
+        "type": "string",
+        "desc": "The workspace filesystem path of the source code"
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": "Deployment mode. \"SNAPSHOT\" (default) creates an immutable copy"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_app",
+    "description": "Delete a Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_start_app",
+    "description": "Start a Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app to start."
+      }
+    ]
+  },
+  {
+    "name": "databricks_stop_app",
+    "description": "Stop a running Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app to stop."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_app_deployments",
+    "description": "List all deployments for a Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app whose deployments to list."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_app_deployment",
+    "description": "Get details of a specific app deployment.",
+    "arguments": [
+      {
+        "name": "app_name",
+        "type": "string",
+        "desc": "The name of the app."
+      },
+      {
+        "name": "deployment_id",
+        "type": "string",
+        "desc": "The unique identifier of the deployment to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_app_environment",
+    "description": "Get the environment configuration for a Databricks App.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the app whose environment to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_execution_context",
+    "description": "Create an execution context on a running cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of a running cluster."
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Programming language for the context. One of"
+      }
+    ]
+  },
+  {
+    "name": "databricks_execute_command",
+    "description": "Execute a command in an existing execution context.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster."
+      },
+      {
+        "name": "context_id",
+        "type": "string",
+        "desc": "The execution context ID returned by"
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Programming language of the command. One of"
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": "The code to execute (e.g. \"print('hello')\" for"
+      }
+    ]
+  },
+  {
+    "name": "databricks_command_status",
+    "description": "Check the status and results of an executed command.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster."
+      },
+      {
+        "name": "context_id",
+        "type": "string",
+        "desc": "The execution context ID."
+      },
+      {
+        "name": "command_id",
+        "type": "string",
+        "desc": "The command ID returned by databricks_execute_command."
+      }
+    ]
+  },
+  {
+    "name": "databricks_destroy_execution_context",
+    "description": "Destroy an execution context on a cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster."
+      },
+      {
+        "name": "context_id",
+        "type": "string",
+        "desc": "The execution context ID to destroy."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_clusters",
+    "description": "List all compute clusters in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_cluster",
+    "description": "Get detailed information about a specific compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_cluster",
+    "description": "Create a new compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_name",
+        "type": "string",
+        "desc": "Display name for the cluster."
+      },
+      {
+        "name": "spark_version",
+        "type": "string",
+        "desc": "Spark runtime version string"
+      },
+      {
+        "name": "node_type_id",
+        "type": "string",
+        "desc": "Instance type for worker nodes"
+      },
+      {
+        "name": "num_workers",
+        "type": "integer",
+        "desc": "Number of worker nodes for a fixed-size cluster."
+      },
+      {
+        "name": "autoscale_min",
+        "type": "integer",
+        "desc": "Minimum number of workers when autoscaling is enabled."
+      },
+      {
+        "name": "autoscale_max",
+        "type": "integer",
+        "desc": "Maximum number of workers when autoscaling is enabled."
+      }
+    ]
+  },
+  {
+    "name": "databricks_start_cluster",
+    "description": "Start a terminated compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to start."
+      }
+    ]
+  },
+  {
+    "name": "databricks_terminate_cluster",
+    "description": "Terminate a running compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to terminate."
+      }
+    ]
+  },
+  {
+    "name": "databricks_restart_cluster",
+    "description": "Restart a running compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to restart."
+      }
+    ]
+  },
+  {
+    "name": "databricks_resize_cluster",
+    "description": "Resize a running cluster to a different number of workers.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to resize."
+      },
+      {
+        "name": "num_workers",
+        "type": "integer",
+        "desc": "The new number of worker nodes. Use 0 for a"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_instance_pools",
+    "description": "List all instance pools in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_instance_pool",
+    "description": "Get detailed information about a specific instance pool.",
+    "arguments": [
+      {
+        "name": "instance_pool_id",
+        "type": "string",
+        "desc": "The unique identifier of the instance pool."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_cluster_policies",
+    "description": "List all cluster policies in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_edit_cluster",
+    "description": "Edit the configuration of an existing compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to edit."
+      },
+      {
+        "name": "cluster_name",
+        "type": "string",
+        "desc": "New display name for the cluster."
+      },
+      {
+        "name": "spark_version",
+        "type": "string",
+        "desc": "Spark runtime version string"
+      },
+      {
+        "name": "node_type_id",
+        "type": "string",
+        "desc": "Instance type for worker nodes"
+      },
+      {
+        "name": "num_workers",
+        "type": "integer",
+        "desc": "Number of worker nodes. Use 0 for a single-node"
+      }
+    ]
+  },
+  {
+    "name": "databricks_pin_cluster",
+    "description": "Pin a compute cluster to prevent it from being auto-deleted.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to pin."
+      }
+    ]
+  },
+  {
+    "name": "databricks_unpin_cluster",
+    "description": "Unpin a compute cluster, allowing it to be auto-deleted.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster to unpin."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_cluster_events",
+    "description": "List recent events for a compute cluster.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "The unique identifier of the cluster."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of events to return. Defaults to 50."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_node_types",
+    "description": "List all available node types for compute clusters.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_list_spark_versions",
+    "description": "List all available Spark runtime versions.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_instance_pool",
+    "description": "Create a new instance pool.",
+    "arguments": [
+      {
+        "name": "instance_pool_name",
+        "type": "string",
+        "desc": "Display name for the instance pool."
+      },
+      {
+        "name": "node_type_id",
+        "type": "string",
+        "desc": "Instance type for pool instances"
+      },
+      {
+        "name": "min_idle_instances",
+        "type": "integer",
+        "desc": "Minimum number of idle instances to maintain"
+      },
+      {
+        "name": "max_capacity",
+        "type": "integer",
+        "desc": "Maximum total instances the pool can hold (idle +"
+      },
+      {
+        "name": "idle_instance_autotermination_minutes",
+        "type": "integer",
+        "desc": "Minutes before idle instances"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_instance_pool",
+    "description": "Delete an instance pool.",
+    "arguments": [
+      {
+        "name": "instance_pool_id",
+        "type": "string",
+        "desc": "The unique identifier of the instance pool"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_connections",
+    "description": "List all external connections in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_connection",
+    "description": "Get detailed information about a specific connection.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the connection to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_connection",
+    "description": "Create a new external connection.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Unique name for the connection within the metastore."
+      },
+      {
+        "name": "connection_type",
+        "type": "string",
+        "desc": "The type of external system to connect to."
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": "Hostname or IP address of the external system."
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": "Port number for the connection (default 443)."
+      },
+      {
+        "name": "options_json",
+        "type": "string",
+        "desc": "Optional JSON string of additional key-value options."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the connection."
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_connection",
+    "description": "Update an existing connection's options or name.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Current name of the connection to update."
+      },
+      {
+        "name": "options_json",
+        "type": "string",
+        "desc": "Optional JSON string of key-value options to set."
+      },
+      {
+        "name": "new_name",
+        "type": "string",
+        "desc": "Optional new name for the connection. Leave empty to"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_connection",
+    "description": "Delete an external connection.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the connection to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_dashboards",
+    "description": "List all Lakeview dashboards in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_dashboard",
+    "description": "Get detailed information about a specific Lakeview dashboard.",
+    "arguments": [
+      {
+        "name": "dashboard_id",
+        "type": "string",
+        "desc": "The UUID identifying the dashboard"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_dashboard",
+    "description": "Create a new Lakeview dashboard.",
+    "arguments": [
+      {
+        "name": "display_name",
+        "type": "string",
+        "desc": "The human-readable name for the dashboard"
+      },
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "The ID of the SQL warehouse to use for executing"
+      },
+      {
+        "name": "serialized_dashboard",
+        "type": "string",
+        "desc": "Optional JSON string containing the dashboard"
+      },
+      {
+        "name": "parent_path",
+        "type": "string",
+        "desc": "Optional workspace folder path where the dashboard"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_dashboard",
+    "description": "Update an existing Lakeview dashboard draft.",
+    "arguments": [
+      {
+        "name": "dashboard_id",
+        "type": "string",
+        "desc": "The UUID identifying the dashboard to update."
+      },
+      {
+        "name": "display_name",
+        "type": "string",
+        "desc": "New display name for the dashboard. If empty,"
+      },
+      {
+        "name": "serialized_dashboard",
+        "type": "string",
+        "desc": "New JSON string containing the updated"
+      }
+    ]
+  },
+  {
+    "name": "databricks_trash_dashboard",
+    "description": "Move a Lakeview dashboard to the trash.",
+    "arguments": [
+      {
+        "name": "dashboard_id",
+        "type": "string",
+        "desc": "The UUID identifying the dashboard to trash."
+      }
+    ]
+  },
+  {
+    "name": "databricks_publish_dashboard",
+    "description": "Publish a Lakeview dashboard draft.",
+    "arguments": [
+      {
+        "name": "dashboard_id",
+        "type": "string",
+        "desc": "The UUID identifying the dashboard to publish."
+      },
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "Optional warehouse ID to override the warehouse set"
+      },
+      {
+        "name": "embed_credentials",
+        "type": "boolean",
+        "desc": "If True (default), the publisher's credentials"
+      }
+    ]
+  },
+  {
+    "name": "databricks_unpublish_dashboard",
+    "description": "Unpublish a Lakeview dashboard.",
+    "arguments": [
+      {
+        "name": "dashboard_id",
+        "type": "string",
+        "desc": "The UUID identifying the dashboard to unpublish."
+      }
+    ]
+  },
+  {
+    "name": "databricks_migrate_dashboard",
+    "description": "Migrate a classic SQL dashboard to Lakeview format.",
+    "arguments": [
+      {
+        "name": "source_dashboard_id",
+        "type": "string",
+        "desc": "The UUID of the classic SQL dashboard to"
+      },
+      {
+        "name": "display_name",
+        "type": "string",
+        "desc": "Optional display name for the new Lakeview dashboard."
+      },
+      {
+        "name": "parent_path",
+        "type": "string",
+        "desc": "Optional workspace folder path for the new dashboard."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_published_dashboard",
+    "description": "Get the published version of a Lakeview dashboard.",
+    "arguments": [
+      {
+        "name": "dashboard_id",
+        "type": "string",
+        "desc": "The UUID identifying the dashboard whose published"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_database_instances",
+    "description": "List all Lakebase PostgreSQL database instances in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_database_instance",
+    "description": "Get detailed information about a specific Lakebase database instance.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the database instance to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_database_instance",
+    "description": "Create a new Lakebase PostgreSQL database instance.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name for the new database instance. Must be unique"
+      },
+      {
+        "name": "capacity",
+        "type": "integer",
+        "desc": "The compute capacity for the instance. Defaults to 1"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_database_instance",
+    "description": "Delete a Lakebase PostgreSQL database instance.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the database instance to delete."
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "If True, also delete any descendant instances. Defaults to"
+      },
+      {
+        "name": "purge",
+        "type": "boolean",
+        "desc": "If True (default), hard delete the instance permanently."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_database_catalogs",
+    "description": "List all catalogs in a Lakebase database instance.",
+    "arguments": [
+      {
+        "name": "instance_name",
+        "type": "string",
+        "desc": "The name of the database instance whose catalogs"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_database_catalog",
+    "description": "Create a new catalog in a Lakebase database instance.",
+    "arguments": [
+      {
+        "name": "instance_name",
+        "type": "string",
+        "desc": "The name of the database instance in which to"
+      },
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "The name for the new catalog. Must be unique within"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_database_tables",
+    "description": "List tables in a Lakebase database schema.",
+    "arguments": [
+      {
+        "name": "instance_name",
+        "type": "string",
+        "desc": "The name of the database instance."
+      },
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "The name of the catalog containing the tables."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "The schema to list tables from. Defaults to \"public\"."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_database_table",
+    "description": "Create a new table in a Lakebase database schema.",
+    "arguments": [
+      {
+        "name": "instance_name",
+        "type": "string",
+        "desc": "The name of the database instance."
+      },
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "The name of the catalog to create the table in."
+      },
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "The name for the new table."
+      },
+      {
+        "name": "columns_json",
+        "type": "string",
+        "desc": "A JSON string representing the column definitions."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "The schema to create the table in. Defaults to \"public\"."
+      }
+    ]
+  },
+  {
+    "name": "databricks_generate_database_credential",
+    "description": "Generate temporary PostgreSQL credentials for Lakebase instances.",
+    "arguments": [
+      {
+        "name": "instance_names",
+        "type": "string",
+        "desc": "Comma-separated list of database instance names to"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_database_roles",
+    "description": "List all roles for a Lakebase database instance.",
+    "arguments": [
+      {
+        "name": "instance_name",
+        "type": "string",
+        "desc": "The name of the database instance whose roles to list."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_experiments",
+    "description": "List MLflow experiments in the workspace.",
+    "arguments": [
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of experiments to return (default 25)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_experiment",
+    "description": "Get detailed information about a specific MLflow experiment.",
+    "arguments": [
+      {
+        "name": "experiment_id",
+        "type": "string",
+        "desc": "The numeric ID of the experiment to retrieve"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_experiment",
+    "description": "Create a new MLflow experiment.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Unique name for the experiment. Workspace experiments"
+      },
+      {
+        "name": "artifact_location",
+        "type": "string",
+        "desc": "Optional root artifact URI for the experiment."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_experiment",
+    "description": "Mark an MLflow experiment as deleted (soft delete).",
+    "arguments": [
+      {
+        "name": "experiment_id",
+        "type": "string",
+        "desc": "The numeric ID of the experiment to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_search_runs",
+    "description": "Search for MLflow runs across one or more experiments.",
+    "arguments": [
+      {
+        "name": "experiment_ids",
+        "type": "string",
+        "desc": "Comma-separated list of experiment IDs to search"
+      },
+      {
+        "name": "filter_string",
+        "type": "string",
+        "desc": "Optional MLflow filter expression. Examples:"
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of runs to return (default 25)."
+      },
+      {
+        "name": "order_by",
+        "type": "string",
+        "desc": "Optional comma-separated list of columns to order by."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_run",
+    "description": "Get detailed information about a specific MLflow run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": "The UUID of the run to retrieve (e.g."
+      }
+    ]
+  },
+  {
+    "name": "databricks_log_metric",
+    "description": "Log a metric value for an MLflow run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": "The UUID of the run to log the metric to."
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "Name of the metric (e.g. \"rmse\", \"accuracy\", \"loss\")."
+      },
+      {
+        "name": "value",
+        "type": "number",
+        "desc": "Numeric value of the metric at this step."
+      },
+      {
+        "name": "step",
+        "type": "integer",
+        "desc": "Optional integer step number for tracking metrics over time."
+      }
+    ]
+  },
+  {
+    "name": "databricks_log_param",
+    "description": "Log a parameter for an MLflow run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": "The UUID of the run to log the parameter to."
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "Name of the parameter (e.g. \"learning_rate\", \"batch_size\","
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": "String value of the parameter. Numeric values should be"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_run",
+    "description": "Create a new MLflow run within an experiment.",
+    "arguments": [
+      {
+        "name": "experiment_id",
+        "type": "string",
+        "desc": "The numeric ID of the experiment to create the"
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": "Optional display name for the run. If empty, MLflow"
+      },
+      {
+        "name": "start_time",
+        "type": "integer",
+        "desc": "Optional Unix timestamp in milliseconds for the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_run",
+    "description": "Update the status of an MLflow run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": "The UUID of the run to update."
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "New status for the run. Valid values: \"RUNNING\","
+      },
+      {
+        "name": "end_time",
+        "type": "integer",
+        "desc": "Optional Unix timestamp in milliseconds for the run"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_run",
+    "description": "Mark an MLflow run as deleted (soft delete).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": "The UUID of the run to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_restore_experiment",
+    "description": "Restore a previously deleted MLflow experiment.",
+    "arguments": [
+      {
+        "name": "experiment_id",
+        "type": "string",
+        "desc": "The numeric ID of the experiment to restore."
+      }
+    ]
+  },
+  {
+    "name": "databricks_search_experiments",
+    "description": "Search for MLflow experiments using filter expressions.",
+    "arguments": [
+      {
+        "name": "filter_string",
+        "type": "string",
+        "desc": "Optional filter expression. Examples:"
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of experiments to return"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_artifacts",
+    "description": "List artifacts associated with an MLflow run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": "The UUID of the run whose artifacts to list."
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Optional relative path within the artifact directory."
+      }
+    ]
+  },
+  {
+    "name": "databricks_dbfs_list",
+    "description": "List files and directories at a DBFS path.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute DBFS path to list (e.g. \"dbfs:/mnt/data\" or \"/mnt/data\")."
+      }
+    ]
+  },
+  {
+    "name": "databricks_dbfs_get_status",
+    "description": "Get the status and metadata of a single DBFS path.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute DBFS path to check (e.g. \"dbfs:/mnt/data/file.csv\")."
+      }
+    ]
+  },
+  {
+    "name": "databricks_dbfs_mkdirs",
+    "description": "Create a directory in DBFS, including any necessary parent directories.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute DBFS path of the directory to create"
+      }
+    ]
+  },
+  {
+    "name": "databricks_dbfs_delete",
+    "description": "Delete a file or directory from DBFS.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute DBFS path to delete (e.g. \"dbfs:/mnt/data/old_file.csv\")."
+      },
+      {
+        "name": "recursive",
+        "type": "boolean",
+        "desc": "If True, recursively delete all files and subdirectories."
+      }
+    ]
+  },
+  {
+    "name": "databricks_dbfs_upload",
+    "description": "Upload a file to DBFS from base64-encoded content.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute DBFS destination path (e.g. \"dbfs:/mnt/data/upload.csv\")."
+      },
+      {
+        "name": "contents_base64",
+        "type": "string",
+        "desc": "The file content encoded as a base64 string."
+      },
+      {
+        "name": "overwrite",
+        "type": "boolean",
+        "desc": "If True, overwrite any existing file at the path."
+      }
+    ]
+  },
+  {
+    "name": "databricks_dbfs_download",
+    "description": "Download a file from DBFS and return its content as base64.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute DBFS path of the file to download"
+      }
+    ]
+  },
+  {
+    "name": "databricks_files_list_directory",
+    "description": "List files and directories within a Unity Catalog Volume path.",
+    "arguments": [
+      {
+        "name": "directory_path",
+        "type": "string",
+        "desc": "Volume-relative directory path"
+      }
+    ]
+  },
+  {
+    "name": "databricks_files_get_metadata",
+    "description": "Get metadata for a file in a Unity Catalog Volume.",
+    "arguments": [
+      {
+        "name": "file_path",
+        "type": "string",
+        "desc": "Volume-relative file path"
+      }
+    ]
+  },
+  {
+    "name": "databricks_files_create_directory",
+    "description": "Create a directory in a Unity Catalog Volume.",
+    "arguments": [
+      {
+        "name": "directory_path",
+        "type": "string",
+        "desc": "Volume-relative directory path to create"
+      }
+    ]
+  },
+  {
+    "name": "databricks_files_delete",
+    "description": "Delete a file from a Unity Catalog Volume.",
+    "arguments": [
+      {
+        "name": "file_path",
+        "type": "string",
+        "desc": "Volume-relative file path to delete"
+      }
+    ]
+  },
+  {
+    "name": "databricks_files_upload",
+    "description": "Upload a file to a Unity Catalog Volume from base64-encoded content.",
+    "arguments": [
+      {
+        "name": "file_path",
+        "type": "string",
+        "desc": "Volume-relative destination path"
+      },
+      {
+        "name": "contents_base64",
+        "type": "string",
+        "desc": "The file content encoded as a base64 string."
+      }
+    ]
+  },
+  {
+    "name": "databricks_files_download",
+    "description": "Download a file from a Unity Catalog Volume as base64-encoded content.",
+    "arguments": [
+      {
+        "name": "file_path",
+        "type": "string",
+        "desc": "Volume-relative file path to download"
+      }
+    ]
+  },
+  {
+    "name": "databricks_genie_start_conversation",
+    "description": "Start a new Genie AI/BI conversation with a question.",
+    "arguments": [
+      {
+        "name": "space_id",
+        "type": "string",
+        "desc": "The ID of the Genie Space to start the conversation in."
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "The natural language question to ask (e.g., \"What were"
+      }
+    ]
+  },
+  {
+    "name": "databricks_genie_create_message",
+    "description": "Send a follow-up message in an existing Genie conversation.",
+    "arguments": [
+      {
+        "name": "space_id",
+        "type": "string",
+        "desc": "The ID of the Genie Space containing the conversation."
+      },
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "The ID of the existing conversation to continue."
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "The follow-up question or refinement (e.g., \"Break that"
+      }
+    ]
+  },
+  {
+    "name": "databricks_genie_get_message",
+    "description": "Get a Genie message and its response.",
+    "arguments": [
+      {
+        "name": "space_id",
+        "type": "string",
+        "desc": "The ID of the Genie Space containing the conversation."
+      },
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "The ID of the conversation containing the message."
+      },
+      {
+        "name": "message_id",
+        "type": "string",
+        "desc": "The ID of the specific message to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_genie_get_message_query_result",
+    "description": "Get the SQL query result from a Genie message.",
+    "arguments": [
+      {
+        "name": "space_id",
+        "type": "string",
+        "desc": "The ID of the Genie Space containing the conversation."
+      },
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "The ID of the conversation containing the message."
+      },
+      {
+        "name": "message_id",
+        "type": "string",
+        "desc": "The ID of the message whose query result to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_genie_execute_message_query",
+    "description": "Re-execute the SQL query from a Genie message.",
+    "arguments": [
+      {
+        "name": "space_id",
+        "type": "string",
+        "desc": "The ID of the Genie Space containing the conversation."
+      },
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "The ID of the conversation containing the message."
+      },
+      {
+        "name": "message_id",
+        "type": "string",
+        "desc": "The ID of the message whose query to re-execute."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_git_credentials",
+    "description": "List all Git credentials for the current user.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_git_credential",
+    "description": "Get detailed information about a specific Git credential.",
+    "arguments": [
+      {
+        "name": "credential_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the Git credential."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_git_credential",
+    "description": "Create a new Git credential for the current user.",
+    "arguments": [
+      {
+        "name": "git_provider",
+        "type": "string",
+        "desc": "The Git provider name. Common values: \"gitHub\","
+      },
+      {
+        "name": "git_username",
+        "type": "string",
+        "desc": "The Git username for authentication."
+      },
+      {
+        "name": "personal_access_token",
+        "type": "string",
+        "desc": "A personal access token or app password"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_git_credential",
+    "description": "Update an existing Git credential.",
+    "arguments": [
+      {
+        "name": "credential_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the credential"
+      },
+      {
+        "name": "git_provider",
+        "type": "string",
+        "desc": "The Git provider name (e.g. \"gitHub\", \"gitLab\")."
+      },
+      {
+        "name": "git_username",
+        "type": "string",
+        "desc": "The new Git username."
+      },
+      {
+        "name": "personal_access_token",
+        "type": "string",
+        "desc": "The new personal access token. Stored"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_git_credential",
+    "description": "Delete a Git credential.",
+    "arguments": [
+      {
+        "name": "credential_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the credential"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_global_init_scripts",
+    "description": "List all global init scripts in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_global_init_script",
+    "description": "Get detailed information about a specific global init script.",
+    "arguments": [
+      {
+        "name": "script_id",
+        "type": "string",
+        "desc": "The unique identifier of the global init script."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_global_init_script",
+    "description": "Create a new global init script.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Display name for the init script. Must be unique within"
+      },
+      {
+        "name": "script",
+        "type": "string",
+        "desc": "The script content, base64-encoded. For example, a bash"
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Whether the script should be active. Defaults to False"
+      },
+      {
+        "name": "position",
+        "type": "integer",
+        "desc": "Execution order position (0-based). Lower positions run"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_global_init_script",
+    "description": "Update an existing global init script.",
+    "arguments": [
+      {
+        "name": "script_id",
+        "type": "string",
+        "desc": "The unique identifier of the script to update."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "New display name for the script."
+      },
+      {
+        "name": "script",
+        "type": "string",
+        "desc": "New script content, base64-encoded."
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Whether the script should be active after the update."
+      },
+      {
+        "name": "position",
+        "type": "integer",
+        "desc": "New execution order position (0-based)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_global_init_script",
+    "description": "Delete a global init script from the workspace.",
+    "arguments": [
+      {
+        "name": "script_id",
+        "type": "string",
+        "desc": "The unique identifier of the script to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_grants",
+    "description": "Get the permissions granted on a Unity Catalog securable.",
+    "arguments": [
+      {
+        "name": "securable_type",
+        "type": "string",
+        "desc": "The type of the securable object. Must be one of:"
+      },
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "The full name of the securable. Format depends on type:"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_effective_grants",
+    "description": "Get the effective (inherited + direct) permissions on a securable.",
+    "arguments": [
+      {
+        "name": "securable_type",
+        "type": "string",
+        "desc": "The type of the securable object. Must be one of:"
+      },
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "The full name of the securable. Format depends on type:"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_grants",
+    "description": "Update (grant or revoke) permissions on a Unity Catalog securable.",
+    "arguments": [
+      {
+        "name": "securable_type",
+        "type": "string",
+        "desc": "The type of the securable object. Must be one of:"
+      },
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "The full name of the securable. Format depends on type."
+      },
+      {
+        "name": "changes_json",
+        "type": "string",
+        "desc": "A JSON string representing a list of permission changes."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_users",
+    "description": "List workspace users with optional SCIM filtering.",
+    "arguments": [
+      {
+        "name": "filter_str",
+        "type": "string",
+        "desc": "Optional SCIM filter expression to narrow results."
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "desc": "Maximum number of users to return (default 100)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_user",
+    "description": "Get detailed information about a specific user.",
+    "arguments": [
+      {
+        "name": "user_id",
+        "type": "string",
+        "desc": "The numeric ID of the user to retrieve (as returned by"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_user",
+    "description": "Create a new user in the workspace.",
+    "arguments": [
+      {
+        "name": "user_name",
+        "type": "string",
+        "desc": "The user's email address, used as their login identity."
+      },
+      {
+        "name": "display_name",
+        "type": "string",
+        "desc": "Optional human-readable display name. Defaults to the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_user",
+    "description": "Delete a user from the workspace.",
+    "arguments": [
+      {
+        "name": "user_id",
+        "type": "string",
+        "desc": "The numeric ID of the user to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_groups",
+    "description": "List workspace groups with optional SCIM filtering.",
+    "arguments": [
+      {
+        "name": "filter_str",
+        "type": "string",
+        "desc": "Optional SCIM filter expression to narrow results."
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "desc": "Maximum number of groups to return (default 100)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_group",
+    "description": "Create a new group in the workspace.",
+    "arguments": [
+      {
+        "name": "display_name",
+        "type": "string",
+        "desc": "The display name for the new group. Must be unique"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_group",
+    "description": "Delete a group from the workspace.",
+    "arguments": [
+      {
+        "name": "group_id",
+        "type": "string",
+        "desc": "The numeric ID of the group to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_service_principals",
+    "description": "List service principals in the workspace with optional SCIM filtering.",
+    "arguments": [
+      {
+        "name": "filter_str",
+        "type": "string",
+        "desc": "Optional SCIM filter expression to narrow results."
+      },
+      {
+        "name": "count",
+        "type": "integer",
+        "desc": "Maximum number of service principals to return (default 100)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_service_principal",
+    "description": "Create a new service principal in the workspace.",
+    "arguments": [
+      {
+        "name": "display_name",
+        "type": "string",
+        "desc": "A human-readable name for the service principal."
+      },
+      {
+        "name": "application_id",
+        "type": "string",
+        "desc": "Optional UUID for the Azure AD application associated"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_permission_levels",
+    "description": "Get the permission levels available for a workspace object.",
+    "arguments": [
+      {
+        "name": "object_type",
+        "type": "string",
+        "desc": "The type of object to query permission levels for."
+      },
+      {
+        "name": "object_id",
+        "type": "string",
+        "desc": "The ID of the specific object to query permission"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_current_user",
+    "description": "Get information about the currently authenticated user.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_group",
+    "description": "Get detailed information about a specific group.",
+    "arguments": [
+      {
+        "name": "group_id",
+        "type": "string",
+        "desc": "The numeric ID of the group to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_service_principal",
+    "description": "Get detailed information about a specific service principal.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The numeric ID of the service principal to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_service_principal",
+    "description": "Delete a service principal from the workspace.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The numeric ID of the service principal to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_permissions",
+    "description": "Get the access control list (ACL) for a workspace object.",
+    "arguments": [
+      {
+        "name": "object_type",
+        "type": "string",
+        "desc": "The type of object to query permissions for."
+      },
+      {
+        "name": "object_id",
+        "type": "string",
+        "desc": "The ID of the specific object. Format varies by"
+      }
+    ]
+  },
+  {
+    "name": "databricks_set_permissions",
+    "description": "Set permissions on a workspace object.",
+    "arguments": [
+      {
+        "name": "object_type",
+        "type": "string",
+        "desc": "The type of object to set permissions on."
+      },
+      {
+        "name": "object_id",
+        "type": "string",
+        "desc": "The ID of the specific object. Format varies by"
+      },
+      {
+        "name": "access_control_list",
+        "type": "string",
+        "desc": "JSON string containing an array of access"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_jobs",
+    "description": "List jobs in the workspace.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of jobs to return. Must be between 1 and 100."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Optional filter to return only jobs whose name contains this"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_job",
+    "description": "Get detailed information about a specific job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the job."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_job",
+    "description": "Create a new job with a single task.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Human-readable name for the job. Does not need to be unique."
+      },
+      {
+        "name": "task_key",
+        "type": "string",
+        "desc": "Unique key for the task within this job. Used to identify"
+      },
+      {
+        "name": "notebook_path",
+        "type": "string",
+        "desc": "Workspace path to the notebook to run (e.g."
+      },
+      {
+        "name": "python_file",
+        "type": "string",
+        "desc": "Path to a Python file in DBFS, workspace, or cloud storage"
+      },
+      {
+        "name": "cluster_id",
+        "type": "string",
+        "desc": "ID of an existing all-purpose cluster to run the task on."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_job",
+    "description": "Delete a job and all its associated runs.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the job to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_run_job",
+    "description": "Trigger a new run of an existing job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the job to run."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_runs",
+    "description": "List job runs, optionally filtered by job ID.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "integer",
+        "desc": "Filter runs to this specific job. If 0 or omitted, returns"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of runs to return. Must be between 1 and 100."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_run",
+    "description": "Get detailed information about a specific job run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the run."
+      }
+    ]
+  },
+  {
+    "name": "databricks_cancel_run",
+    "description": "Cancel an active job run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the run to cancel."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_run_output",
+    "description": "Get the output of a completed job run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the run."
+      }
+    ]
+  },
+  {
+    "name": "databricks_export_run",
+    "description": "Export the content of a job run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the run to export."
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_job",
+    "description": "Update the settings of an existing job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the job to update."
+      },
+      {
+        "name": "new_settings",
+        "type": "string",
+        "desc": "JSON string containing the new job settings."
+      }
+    ]
+  },
+  {
+    "name": "databricks_cancel_all_runs",
+    "description": "Cancel all active runs of a job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the job whose runs"
+      }
+    ]
+  },
+  {
+    "name": "databricks_repair_run",
+    "description": "Repair a failed job run by re-running specific tasks.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "integer",
+        "desc": "The unique numeric identifier of the run to repair."
+      },
+      {
+        "name": "rerun_tasks",
+        "type": "string",
+        "desc": "Comma-separated list of task keys to re-run"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_metastores",
+    "description": "List all Unity Catalog metastores accessible to the caller.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_metastore",
+    "description": "Get detailed information about a specific metastore.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier (UUID) of the metastore."
+      }
+    ]
+  },
+  {
+    "name": "databricks_current_metastore",
+    "description": "Get the metastore assigned to the current workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_metastore_summary",
+    "description": "Get a summary of the metastore assigned to the current workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_metastore",
+    "description": "Create a new Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new metastore. Must be unique within the account."
+      },
+      {
+        "name": "storage_root",
+        "type": "string",
+        "desc": "Cloud storage root URL for the metastore's managed data"
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "Optional cloud region for the metastore (e.g. \"us-east-1\")."
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_metastore",
+    "description": "Update properties of an existing metastore.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier (UUID) of the metastore to update."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Optional new name for the metastore."
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "desc": "Optional new owner of the metastore (user or group name)."
+      },
+      {
+        "name": "storage_root_credential_id",
+        "type": "string",
+        "desc": "Optional ID of the storage credential"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_metastore",
+    "description": "Delete a Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier (UUID) of the metastore to delete."
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "If True, forcibly delete the metastore and all its contents."
+      }
+    ]
+  },
+  {
+    "name": "databricks_assign_metastore",
+    "description": "Assign a metastore to a workspace.",
+    "arguments": [
+      {
+        "name": "workspace_id",
+        "type": "integer",
+        "desc": "The numeric ID of the Databricks workspace."
+      },
+      {
+        "name": "metastore_id",
+        "type": "string",
+        "desc": "The unique identifier (UUID) of the metastore to assign."
+      },
+      {
+        "name": "default_catalog_name",
+        "type": "string",
+        "desc": "The name of the default catalog to use in the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_online_table",
+    "description": "Create a new online table backed by a Delta table.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Full three-level name for the online table"
+      },
+      {
+        "name": "source_table_full_name",
+        "type": "string",
+        "desc": "Full three-level name of the source Delta table"
+      },
+      {
+        "name": "primary_key_columns_json",
+        "type": "string",
+        "desc": "JSON array of column names that form the"
+      },
+      {
+        "name": "run_triggered",
+        "type": "boolean",
+        "desc": "If True, use triggered (manual) sync mode instead of"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_online_table",
+    "description": "Get detailed information about a specific online table.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Full three-level name of the online table"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_online_table",
+    "description": "Delete an online table.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Full three-level name of the online table to delete"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_pipelines",
+    "description": "List DLT pipelines in the workspace.",
+    "arguments": [
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of pipelines to return. Defaults to 25."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_pipeline",
+    "description": "Get detailed information about a specific DLT pipeline.",
+    "arguments": [
+      {
+        "name": "pipeline_id",
+        "type": "string",
+        "desc": "The unique identifier of the pipeline (UUID format)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_pipeline",
+    "description": "Create a new DLT pipeline.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Human-readable name for the pipeline."
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target schema name where output tables are created. For Unity"
+      },
+      {
+        "name": "catalog",
+        "type": "string",
+        "desc": "Unity Catalog catalog name. When set, the pipeline publishes"
+      },
+      {
+        "name": "notebook_path",
+        "type": "string",
+        "desc": "Workspace path to the notebook containing DLT"
+      },
+      {
+        "name": "continuous",
+        "type": "boolean",
+        "desc": "If True, the pipeline runs continuously in streaming mode,"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_pipeline",
+    "description": "Update an existing DLT pipeline configuration.",
+    "arguments": [
+      {
+        "name": "pipeline_id",
+        "type": "string",
+        "desc": "The unique identifier of the pipeline to update."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "New name for the pipeline. Leave empty to keep the current name."
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "New target schema. Leave empty to keep the current target."
+      },
+      {
+        "name": "catalog",
+        "type": "string",
+        "desc": "New Unity Catalog catalog. Leave empty to keep the current catalog."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_pipeline",
+    "description": "Delete a DLT pipeline.",
+    "arguments": [
+      {
+        "name": "pipeline_id",
+        "type": "string",
+        "desc": "The unique identifier of the pipeline to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_start_pipeline",
+    "description": "Start a pipeline update (data refresh).",
+    "arguments": [
+      {
+        "name": "pipeline_id",
+        "type": "string",
+        "desc": "The unique identifier of the pipeline to start."
+      },
+      {
+        "name": "full_refresh",
+        "type": "boolean",
+        "desc": "If True, reprocesses all data from scratch, dropping and"
+      }
+    ]
+  },
+  {
+    "name": "databricks_stop_pipeline",
+    "description": "Stop a running pipeline.",
+    "arguments": [
+      {
+        "name": "pipeline_id",
+        "type": "string",
+        "desc": "The unique identifier of the pipeline to stop."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_pipeline_events",
+    "description": "List recent events for a DLT pipeline.",
+    "arguments": [
+      {
+        "name": "pipeline_id",
+        "type": "string",
+        "desc": "The unique identifier of the pipeline."
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of events to return. Defaults to 25."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_quality_monitor",
+    "description": "Create a quality monitor on a Unity Catalog table.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the table to monitor in"
+      },
+      {
+        "name": "output_schema_name",
+        "type": "string",
+        "desc": "Full name of the schema where profile and"
+      },
+      {
+        "name": "assets_dir",
+        "type": "string",
+        "desc": "Path in the workspace where monitor dashboard and"
+      },
+      {
+        "name": "monitor_type",
+        "type": "string",
+        "desc": "Type of monitor. One of \"SNAPSHOT\" (point-in-time"
+      },
+      {
+        "name": "slicing_exprs",
+        "type": "string",
+        "desc": "Optional comma-separated list of column expressions"
+      },
+      {
+        "name": "baseline_table_name",
+        "type": "string",
+        "desc": "Optional full name of a baseline table for"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_quality_monitor",
+    "description": "Get the quality monitor configuration for a table.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_quality_monitor",
+    "description": "Update the quality monitor configuration for a table.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      },
+      {
+        "name": "output_schema_name",
+        "type": "string",
+        "desc": "Full name of the schema for profile and"
+      },
+      {
+        "name": "assets_dir",
+        "type": "string",
+        "desc": "Path for monitor dashboard and config assets."
+      },
+      {
+        "name": "slicing_exprs",
+        "type": "string",
+        "desc": "Optional comma-separated list of column expressions"
+      },
+      {
+        "name": "baseline_table_name",
+        "type": "string",
+        "desc": "Optional full name of a baseline table for"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_quality_monitor",
+    "description": "Delete the quality monitor from a table.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_run_quality_monitor_refresh",
+    "description": "Trigger a refresh of the quality monitor for a table.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_quality_monitor_refresh",
+    "description": "Get the status of a specific quality monitor refresh.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      },
+      {
+        "name": "refresh_id",
+        "type": "string",
+        "desc": "The unique identifier of the refresh run."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_quality_monitor_refreshes",
+    "description": "List all refresh runs for a quality monitor.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_cancel_quality_monitor_refresh",
+    "description": "Cancel a running quality monitor refresh.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level name of the monitored table in"
+      },
+      {
+        "name": "refresh_id",
+        "type": "string",
+        "desc": "The unique identifier of the refresh run to cancel."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_secret_scopes",
+    "description": "List all secret scopes in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_secret_scope",
+    "description": "Create a new Databricks-backed secret scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name for the new secret scope. Must be unique within the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_secret_scope",
+    "description": "Delete a secret scope and all of its secrets.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name of the secret scope to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_secrets",
+    "description": "List the metadata of all secrets within a scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name of the secret scope to list secrets from."
+      }
+    ]
+  },
+  {
+    "name": "databricks_put_secret",
+    "description": "Store a secret value in a scope, creating or overwriting the key.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name of the secret scope to store the secret in."
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "Name of the secret key. Must be unique within the scope."
+      },
+      {
+        "name": "string_value",
+        "type": "string",
+        "desc": "The secret value to store as a UTF-8 string."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_secret",
+    "description": "Delete a secret from a scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name of the secret scope containing the secret."
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "Name of the secret key to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_secret_acls",
+    "description": "List access control entries for a secret scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name of the secret scope to list ACLs for."
+      }
+    ]
+  },
+  {
+    "name": "databricks_put_secret_acl",
+    "description": "Set an access control entry on a secret scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Name of the secret scope to set the ACL on."
+      },
+      {
+        "name": "principal",
+        "type": "string",
+        "desc": "The principal (user or group) to grant access to."
+      },
+      {
+        "name": "permission",
+        "type": "string",
+        "desc": "Permission level to grant. Must be one of:"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_serving_endpoints",
+    "description": "List all model serving endpoints in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_serving_endpoint",
+    "description": "Get detailed information about a specific serving endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the serving endpoint. Must be unique within the workspace."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_serving_endpoint",
+    "description": "Create a new model serving endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Unique name for the endpoint. Alphanumeric characters, dashes, and"
+      },
+      {
+        "name": "model_name",
+        "type": "string",
+        "desc": "Full name of the model to serve (e.g. \"catalog.schema.model\""
+      },
+      {
+        "name": "model_version",
+        "type": "string",
+        "desc": "Version of the model to serve (e.g. \"1\", \"2\")."
+      },
+      {
+        "name": "workload_size",
+        "type": "string",
+        "desc": "Compute size per replica. One of \"Small\", \"Medium\", \"Large\"."
+      },
+      {
+        "name": "scale_to_zero",
+        "type": "boolean",
+        "desc": "Whether the endpoint scales to zero replicas when idle."
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_serving_endpoint",
+    "description": "Update the configuration of an existing serving endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the existing serving endpoint to update."
+      },
+      {
+        "name": "model_name",
+        "type": "string",
+        "desc": "Full name of the model to serve."
+      },
+      {
+        "name": "model_version",
+        "type": "string",
+        "desc": "Version of the model to serve."
+      },
+      {
+        "name": "workload_size",
+        "type": "string",
+        "desc": "Compute size per replica. One of \"Small\", \"Medium\", \"Large\"."
+      },
+      {
+        "name": "scale_to_zero",
+        "type": "boolean",
+        "desc": "Whether the endpoint scales to zero when idle."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_serving_endpoint",
+    "description": "Delete a serving endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the serving endpoint to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_query_serving_endpoint",
+    "description": "Query a model serving endpoint for predictions.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the serving endpoint to query."
+      },
+      {
+        "name": "inputs",
+        "type": "string",
+        "desc": "JSON string containing the input data. The format depends on"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_serving_endpoint_logs",
+    "description": "Retrieve build logs for a served model within an endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the serving endpoint."
+      },
+      {
+        "name": "served_model_name",
+        "type": "string",
+        "desc": "Name of the served model within the endpoint"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_serving_endpoint_permissions",
+    "description": "List permissions on a serving endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the serving endpoint."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_model_versions",
+    "description": "List all versions of a Unity Catalog registered model.",
+    "arguments": [
+      {
+        "name": "full_model_name",
+        "type": "string",
+        "desc": "Full three-level name of the Unity Catalog model"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_serving_endpoint_openapi",
+    "description": "Get the OpenAPI specification for a serving endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the serving endpoint."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_shares",
+    "description": "List all Delta Sharing shares in the metastore.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_share",
+    "description": "Get detailed information about a specific share.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the share to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_share",
+    "description": "Create a new Delta Sharing share.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Unique name for the new share within the metastore."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the share and"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_recipients",
+    "description": "List all Delta Sharing recipients in the metastore.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_recipient",
+    "description": "Create a new Delta Sharing recipient.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Unique name for the recipient within the metastore."
+      },
+      {
+        "name": "authentication_type",
+        "type": "string",
+        "desc": "Authentication method for the recipient."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the recipient and"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_share",
+    "description": "Update properties of an existing Delta Sharing share.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the share to update."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional new description for the share. If empty,"
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "desc": "Optional new owner for the share. If empty, the owner"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_share",
+    "description": "Delete a Delta Sharing share.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the share to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_recipient",
+    "description": "Get detailed information about a specific Delta Sharing recipient.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the recipient to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_recipient",
+    "description": "Delete a Delta Sharing recipient.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the recipient to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_providers",
+    "description": "List all Delta Sharing providers in the metastore.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_provider",
+    "description": "Get detailed information about a specific Delta Sharing provider.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the provider to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_warehouses",
+    "description": "List all SQL warehouses in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_warehouse",
+    "description": "Get detailed information about a specific SQL warehouse.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier of the SQL warehouse."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_warehouse",
+    "description": "Create a new SQL warehouse.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Display name for the warehouse."
+      },
+      {
+        "name": "cluster_size",
+        "type": "string",
+        "desc": "T-shirt size for the warehouse compute"
+      },
+      {
+        "name": "max_num_clusters",
+        "type": "integer",
+        "desc": "Maximum number of clusters for auto-scaling (1-100)."
+      },
+      {
+        "name": "auto_stop_mins",
+        "type": "integer",
+        "desc": "Minutes of inactivity before auto-stop (0 to disable)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_start_warehouse",
+    "description": "Start a stopped SQL warehouse.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier of the SQL warehouse to start."
+      }
+    ]
+  },
+  {
+    "name": "databricks_stop_warehouse",
+    "description": "Stop a running SQL warehouse.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier of the SQL warehouse to stop."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_warehouse",
+    "description": "Delete a SQL warehouse.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "The unique identifier of the SQL warehouse to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_execute_sql",
+    "description": "Execute a SQL statement on a Databricks SQL warehouse.",
+    "arguments": [
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "The ID of the SQL warehouse to execute on."
+      },
+      {
+        "name": "statement",
+        "type": "string",
+        "desc": "The SQL statement to execute (max 16 MiB)."
+      },
+      {
+        "name": "catalog",
+        "type": "string",
+        "desc": "Optional default catalog for the statement"
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Optional default schema for the statement"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_statement_status",
+    "description": "Get the status and results of a previously executed SQL statement.",
+    "arguments": [
+      {
+        "name": "statement_id",
+        "type": "string",
+        "desc": "The statement ID returned by databricks_execute_sql."
+      }
+    ]
+  },
+  {
+    "name": "databricks_cancel_statement",
+    "description": "Cancel an executing SQL statement.",
+    "arguments": [
+      {
+        "name": "statement_id",
+        "type": "string",
+        "desc": "The statement ID of the statement to cancel."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_queries",
+    "description": "List saved SQL queries accessible to the current user.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_query",
+    "description": "Create a new saved SQL query.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Display name for the query."
+      },
+      {
+        "name": "query_text",
+        "type": "string",
+        "desc": "The SQL statement body."
+      },
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "The ID of the SQL warehouse to target."
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Optional human-readable description."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_alerts",
+    "description": "List all SQL alerts accessible to the current user.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_alert",
+    "description": "Create a new SQL alert based on a saved query.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Display name for the alert."
+      },
+      {
+        "name": "query_id",
+        "type": "string",
+        "desc": "The ID of the saved query to monitor."
+      },
+      {
+        "name": "condition",
+        "type": "string",
+        "desc": "A description of the alert condition. This should"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_query_history",
+    "description": "List recent query execution history.",
+    "arguments": [
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "Optional warehouse ID to filter history."
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of history entries to return"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_storage_credentials",
+    "description": "List all storage credentials in the Unity Catalog metastore.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_storage_credential",
+    "description": "Get detailed information about a specific storage credential.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the storage credential to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_storage_credential",
+    "description": "Create a new storage credential in the Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new storage credential. Must be unique."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description."
+      },
+      {
+        "name": "aws_iam_role_arn",
+        "type": "string",
+        "desc": "For AWS \u2014 the IAM role ARN that provides access"
+      },
+      {
+        "name": "azure_service_principal_application_id",
+        "type": "string",
+        "desc": "For Azure \u2014 the application"
+      },
+      {
+        "name": "azure_service_principal_client_secret",
+        "type": "string",
+        "desc": "For Azure \u2014 the client secret"
+      },
+      {
+        "name": "azure_service_principal_directory_id",
+        "type": "string",
+        "desc": "For Azure \u2014 the directory"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_storage_credential",
+    "description": "Update an existing storage credential.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Current name of the storage credential to update."
+      },
+      {
+        "name": "new_name",
+        "type": "string",
+        "desc": "Optional new name for the credential."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional new description."
+      },
+      {
+        "name": "aws_iam_role_arn",
+        "type": "string",
+        "desc": "For AWS \u2014 updated IAM role ARN."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_storage_credential",
+    "description": "Delete a storage credential from the Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the storage credential to delete."
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "If True, delete even if referenced by external locations."
+      }
+    ]
+  },
+  {
+    "name": "databricks_validate_storage_credential",
+    "description": "Validate a storage credential's access to a cloud storage location.",
+    "arguments": [
+      {
+        "name": "storage_credential_name",
+        "type": "string",
+        "desc": "Name of an existing credential to validate."
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "Cloud storage URL to validate access against"
+      },
+      {
+        "name": "aws_iam_role_arn",
+        "type": "string",
+        "desc": "For testing a new AWS credential \u2014 the IAM role ARN."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_external_locations",
+    "description": "List all external locations in the Unity Catalog metastore.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_external_location",
+    "description": "Get detailed information about a specific external location.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the external location to retrieve."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_external_location",
+    "description": "Create a new external location in the Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new external location. Must be unique."
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "Cloud storage URL that this external location represents"
+      },
+      {
+        "name": "credential_name",
+        "type": "string",
+        "desc": "Name of the storage credential to use for access."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_external_location",
+    "description": "Delete an external location from the Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the external location to delete."
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "If True, delete even if the location is used by managed"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_tokens",
+    "description": "List all personal access tokens for the current user.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_token",
+    "description": "Create a new personal access token for the current user.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional description of the token's intended use"
+      },
+      {
+        "name": "lifetime_seconds",
+        "type": "integer",
+        "desc": "Token lifetime in seconds. Use 0 or omit for"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_token",
+    "description": "Revoke (delete) a personal access token for the current user.",
+    "arguments": [
+      {
+        "name": "token_id",
+        "type": "string",
+        "desc": "The unique identifier of the token to revoke."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_token_management",
+    "description": "List all personal access tokens in the workspace (admin only).",
+    "arguments": []
+  },
+  {
+    "name": "databricks_delete_token_management",
+    "description": "Revoke any user's personal access token (admin only).",
+    "arguments": [
+      {
+        "name": "token_id",
+        "type": "string",
+        "desc": "The unique identifier of the token to revoke."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_catalogs",
+    "description": "List all catalogs in the Unity Catalog metastore.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_catalog",
+    "description": "Get detailed information about a specific catalog.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The name of the catalog to retrieve (e.g. \"my_catalog\")."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_catalog",
+    "description": "Create a new catalog in the Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new catalog. Must be unique within the metastore."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the catalog."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_catalog",
+    "description": "Delete a catalog from the Unity Catalog metastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the catalog to delete."
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "If True, delete the catalog even if it contains schemas."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_schemas",
+    "description": "List all schemas within a catalog.",
+    "arguments": [
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog to list schemas from."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_schema",
+    "description": "Get detailed information about a specific schema.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full name of the schema in \"catalog.schema\" format"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_schema",
+    "description": "Create a new schema within a catalog.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new schema, relative to the parent catalog."
+      },
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the schema."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_schema",
+    "description": "Delete a schema from Unity Catalog.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full name of the schema in \"catalog.schema\" format"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_tables",
+    "description": "List all tables within a schema.",
+    "arguments": [
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Name of the schema to list tables from."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_table",
+    "description": "Get detailed information about a specific table.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the table in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_table",
+    "description": "Delete a table from Unity Catalog.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the table in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_volumes",
+    "description": "List all volumes within a schema.",
+    "arguments": [
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Name of the schema to list volumes from."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_volume",
+    "description": "Create a new volume within a schema.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new volume."
+      },
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Name of the parent schema."
+      },
+      {
+        "name": "volume_type",
+        "type": "string",
+        "desc": "Type of volume \u2014 \"MANAGED\" (default, Databricks-managed"
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the volume."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_volume",
+    "description": "Delete a volume from Unity Catalog.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the volume in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_functions",
+    "description": "List all user-defined functions within a schema.",
+    "arguments": [
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Name of the schema to list functions from."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_function",
+    "description": "Get detailed information about a specific function.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the function in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_function",
+    "description": "Delete a user-defined function from Unity Catalog.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the function in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_registered_models",
+    "description": "List registered models in Unity Catalog.",
+    "arguments": [
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Optional catalog name to filter models."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Optional schema name to filter models."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_registered_model",
+    "description": "Get detailed information about a specific registered model.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the registered model in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_catalog",
+    "description": "Update properties of an existing catalog.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the catalog to update."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional new description for the catalog. If empty,"
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "desc": "Optional new owner for the catalog. If empty, the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_schema",
+    "description": "Update properties of an existing schema.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full name of the schema in \"catalog.schema\" format"
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional new description for the schema. If empty,"
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "desc": "Optional new owner for the schema. If empty, the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_registered_model",
+    "description": "Create a new registered model in Unity Catalog.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the new registered model."
+      },
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Name of the parent schema."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional human-readable description of the model."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_registered_model",
+    "description": "Delete a registered model from Unity Catalog.",
+    "arguments": [
+      {
+        "name": "full_name",
+        "type": "string",
+        "desc": "Full three-level name of the registered model in"
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_vector_search_endpoints",
+    "description": "List all vector search endpoints in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_create_vector_search_endpoint",
+    "description": "Create a new vector search endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Unique name for the vector search endpoint."
+      },
+      {
+        "name": "endpoint_type",
+        "type": "string",
+        "desc": "Type of endpoint to create. Currently only \"STANDARD\" is"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_vector_search_endpoint",
+    "description": "Get detailed information about a vector search endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the vector search endpoint."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_vector_search_endpoint",
+    "description": "Delete a vector search endpoint.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the vector search endpoint to delete."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_vector_search_indexes",
+    "description": "List all vector search indexes hosted on a specific endpoint.",
+    "arguments": [
+      {
+        "name": "endpoint_name",
+        "type": "string",
+        "desc": "Name of the vector search endpoint whose indexes to list."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_vector_search_index",
+    "description": "Create a new vector search index.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Full three-level name for the index (catalog.schema.index_name)."
+      },
+      {
+        "name": "endpoint_name",
+        "type": "string",
+        "desc": "Name of the vector search endpoint to host this index."
+      },
+      {
+        "name": "primary_key",
+        "type": "string",
+        "desc": "Column name to use as the primary key for the index."
+      },
+      {
+        "name": "index_type",
+        "type": "string",
+        "desc": "Type of index. Either \"DELTA_SYNC\" or \"DIRECT_ACCESS\"."
+      },
+      {
+        "name": "source_table_name",
+        "type": "string",
+        "desc": "Full name of the source Delta table (required for"
+      },
+      {
+        "name": "embedding_dimension",
+        "type": "integer",
+        "desc": "Dimensionality of embedding vectors (required for"
+      },
+      {
+        "name": "embedding_model_endpoint_name",
+        "type": "string",
+        "desc": "Name of a serving endpoint that computes"
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_vector_search_index",
+    "description": "Delete a vector search index.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Full three-level name of the index to delete (catalog.schema.index_name)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_query_vector_search_index",
+    "description": "Query a vector search index for similar items.",
+    "arguments": [
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Full three-level name of the index to query."
+      },
+      {
+        "name": "query_text",
+        "type": "string",
+        "desc": "Text query string. Used with DELTA_SYNC indexes that have"
+      },
+      {
+        "name": "query_vector",
+        "type": "string",
+        "desc": "JSON array string of floats representing the query embedding"
+      },
+      {
+        "name": "columns",
+        "type": "string",
+        "desc": "Comma-separated list of column names to include in results."
+      },
+      {
+        "name": "num_results",
+        "type": "integer",
+        "desc": "Maximum number of results to return. Defaults to 10."
+      },
+      {
+        "name": "filters_json",
+        "type": "string",
+        "desc": "Optional JSON string of filter conditions. Example:"
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_vector_search_index",
+    "description": "Get detailed information about a specific vector search index.",
+    "arguments": [
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Full three-level name of the index"
+      }
+    ]
+  },
+  {
+    "name": "databricks_sync_vector_search_index",
+    "description": "Trigger a sync of a DELTA_SYNC vector search index.",
+    "arguments": [
+      {
+        "name": "index_name",
+        "type": "string",
+        "desc": "Full three-level name of the index"
+      }
+    ]
+  },
+  {
+    "name": "databricks_workspace_status",
+    "description": "Get a comprehensive status overview of the Databricks workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_setup_schema",
+    "description": "Create a catalog (optionally) and schema in one step.",
+    "arguments": [
+      {
+        "name": "catalog_name",
+        "type": "string",
+        "desc": "Name of the parent catalog."
+      },
+      {
+        "name": "schema_name",
+        "type": "string",
+        "desc": "Name of the schema to create."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional description for the schema."
+      },
+      {
+        "name": "create_catalog",
+        "type": "boolean",
+        "desc": "If True, create the catalog first (skips if it already exists)."
+      }
+    ]
+  },
+  {
+    "name": "databricks_query_as_markdown",
+    "description": "Execute a SQL query and return results formatted as a markdown table.",
+    "arguments": [
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "ID of the SQL warehouse to use."
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": "The SQL statement to execute."
+      },
+      {
+        "name": "catalog",
+        "type": "string",
+        "desc": "Optional catalog context for the query."
+      },
+      {
+        "name": "schema",
+        "type": "string",
+        "desc": "Optional schema context for the query."
+      }
+    ]
+  },
+  {
+    "name": "databricks_find_and_start_warehouse",
+    "description": "Find an available SQL warehouse and start it if needed.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_table_preview",
+    "description": "Preview a table's schema and sample data in one call.",
+    "arguments": [
+      {
+        "name": "table_name",
+        "type": "string",
+        "desc": "Full three-level table name (catalog.schema.table)."
+      },
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "SQL warehouse ID to use. If empty, finds one automatically."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Number of sample rows to return. Defaults to 10."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_workspace",
+    "description": "List objects in a workspace directory.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute workspace path to list (default: root \"/\")."
+      }
+    ]
+  },
+  {
+    "name": "databricks_get_workspace_status",
+    "description": "Get the status and metadata of a workspace object.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute workspace path of the object."
+      }
+    ]
+  },
+  {
+    "name": "databricks_import_notebook",
+    "description": "Import a notebook or file into the workspace.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute workspace path where the notebook will be created."
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Base64-encoded content of the notebook."
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Import format \u2014 \"SOURCE\" (default), \"HTML\", \"JUPYTER\","
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Notebook language \u2014 \"PYTHON\" (default), \"SQL\", \"SCALA\","
+      },
+      {
+        "name": "overwrite",
+        "type": "boolean",
+        "desc": "If True, overwrite any existing object at the path."
+      }
+    ]
+  },
+  {
+    "name": "databricks_export_notebook",
+    "description": "Export a notebook from the workspace.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute workspace path of the notebook to export."
+      }
+    ]
+  },
+  {
+    "name": "databricks_mkdirs",
+    "description": "Create a directory in the workspace.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute workspace path of the directory to create."
+      }
+    ]
+  },
+  {
+    "name": "databricks_delete_workspace",
+    "description": "Delete a workspace object or directory.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Absolute workspace path of the object to delete."
+      },
+      {
+        "name": "recursive",
+        "type": "boolean",
+        "desc": "If True, recursively delete all contents of a directory."
+      }
+    ]
+  },
+  {
+    "name": "databricks_list_repos",
+    "description": "List all Git repositories configured in the workspace.",
+    "arguments": []
+  },
+  {
+    "name": "databricks_get_repo",
+    "description": "Get detailed information about a specific Git repository.",
+    "arguments": [
+      {
+        "name": "repo_id",
+        "type": "integer",
+        "desc": "The numeric ID of the repository."
+      }
+    ]
+  },
+  {
+    "name": "databricks_create_repo",
+    "description": "Add a Git repository to the workspace.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "The URL of the Git repository to clone."
+      },
+      {
+        "name": "provider",
+        "type": "string",
+        "desc": "Git provider \u2014 \"github\" (default), \"gitlab\","
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Optional workspace path for the repo. If empty, the"
+      }
+    ]
+  },
+  {
+    "name": "databricks_update_repo",
+    "description": "Update a Git repository to a different branch or tag.",
+    "arguments": [
+      {
+        "name": "repo_id",
+        "type": "integer",
+        "desc": "The numeric ID of the repository."
+      },
+      {
+        "name": "branch",
+        "type": "string",
+        "desc": "The name of the branch to check out (e.g. \"main\", \"develop\")."
+      }
+    ]
+  },
+  {
+    "name": "databricks_tool_guide",
+    "description": "Find the right Databricks tools for a task or role.",
+    "arguments": [
+      {
+        "name": "task",
+        "type": "string",
+        "desc": "Describe what you want to do (e.g. \"run a SQL query\","
+      },
+      {
+        "name": "role",
+        "type": "string",
+        "desc": "One of: data_engineer, ml_engineer, platform_admin,"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## New MCP Server: Databricks SDK MCP

**Category:** Cloud / Data Platform

### Description

Comprehensive SDK-first MCP server for Databricks providing **263 tools** across **28 service domains** and **8 prompt templates**.

Built on the official [Databricks Python SDK](https://github.com/databricks/databricks-sdk-py) for type safety and automatic API freshness.

### Service Domains

Unity Catalog, SQL, Compute, Jobs, Pipelines, Serving Endpoints, Vector Search, Apps, Lakebase, Dashboards, Genie, Secrets, IAM, Connections, Experiments, Delta Sharing, Files (DBFS & Volumes), Grants, Storage, Metastores, Online Tables, Global Init Scripts, Tokens, Git Credentials, Quality Monitors, Command Execution, and Composite Workflows.

### Key Features

- **SDK-first**: Uses `databricks-sdk` — no raw REST calls
- **Zero custom auth**: Delegates to SDK (PAT, OAuth, Azure AD, service principal)
- **Selective loading**: Role-based presets (data_engineer, ml_engineer, platform_admin, etc.)
- **Tool discovery**: Built-in `databricks_tool_guide` tool for agent self-guidance
- **8 MCP Prompts**: Guided workflows for common multi-step operations

### Configuration

| Variable | Required | Description |
|----------|----------|-------------|
| `DATABRICKS_HOST` | Yes | Workspace URL |
| `DATABRICKS_TOKEN` | Yes (secret) | PAT or OAuth token |
| `DATABRICKS_MCP_TOOLS_INCLUDE` | No | Comma-separated modules to load |

### Links

- **GitHub**: https://github.com/pramodbhatofficial/databricks-mcp-server
- **PyPI**: https://pypi.org/project/databricks-sdk-mcp/
- **MCP Registry**: io.github.pramodbhatofficial/databricks-sdk-mcp
- **License**: Apache 2.0

### Notes

- `tools.json` is included since the server requires `DATABRICKS_HOST`/`DATABRICKS_TOKEN` to list tools
- Option A (Docker-built image) preferred