### PR TITLE
feat: add Terramate Cloud MCP server

### DIFF
--- a/servers/terramate-cloud/server.yaml
+++ b/servers/terramate-cloud/server.yaml
@@ -1,0 +1,34 @@
+name: terramate-cloud
+image: mcp/terramate-cloud
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - terramate
+    - infrastructure
+about:
+  title: Terramate Cloud
+  description: Interact with Terramate Cloud to manage stacks, detect infrastructure drift, track deployments, and review pull request plans.
+  icon: https://www.google.com/s2/favicons?domain=terramate.io&sz=64
+source:
+  project: https://github.com/terramate-io/terramate-mcp-server
+  commit: 0cab5ff94b80c97deebf158eeb781d1a27251195
+config:
+  description: Configure access to Terramate Cloud. Generate an API key from your Terramate Cloud organization settings.
+  secrets:
+    - name: terramate-cloud.api_key
+      env: TERRAMATE_API_KEY
+      example: YOUR_TERRAMATE_API_KEY
+  env:
+    - name: TERRAMATE_REGION
+      example: us
+      value: "{{terramate-cloud.region}}"
+  parameters:
+    type: object
+    properties:
+      region:
+        type: string
+        default: us
+    required:
+      - region

--- a/servers/terramate-cloud/tools.json
+++ b/servers/terramate-cloud/tools.json
@@ -1,0 +1,199 @@
+[
+  {
+    "name": "tmc_authenticate",
+    "description": "Authenticates with Terramate Cloud and retrieves organization membership UUIDs",
+    "arguments": []
+  },
+  {
+    "name": "tmc_list_stacks",
+    "description": "Lists stacks in a Terramate Cloud organization with filtering by status, drift, deployment, tags, and search",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_stack",
+    "description": "Gets full details for a single stack by ID",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "stack_id",
+        "type": "string",
+        "desc": "Stack ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_list_drifts",
+    "description": "Lists drift detection runs for a stack",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "stack_id",
+        "type": "string",
+        "desc": "Stack ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_drift",
+    "description": "Gets full drift details including changeset for a specific drift run",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "drift_id",
+        "type": "string",
+        "desc": "Drift run ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_list_review_requests",
+    "description": "Lists pull requests and merge requests tracked in Terramate Cloud",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_review_request",
+    "description": "Gets full pull request details including terraform plans for all affected stacks",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "review_request_id",
+        "type": "string",
+        "desc": "Review request ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_list_deployments",
+    "description": "Lists CI/CD workflow deployments with status counts",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_stack_deployment",
+    "description": "Gets full deployment details including terraform apply output for a stack",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "deployment_id",
+        "type": "string",
+        "desc": "Deployment ID"
+      },
+      {
+        "name": "stack_id",
+        "type": "string",
+        "desc": "Stack ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_list_resources",
+    "description": "Lists stack-level resources from plan or state with filtering by type, provider, and status",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "stack_id",
+        "type": "string",
+        "desc": "Stack ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_resource",
+    "description": "Gets full resource details by UUID including optional state values",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "resource_id",
+        "type": "string",
+        "desc": "Resource UUID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_stack_preview_logs",
+    "description": "Gets raw terraform plan logs (stdout/stderr) for a stack preview, useful for debugging failed plans in pull requests",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "preview_id",
+        "type": "string",
+        "desc": "Preview ID"
+      },
+      {
+        "name": "stack_id",
+        "type": "string",
+        "desc": "Stack ID"
+      }
+    ]
+  },
+  {
+    "name": "tmc_get_deployment_logs",
+    "description": "Gets raw terraform apply logs (stdout/stderr) for debugging failed deployments",
+    "arguments": [
+      {
+        "name": "org_uuid",
+        "type": "string",
+        "desc": "Organization UUID"
+      },
+      {
+        "name": "deployment_id",
+        "type": "string",
+        "desc": "Deployment ID"
+      },
+      {
+        "name": "stack_id",
+        "type": "string",
+        "desc": "Stack ID"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** terramate-cloud
**Repository URL:** https://github.com/terramate-io/terramate-mcp-server
**Brief Description:** Interact with Terramate Cloud to manage stacks, detect infrastructure drift, track deployments, and review pull request plans. Provides 13 MCP tools covering stack management, drift detection, deployments, PR/MR plan review, and resource listing.

## Basic Requirements

- [x] **Open Source**: License is MPL-2.0 (note: the README badge incorrectly shows MIT — the actual LICENSE file is Mozilla Public License 2.0)
- [x] **MCP Compliant**: Implements MCP API specification using the `mark3labs/mcp-go` library
- [x] **Active Development**: Recent commits (last commit: 2026-02-13)
- [x] **Docker Artifact**: Dockerfile present (multi-stage Go build, alpine runtime)
- [x] **Documentation**: README with full setup instructions and tool descriptions
- [x] **Security Contact**: GitHub security advisories enabled on the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

- A `tools.json` is included with all 13 tool declarations because the server requires `TERRAMATE_API_KEY` authentication before it can dynamically list tools, which would cause `task build --tools` to fail without credentials.
- The server is configured to accept `TERRAMATE_API_KEY` (secret) and `TERRAMATE_REGION` (parameter, default: `us`) for the Docker Desktop config UI.
- The upstream repo already publishes an image to `ghcr.io/terramate-io/terramate-mcp-server:latest`; this entry requests Docker to build and host it as `mcp/terramate-cloud`.
- `task validate` and `task build --tools` both pass locally (13 tools found, image built as `mcp/terramate-cloud`).