### PR TITLE
Add hass-mcp-plus: Enhanced Home Assistant MCP server

### DIFF
--- a/servers/hass-mcp-plus/server.yaml
+++ b/servers/hass-mcp-plus/server.yaml
@@ -1,0 +1,40 @@
+name: hass-mcp-plus
+image: mcp/hass-mcp-plus
+type: server
+meta:
+  category: home-automation
+  tags:
+    - home-automation
+    - smart-home
+    - home-assistant
+about:
+  title: Hass-MCP-Plus
+  description: Enhanced Home Assistant MCP server with 24 tools for smart home control, automation trace debugging, entity registry management, CEL expression queries, long-term statistics, and core journal log access.
+  icon: https://www.home-assistant.io/images/favicon-192x192.png
+source:
+  project: https://github.com/rmaher001/hass-mcp-plus
+  branch: master
+  commit: fcb71361757446cc6df086010d18677b443da8f2
+config:
+  description: Configure the connection to Home Assistant
+  secrets:
+    - name: hass-mcp-plus.ha_token
+      env: HA_TOKEN
+      example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...
+    - name: hass-mcp-plus.ha_url
+      env: HA_URL
+      example: http://192.168.1.100:8123
+  env:
+    - name: TZ
+      example: America/Los_Angeles
+      value: "{{hass-mcp-plus.tz}}"
+    - name: HA_VERIFY_SSL
+      example: "false"
+      value: "{{hass-mcp-plus.ha_verify_ssl}}"
+  parameters:
+    type: object
+    properties:
+      tz:
+        type: string
+      ha_verify_ssl:
+        type: string

