### PR TITLE
Add deBridge MCP server

### DIFF
--- a/servers/debridge/server.yaml
+++ b/servers/debridge/server.yaml
@@ -1,0 +1,14 @@
+name: debridge
+image: mcp/debridge-mcp
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+about:
+  title: DeBridge
+  description: Official MCP server for the deBridge cross-chain protocol for cross-chain liquidity routing, swap execution, pricing, fee estimation, and DeFi transaction orchestration across blockchains like Solana, Ethereum, Arbitrum, Optimism, Base, Polygon, BNB Chain, Avalanche, Linea, Scroll, TON and others.
+  icon: https://debridge.com/assets/img/logo/token.svg
+source:
+  project: https://github.com/debridge-finance/debridge-mcp
+  commit: 81e9802df6e8f001c48e74828a3d606a7fac1777


### PR DESCRIPTION
# Summary

Adds Official MCP server for the [deBridge](https://debridge.com) protocol. 

## MCP Server Information

**Server Name:** deBridge
**Repository URL:** [debridge-finance/debridge-mcp])https://github.com/debridge-finance/debridge-mcp)
**Brief Description:** Exposes programmatic endpoints for cross-chain liquidity routing, swap execution, pricing, fee estimation, and transaction orchestration across heterogeneous blockchain environments.

## Basic Requirements

- [X] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [X] **MCP Compliant**: Implements MCP API specification
- [X] **Active Development**: Recent commits and maintained
- [X] **Docker Artifact**: Dockerfile
- [X] **Documentation**: Basic README and setup instructions
- [X] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [X] This server meets the basic requirements listed above
- [X] I understand this will undergo automated and manual review.
- [X] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [X] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [X] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

deBridge issue reference: https://github.com/debridge-finance/debridge-mcp/issues/3 
