### PR TITLE
feat: add serena MCP server

### DIFF
--- a/servers/serena/server.yaml
+++ b/servers/serena/server.yaml
@@ -1,6 +1,7 @@
 name: serena
 image: mcp/serena
 type: server
+longLived: true
 meta:
   category: development
   tags:
@@ -21,10 +22,21 @@ source:
   project: https://github.com/oraios/serena
   commit: 15f60a0b1f3dfc8f653b15a0057c3baf55447a4b
 run:
+  command:
+    - --transport
+    - "{{serena.transport}}"
+    - --host
+    - "0.0.0.0"
+    - --port
+    - "{{serena.port}}"
   volumes:
     - "{{serena.project_path|volume-target}}:/workspace"
+  ports:
+    - "{{serena.port}}:{{serena.port}}"
 config:
-  description: Configure the path to the project you want Serena to work on
+  description: >
+    Configure Serena's project path and transport mode.
+    Defaults to SSE transport so the same running instance can switch between projects.
   parameters:
     type: object
     properties:
@@ -32,5 +44,17 @@ config:
         type: string
         description: Path to the project directory for Serena to analyze
         default: /Users/demo/sources
+      transport:
+        type: string
+        description: "Transport protocol for the MCP server (sse allows switching projects with the same instance)"
+        enum:
+          - sse
+          - stdio
+          - streamable-http
+        default: sse
+      port:
+        type: string
+        description: "Listen port for the MCP server (used with sse and streamable-http transports)"
+        default: "8000"
     required:
       - project_path

--- a/servers/serena/server.yaml
+++ b/servers/serena/server.yaml
@@ -1,0 +1,36 @@
+name: serena
+image: mcp/serena
+type: server
+meta:
+  category: development
+  tags:
+    - code
+    - development
+    - refactoring
+    - code-analysis
+    - language-server
+    - semantic-search
+about:
+  title: Serena
+  description: >
+    Coding agent toolkit providing semantic code retrieval and editing capabilities.
+    Uses language server backends to offer symbol-level code navigation, search,
+    and refactoring across 30+ programming languages.
+  icon: https://avatars.githubusercontent.com/u/181485370?v=4
+source:
+  project: https://github.com/oraios/serena
+  commit: 15f60a0b1f3dfc8f653b15a0057c3baf55447a4b
+run:
+  volumes:
+    - "{{serena.project_path|volume-target}}:/workspace"
+config:
+  description: Configure the path to the project you want Serena to work on
+  parameters:
+    type: object
+    properties:
+      project_path:
+        type: string
+        description: Path to the project directory for Serena to analyze
+        default: /Users/demo/sources
+    required:
+      - project_path

