### PR TITLE
Add RouteMesh MCP server

### DIFF
--- a/servers/routemesh/server.yaml
+++ b/servers/routemesh/server.yaml
@@ -1,0 +1,21 @@
+name: routemesh
+image: mcp/routemesh
+type: server
+meta:
+  category: web-services
+  tags:
+    - blockchain
+    - rpc
+    - evm
+about:
+  title: RouteMesh
+  description: Query multiple EVM blockchain chains from one MCP server. Pull on-chain data including blocks, transactions, logs, balances, and fees with RouteMesh routing and failover.
+  icon: https://www.google.com/s2/favicons?domain=routeme.sh&sz=64
+source:
+  project: https://github.com/routemesh/routemesh-mcp
+  commit: d73839769ee61e278047dea9db2a6a8c78009784
+config:
+  secrets:
+    - name: routemesh.api_key
+      env: ROUTEMESH_API_KEY
+      example: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


### PR DESCRIPTION
## MCP Server Information

**Server Name:** routemesh
**Repository URL:** https://github.com/routemesh/routemesh-mcp
**Brief Description:** Read-only MCP server for querying blockchain data across multiple EVM chains via RouteMesh routing and failover.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name routemesh`
- [x] I have built the MCP Server using `task build -- --tools routemesh`