### PR TITLE
Update auto-merge allowlist with new docker-docs server

### DIFF
--- a/.github/auto-merge-allowlist.yaml
+++ b/.github/auto-merge-allowlist.yaml
@@ -19,7 +19,7 @@ servers:
   # Known publisher servers from Docker Desktop's known-publisher-server-ids.ts
   # These servers are maintained by verified publishers and eligible for auto-merge
 
-  # Remote servers (66 servers)
+  # Remote servers (67 servers)
   - apify
   - asana
   - astro-docs
@@ -44,6 +44,7 @@ servers:
   - dappier-remote
   - deepwiki
   - dialer
+  - docker-docs
   - dodo-payments
   - find-a-domain
   - firefly


### PR DESCRIPTION
Added the docker-docs server here: https://github.com/docker/mcp-registry/pull/1170/changes