--- a/servers/hass-mcp-plus/tools.json
+++ b/servers/hass-mcp-plus/tools.json
@@ -1,0 +1,210 @@
+[
+  {
+    "name": "get_version",
+    "description": "Get the Home Assistant version",
+    "arguments": []
+  },
+  {
+    "name": "get_entity",
+    "description": "Get the state of a Home Assistant entity with optional field filtering",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID to get (e.g. light.living_room)"},
+      {"name": "fields", "type": "array", "desc": "Optional list of fields to include"},
+      {"name": "detailed", "type": "boolean", "desc": "If true, returns all entity fields"}
+    ]
+  },
+  {
+    "name": "entity_action",
+    "description": "Perform an action on a Home Assistant entity (on, off, toggle)",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID to control"},
+      {"name": "action", "type": "string", "desc": "The action: on, off, toggle"},
+      {"name": "params", "type": "object", "desc": "Optional additional parameters"}
+    ]
+  },
+  {
+    "name": "list_entities",
+    "description": "Get a list of Home Assistant entities with optional filtering",
+    "arguments": [
+      {"name": "domain", "type": "string", "desc": "Optional domain filter"},
+      {"name": "search_query", "type": "string", "desc": "Optional search term"},
+      {"name": "limit", "type": "integer", "desc": "Maximum entities to return"},
+      {"name": "compact", "type": "boolean", "desc": "Minimal output format"}
+    ]
+  },
+  {
+    "name": "search_entities",
+    "description": "Search for entities matching a query string",
+    "arguments": [
+      {"name": "query", "type": "string", "desc": "Search query"},
+      {"name": "limit", "type": "integer", "desc": "Maximum results"}
+    ]
+  },
+  {
+    "name": "query_entities",
+    "description": "Query entities using CEL expressions with numeric comparisons and boolean logic",
+    "arguments": [
+      {"name": "domain", "type": "string", "desc": "Optional domain pre-filter"},
+      {"name": "expression", "type": "string", "desc": "CEL expression for filtering"},
+      {"name": "limit", "type": "integer", "desc": "Maximum entities to return"}
+    ]
+  },
+  {
+    "name": "domain_summary",
+    "description": "Get a summary of entities in a specific domain",
+    "arguments": [
+      {"name": "domain", "type": "string", "desc": "The domain to summarize"},
+      {"name": "example_limit", "type": "integer", "desc": "Max examples per state"}
+    ]
+  },
+  {
+    "name": "system_overview",
+    "description": "Get a comprehensive overview of the entire Home Assistant system",
+    "arguments": []
+  },
+  {
+    "name": "get_entity_registry",
+    "description": "Get detailed registry entry for a single entity",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID to look up"}
+    ]
+  },
+  {
+    "name": "list_entity_registry",
+    "description": "List all entity registry entries with optional domain filter",
+    "arguments": [
+      {"name": "domain", "type": "string", "desc": "Optional domain filter"},
+      {"name": "limit", "type": "integer", "desc": "Maximum entries to return"}
+    ]
+  },
+  {
+    "name": "update_entity",
+    "description": "Update entity properties: rename, change icon, assign area, disable/enable, hide/unhide",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID to update"},
+      {"name": "name", "type": "string", "desc": "Custom friendly name"},
+      {"name": "icon", "type": "string", "desc": "Custom icon"},
+      {"name": "disabled_by", "type": "string", "desc": "Set to user to disable, none to enable"},
+      {"name": "hidden_by", "type": "string", "desc": "Set to user to hide, none to unhide"},
+      {"name": "area_id", "type": "string", "desc": "Assign to area"},
+      {"name": "new_entity_id", "type": "string", "desc": "Rename entity ID"}
+    ]
+  },
+  {
+    "name": "remove_entity",
+    "description": "Remove an entity from the registry with two-phase safety (preview before delete)",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID to remove"},
+      {"name": "confirm", "type": "boolean", "desc": "If true, performs removal; if false, previews"}
+    ]
+  },
+  {
+    "name": "list_automations",
+    "description": "Get a list of all automations with pagination",
+    "arguments": [
+      {"name": "limit", "type": "integer", "desc": "Maximum automations to return"}
+    ]
+  },
+  {
+    "name": "list_automation_traces",
+    "description": "Get recent execution traces for a specific automation",
+    "arguments": [
+      {"name": "automation_id", "type": "string", "desc": "The automation ID"},
+      {"name": "domain", "type": "string", "desc": "Domain: automation or script"},
+      {"name": "limit", "type": "integer", "desc": "Maximum traces to return"}
+    ]
+  },
+  {
+    "name": "get_automation_trace",
+    "description": "Get detailed trace for a specific automation run",
+    "arguments": [
+      {"name": "automation_id", "type": "string", "desc": "The automation ID"},
+      {"name": "run_id", "type": "string", "desc": "The specific run ID"},
+      {"name": "domain", "type": "string", "desc": "Domain: automation or script"}
+    ]
+  },
+  {
+    "name": "get_error_log",
+    "description": "Get the Home Assistant error log with integration and level filtering",
+    "arguments": [
+      {"name": "limit", "type": "integer", "desc": "Maximum records to return"},
+      {"name": "integration", "type": "string", "desc": "Filter by integration name"},
+      {"name": "level", "type": "string", "desc": "Filter by log level"},
+      {"name": "since_minutes", "type": "integer", "desc": "Only return errors from last N minutes"}
+    ]
+  },
+  {
+    "name": "get_core_logs",
+    "description": "Get Home Assistant core journal logs with debug-level filtering",
+    "arguments": [
+      {"name": "limit", "type": "integer", "desc": "Maximum records to return"},
+      {"name": "level", "type": "string", "desc": "Filter: DEBUG, INFO, WARNING, ERROR"},
+      {"name": "integration", "type": "string", "desc": "Filter by integration name"},
+      {"name": "pattern", "type": "string", "desc": "Substring match on message content"},
+      {"name": "since_minutes", "type": "integer", "desc": "Only return logs from last N minutes"}
+    ]
+  },
+  {
+    "name": "set_log_level",
+    "description": "Set the log level for a Home Assistant integration",
+    "arguments": [
+      {"name": "integration", "type": "string", "desc": "Integration name"},
+      {"name": "level", "type": "string", "desc": "Log level: debug, info, warning, error"},
+      {"name": "custom_component", "type": "boolean", "desc": "Target custom_components path"}
+    ]
+  },
+  {
+    "name": "get_history",
+    "description": "Get raw state change history with automatic pagination and sampling",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID"},
+      {"name": "hours", "type": "integer", "desc": "Hours of history"},
+      {"name": "limit", "type": "integer", "desc": "Maximum records"},
+      {"name": "sample_strategy", "type": "string", "desc": "Sampling: recent, first, even"}
+    ]
+  },
+  {
+    "name": "get_history_range",
+    "description": "Get state changes for a specific date/time range with sampling",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID"},
+      {"name": "start_time", "type": "string", "desc": "Start time (ISO 8601)"},
+      {"name": "end_time", "type": "string", "desc": "End time (ISO 8601)"},
+      {"name": "limit", "type": "integer", "desc": "Maximum records"},
+      {"name": "sample_strategy", "type": "string", "desc": "Sampling: recent, first, even"}
+    ]
+  },
+  {
+    "name": "get_statistics",
+    "description": "Get aggregated statistics (mean, min, max) with configurable periods",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID"},
+      {"name": "hours", "type": "integer", "desc": "Hours of statistics"},
+      {"name": "period", "type": "string", "desc": "Period: 5minute, hour, day, week, month"}
+    ]
+  },
+  {
+    "name": "get_statistics_range",
+    "description": "Get long-term statistics for any date range",
+    "arguments": [
+      {"name": "entity_id", "type": "string", "desc": "The entity ID"},
+      {"name": "start_time", "type": "string", "desc": "Start time (ISO 8601)"},
+      {"name": "end_time", "type": "string", "desc": "End time (ISO 8601)"},
+      {"name": "period", "type": "string", "desc": "Period: 5minute, hour, day, week, month"}
+    ]
+  },
+  {
+    "name": "call_service",
+    "description": "Call any Home Assistant service (low-level API access)",
+    "arguments": [
+      {"name": "domain", "type": "string", "desc": "Service domain"},
+      {"name": "service", "type": "string", "desc": "Service name"},
+      {"name": "data", "type": "object", "desc": "Service data"}
+    ]
+  },
+  {
+    "name": "restart_ha",
+    "description": "Restart Home Assistant",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## Summary

Adds **hass-mcp-plus**, an enhanced Home Assistant MCP server with 24 tools for smart home control and monitoring.

## Server Details

- **Repository**: https://github.com/rmaher001/hass-mcp-plus
- **License**: MIT
- **Language**: Python 3.13+
- **Category**: home-automation

## Key Features

- **24 tools** for comprehensive Home Assistant control
- **CEL expression queries** for complex entity filtering (e.g., "all battery sensors below 20%")
- **Entity registry management** — remove, update, list, and inspect registry entries
- **Two-phase delete safety** for entity removal (preview before delete)
- **Long-term statistics** with hourly/daily/weekly/monthly aggregation
- **Automation trace debugging** — list and inspect execution traces
- **Core journal log access** with debug-level and integration filtering
- **Context flooding prevention** with pagination, sampling, and truncation
- **Input validation and error sanitization** on all API calls
- **167 tests** covering unit, integration, and security scenarios

## Configuration

Requires two secrets:
- `HA_TOKEN` — Home Assistant Long-Lived Access Token
- `HA_URL` — Home Assistant URL

Optional environment variables:
- `TZ` — Timezone
- `HA_VERIFY_SSL` — SSL certificate verification

## Notes

- Includes `tools.json` with all 24 tool definitions since the server requires HA credentials to start
- Available on [PyPI](https://pypi.org/project/hass-mcp-plus/) and [Docker Hub](https://hub.docker.com/r/rmaher001/hass-mcp-plus)