### PR TITLE
Add mcp-interactive-terminal

### DIFF
--- a/servers/mcp-interactive-terminal/server.yaml
+++ b/servers/mcp-interactive-terminal/server.yaml
@@ -1,0 +1,29 @@
+name: mcp-interactive-terminal
+image: mcp/mcp-interactive-terminal
+type: server
+meta:
+  category: dev-tools
+  tags:
+    - terminal
+    - interactive
+    - repl
+    - ssh
+    - cli
+    - dev-tools
+about:
+  title: MCP Interactive Terminal
+  description: |
+    MCP server providing real interactive terminal sessions for REPLs, SSH, database clients, and any interactive CLI with clean text output, smart completion detection, and multi-layer security.
+
+    Features:
+    - Real interactive terminal sessions with persistent state
+    - Support for REPLs (Python, Node.js, etc.), SSH, database clients
+    - Smart output completion detection
+    - Clean text output processing
+    - Multi-layer security controls
+    - Session management and lifecycle handling
+  icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
+source:
+  project: https://github.com/amol21p/mcp-interactive-terminal
+  branch: main
+  commit: d35133fa1eddabce0bae2c34960f9c359dcaa2f7


### PR DESCRIPTION
## Summary
- Add **mcp-interactive-terminal** to the Docker MCP Registry
- MCP server providing real interactive terminal sessions for REPLs, SSH, database clients, and any interactive CLI with clean text output, smart completion detection, and multi-layer security
- Source: https://github.com/amol21p/mcp-interactive-terminal
- License: MIT
- Author: amol21p

## Changes
- Added `servers/mcp-interactive-terminal/server.yaml`

## Test plan
- [ ] Verify server.yaml format matches registry standards
- [ ] CI passes on the PR
- [ ] Docker image builds successfully from source repo