### PR TITLE
Add Taskade MCP server

### DIFF
--- a/servers/taskade/readme.md
+++ b/servers/taskade/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/taskade/mcp

--- a/servers/taskade/server.yaml
+++ b/servers/taskade/server.yaml
@@ -1,0 +1,27 @@
+name: taskade
+image: mcp/taskade
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - project-management
+    - tasks
+    - ai-agents
+    - workflow-automation
+    - secrets
+about:
+  title: Taskade
+  description: AI-powered project management with 57 MCP tools for workspaces, projects, tasks, AI agents, templates, media, and team collaboration
+  icon: https://www.google.com/s2/favicons?domain=taskade.com&sz=64
+source:
+  project: https://github.com/taskade/mcp
+  commit: 813ff1f58e7064da070926620b0c1ac3471c4e22
+run:
+  env:
+    TASKADE_API_KEY: $TASKADE_API_KEY
+config:
+  secrets:
+    - name: taskade.api_key
+      env: TASKADE_API_KEY
+      example: your-taskade-api-key

--- a/servers/taskade/tools.json
+++ b/servers/taskade/tools.json
@@ -1,0 +1,1103 @@
+[
+  {
+    "name": "workspaceCreateProject",
+    "description": "Create a project in a workspace",
+    "arguments": [
+      {
+        "name": "contentType",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "workspaceId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "workspacesGet",
+    "description": "Get all workspaces for a user",
+    "arguments": []
+  },
+  {
+    "name": "workspaceFoldersGet",
+    "description": "Get all folders for a workspace",
+    "arguments": [
+      {
+        "name": "workspaceId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectGet",
+    "description": "Get project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectComplete",
+    "description": "Mark the project as completed",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectRestore",
+    "description": "Restore project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectCopy",
+    "description": "Copy a project to a folder",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectTitle",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectCreate",
+    "description": "Create a project in a team",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contentType",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectFromTemplate",
+    "description": "Create a project from a custom template",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "templateId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectMembersGet",
+    "description": "Get members of a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectFieldsGet",
+    "description": "Get all fields for a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectShareLinkGet",
+    "description": "Get share link for the project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectShareLinkEnable",
+    "description": "Enable share link in the project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectBlocksGet",
+    "description": "Get all blocks for a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "after",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "before",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "projectTasksGet",
+    "description": "Get all tasks for a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "after",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "before",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskGet",
+    "description": "Get task with id",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskDelete",
+    "description": "Delete a task in a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskPut",
+    "description": "Update task.",
+    "arguments": [
+      {
+        "name": "contentType",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskComplete",
+    "description": "Complete a task in a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskUncomplete",
+    "description": "Mark a task as incomplete in a project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskCreate",
+    "description": "Create one or more tasks in a project",
+    "arguments": [
+      {
+        "name": "contentType",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "placement",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "placement",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskMove",
+    "description": "Move a task within the project",
+    "arguments": [
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "position",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskAssigneesGet",
+    "description": "Get the assignees of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskPutAssignees",
+    "description": "Task assignment",
+    "arguments": [
+      {
+        "name": "handles",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskDeleteAssignees",
+    "description": "Remove assignee from a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "assigneeHandle",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskGetDate",
+    "description": "Get the date of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskDeleteDate",
+    "description": "Delete date of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskPutDate",
+    "description": "Create or update date for a task",
+    "arguments": [
+      {
+        "name": "date",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timezone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "date",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timezone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskNoteGet",
+    "description": "Get the note of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskNotePut",
+    "description": "Add/update a note to the task",
+    "arguments": [
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskNoteDelete",
+    "description": "Delete the note of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskFieldsValueGet",
+    "description": "Get all field values for a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskFieldValueGet",
+    "description": "Get the field value of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fieldId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskFieldValueDelete",
+    "description": "Delete the field value of a task",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fieldId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "taskFieldValuePut",
+    "description": "Update/create the field value of a task",
+    "arguments": [
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "taskId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fieldId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "folderProjectsGet",
+    "description": "Get all projects in a team, or in the home team of a workspace.",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "folderAgentGenerate",
+    "description": "Generate agent based on input text prompts",
+    "arguments": [
+      {
+        "name": "text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "folderCreateAgent",
+    "description": "Create an agent in a team or workspace.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "commands",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "knowledgeEnabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "inputPlaceholder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "folderAgentGet",
+    "description": "Get agents in a folder.",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "mediasGet",
+    "description": "Get medias in a folder",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "folderProjectTemplatesGet",
+    "description": "Get projects templates in a folder.",
+    "arguments": [
+      {
+        "name": "folderId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "meProjectsGet",
+    "description": "Get all projects of mine",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "sort",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentPublicAccessEnable",
+    "description": "Enable public access in the agent",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentGet",
+    "description": "Get agent with id",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "deleteAgent",
+    "description": "Delete an agent",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentUpdate",
+    "description": "Update agent",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "commands",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "knowledgeEnabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "inputPlaceholder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentPublicGet",
+    "description": "Get public agent",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentPublicUpdate",
+    "description": "Update public agent",
+    "arguments": [
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "canCopyKnowledge",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "hideBranding",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "theme",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autoEndChats",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentKnowledgeProjectCreate",
+    "description": "Create a knowledge project",
+    "arguments": [
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentKnowledgeMediaCreate",
+    "description": "Create a knowledge media",
+    "arguments": [
+      {
+        "name": "mediaId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentKnowledgeProjectRemove",
+    "description": "Remove a knowledge project",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "projectId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentKnowledgeMediaRemove",
+    "description": "Remove a knowledge media",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mediaId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentConvosGet",
+    "description": "Get agent conversations",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "page",
+        "type": "number",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agentConvoGet",
+    "description": "Get agent conversation by id",
+    "arguments": [
+      {
+        "name": "agentId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "convoId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "mediaGet",
+    "description": "Get media with id",
+    "arguments": [
+      {
+        "name": "mediaId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "mediaDelete",
+    "description": "Delete a media",
+    "arguments": [
+      {
+        "name": "mediaId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "publicAgentGet",
+    "description": "Get public agent by public agent ID",
+    "arguments": [
+      {
+        "name": "publicAgentId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** taskade
**Repository URL:** https://github.com/taskade/mcp
**Brief Description:** Official Taskade MCP server — 57 AI-powered tools for workspaces, projects, tasks, AI agents, templates, media, and team collaboration via Model Context Protocol.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name taskade`
- [ ] I have built the MCP Server using `task build -- --tools taskade`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## About Taskade MCP Server

[Taskade](https://taskade.com) is an AI-powered productivity platform for teams. The MCP server exposes 57 tools covering:

- **Workspaces** (3 tools) — list workspaces, folders, create projects
- **Projects** (12 tools) — CRUD, copy, share, templates, members, fields, blocks, tasks
- **Tasks** (18 tools) — full CRUD, assign, due dates, completion, notes, custom fields
- **AI Agents** (15 tools) — create, configure, publish, knowledge management, conversations
- **Templates** — generate projects from custom templates
- **Media** (3 tools) — list, get, delete media files
- **Personal** — list user's projects

### Details

- **GitHub**: https://github.com/taskade/mcp
- **npm**: `@taskade/mcp-server`
- **License**: MIT
- **Language**: TypeScript
- **Dockerfile**: Available in the repo root
- **Auth**: Requires `TASKADE_API_KEY` (from [Taskade Settings > API](https://www.taskade.com/settings/api))
- **Category**: productivity

### Files included

- `servers/taskade/server.yaml` — Server configuration with commit pinning
- `servers/taskade/tools.json` — 57 tools extracted from source (avoids `build --tools` failures since API key is required)
- `servers/taskade/readme.md` — Documentation link

> Note: `tools.json` is provided because the server requires a valid `TASKADE_API_KEY` to start and list tools. This follows the guidance in CONTRIBUTING.md for servers that need configuration before listing tools.