--- a/servers/serena/tools.json
+++ b/servers/serena/tools.json
@@ -1,0 +1,263 @@
+[
+    {
+        "name": "find_symbol",
+        "description": "Performs a global or local search for code symbols using the language server backend.",
+        "arguments": [
+            {
+                "name": "name_path_pattern",
+                "type": "string",
+                "desc": "Symbol name matching pattern to search for"
+            },
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "Optional file or directory to restrict the search to"
+            }
+        ]
+    },
+    {
+        "name": "find_referencing_symbols",
+        "description": "Finds symbols that reference the given symbol using the language server backend.",
+        "arguments": [
+            {
+                "name": "name_path",
+                "type": "string",
+                "desc": "Target symbol identifier to find references of"
+            },
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "File containing the symbol"
+            }
+        ]
+    },
+    {
+        "name": "get_symbols_overview",
+        "description": "Gets an overview of the top-level symbols defined in a given file.",
+        "arguments": [
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "File path to get the symbol overview for"
+            }
+        ]
+    },
+    {
+        "name": "replace_symbol_body",
+        "description": "Replaces the full definition of a symbol using the language server backend.",
+        "arguments": [
+            {
+                "name": "name_path",
+                "type": "string",
+                "desc": "Symbol identifier to replace"
+            },
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "File location of the symbol"
+            },
+            {
+                "name": "body",
+                "type": "string",
+                "desc": "New symbol definition content"
+            }
+        ]
+    },
+    {
+        "name": "insert_after_symbol",
+        "description": "Inserts content after the end of the definition of a given symbol.",
+        "arguments": [
+            {
+                "name": "name_path",
+                "type": "string",
+                "desc": "Reference symbol identifier"
+            },
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "File location of the symbol"
+            },
+            {
+                "name": "body",
+                "type": "string",
+                "desc": "Content to insert after the symbol"
+            }
+        ]
+    },
+    {
+        "name": "insert_before_symbol",
+        "description": "Inserts content before the beginning of the definition of a given symbol.",
+        "arguments": [
+            {
+                "name": "name_path",
+                "type": "string",
+                "desc": "Reference symbol identifier"
+            },
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "File location of the symbol"
+            },
+            {
+                "name": "body",
+                "type": "string",
+                "desc": "Content to insert before the symbol"
+            }
+        ]
+    },
+    {
+        "name": "rename_symbol",
+        "description": "Renames a symbol throughout the codebase using language server refactoring capabilities.",
+        "arguments": [
+            {
+                "name": "name_path",
+                "type": "string",
+                "desc": "Symbol identifier to rename"
+            },
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "File location of the symbol"
+            },
+            {
+                "name": "new_name",
+                "type": "string",
+                "desc": "New name for the symbol"
+            }
+        ]
+    },
+    {
+        "name": "read_file",
+        "description": "Reads a file within the project directory.",
+        "arguments": [
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "Path to the file to read"
+            }
+        ]
+    },
+    {
+        "name": "create_text_file",
+        "description": "Creates or overwrites a file in the project directory.",
+        "arguments": [
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "Path where the file will be created"
+            },
+            {
+                "name": "content",
+                "type": "string",
+                "desc": "Content to write to the file"
+            }
+        ]
+    },
+    {
+        "name": "list_dir",
+        "description": "Lists files and directories in the given directory.",
+        "arguments": [
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "Directory path to list"
+            }
+        ]
+    },
+    {
+        "name": "find_file",
+        "description": "Finds files matching a given mask in the project.",
+        "arguments": [
+            {
+                "name": "file_mask",
+                "type": "string",
+                "desc": "File name pattern to search for"
+            }
+        ]
+    },
+    {
+        "name": "replace_content",
+        "description": "Replaces content in a file, optionally using regular expressions.",
+        "arguments": [
+            {
+                "name": "relative_path",
+                "type": "string",
+                "desc": "Path to the file to modify"
+            },
+            {
+                "name": "needle",
+                "type": "string",
+                "desc": "Content to search for"
+            },
+            {
+                "name": "repl",
+                "type": "string",
+                "desc": "Replacement content"
+            }
+        ]
+    },
+    {
+        "name": "search_for_pattern",
+        "description": "Flexible search for arbitrary patterns in the codebase, including non-code files.",
+        "arguments": [
+            {
+                "name": "substring_pattern",
+                "type": "string",
+                "desc": "Pattern to search for in the codebase"
+            }
+        ]
+    },
+    {
+        "name": "execute_shell_command",
+        "description": "Executes a shell command and returns its output.",
+        "arguments": [
+            {
+                "name": "command",
+                "type": "string",
+                "desc": "Shell command to execute"
+            }
+        ]
+    },
+    {
+        "name": "restart_language_server",
+        "description": "Restarts the language server, may be necessary when edits not through Serena happen.",
+        "arguments": []
+    },
+    {
+        "name": "onboarding",
+        "description": "Performs onboarding by identifying the project structure and essential tasks.",
+        "arguments": []
+    },
+    {
+        "name": "write_memory",
+        "description": "Writes a named memory for future reference to Serena's project-specific memory store.",
+        "arguments": [
+            {
+                "name": "memory_file_name",
+                "type": "string",
+                "desc": "Name of the memory to write"
+            },
+            {
+                "name": "content",
+                "type": "string",
+                "desc": "Content to store in the memory"
+            }
+        ]
+    },
+    {
+        "name": "read_memory",
+        "description": "Reads the memory with the given name from Serena's project-specific memory store.",
+        "arguments": [
+            {
+                "name": "memory_file_name",
+                "type": "string",
+                "desc": "Name of the memory to read"
+            }
+        ]
+    },
+    {
+        "name": "list_memories",
+        "description": "Lists memories in Serena's project-specific memory store.",
+        "arguments": []
+    }
+]


### PR DESCRIPTION
Fix: https://github.com/oraios/serena/issues/1044

## Summary
- Adds [Serena](https://github.com/oraios/serena) to the MCP registry
- Serena is a coding agent toolkit providing semantic code retrieval and editing capabilities using language server backends across 30+ programming languages
- MIT licensed, 20k+ GitHub stars, 114+ contributors

## Server Details
- **Category**: development
- **Type**: local (containerized)
- **Key capabilities**: Symbol-level code navigation, search, refactoring via LSP backends
- **Tools**: 19 tools including `find_symbol`, `find_referencing_symbols`, `replace_symbol_body`, `rename_symbol`, file operations, shell commands, and memory management

## Test plan
- [x] `task validate -- serena` passes
- [x] `task build -- --tools serena` builds successfully
- [x] Docker MCP catalog import works