### PR TITLE
Add Lumenore Analytics MCP Server

### DIFF
--- a/servers/lumenore-mcp/readme.md
+++ b/servers/lumenore-mcp/readme.md
@@ -1,0 +1,26 @@
+# Lumenore Analytics MCP Server
+
+Provides AI assistants with access to Lumenore's analytics and natural language query capabilities across 273 datasets.
+
+## Features
+
+- **Natural Language Queries**: Convert questions to data insights
+- **Advanced Analytics**: Trends, predictions, correlations, outliers, changes, Pareto analysis
+- **Real-time Processing**: Stream responses for large datasets
+- **Zero Data Storage**: In-memory processing with no persistent logging
+
+## Configuration
+
+Required credentials:
+- `LUMENORE_CLIENT_ID`: Your client ID
+- `LUMENORE_SECRET`: Your secret key
+- `SERVER_URL`: Lumenore server URL (optional, defaults to https://preview.lumenore.com)
+
+## Usage
+
+Query datasets using natural language and leverage 8 analytics tools for comprehensive insights.
+
+## Links
+
+- [GitHub Repository](https://github.com/Lumenore-Platform/lumenore-mcp)
+- [Lumenore Platform](https://lumenore.com)

--- a/servers/lumenore-mcp/server.yaml
+++ b/servers/lumenore-mcp/server.yaml
@@ -1,0 +1,38 @@
+name: lumenore-mcp
+image: mcp/lumenore-mcp
+type: server
+meta:
+  category: analytics
+  tags:
+    - analytics
+    - business-intelligence
+    - nlq
+    - data-science
+    - ai
+  about:
+    title: Lumenore Analytics MCP Server
+    description: |
+      A Model Context Protocol server providing AI assistants with access to 
+      Lumenore's analytics and natural language query capabilities. Offers 
+      advanced analytics including trends, predictions, correlations, outliers, 
+      and Pareto analysis across 273 datasets.
+    icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
+  source:
+    project: https://github.com/Lumenore-Platform/lumenore-mcp
+    commit: 3f8518e800eefc1bb7e09cf21c6ebf302158da0e
+  config:
+    description: Configure Lumenore API credentials
+    secrets:
+      - name: lumenore-mcp.client_id
+        env: LUMENORE_CLIENT_ID
+        example: "your_client_id"
+        description: "Lumenore API Client ID"
+      - name: lumenore-mcp.secret
+        env: LUMENORE_SECRET
+        example: "your_secret_key"
+        description: "Lumenore API Secret Key"
+    env:
+      - name: SERVER_URL
+        default: "https://preview.lumenore.com"
+        example: "https://preview.lumenore.com"
+        description: "Lumenore server URL"

--- a/servers/lumenore-mcp/tools.json
+++ b/servers/lumenore-mcp/tools.json
@@ -1,0 +1,130 @@
+[
+  {
+    "name": "nlq_to_data",
+    "description": "Converts natural language queries into structured data analysis results. Processes user queries expressed in plain English and transforms them into appropriate analytical operations on the specified dataset schema.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language question to convert into structured data query (e.g., 'show me top 10 customers by revenue')"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema to query against. Must be a positive integer."
+      }
+    ]
+  },
+  {
+    "name": "get_trend_data",
+    "description": "Performs trend analysis to identify temporal patterns and directional changes in data. Analyzes time-based patterns, growth trends, seasonal behaviors, and directional changes.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language query describing the trend analysis needed"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema to analyze"
+      }
+    ]
+  },
+  {
+    "name": "get_dataset_metadata",
+    "description": "Fetches all available datasets with comprehensive metadata including dataset names, IDs, timestamps, and types.",
+    "arguments": []
+  },
+  {
+    "name": "get_predicted_data",
+    "description": "Generates predictive analytics and forecasts based on historical data patterns.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language query describing the prediction needed"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema"
+      }
+    ]
+  },
+  {
+    "name": "get_correlated_data",
+    "description": "Identifies correlations and relationships between different data variables.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language query describing the correlation analysis needed"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema"
+      }
+    ]
+  },
+  {
+    "name": "get_outlier_data",
+    "description": "Detects anomalies and outliers in datasets using statistical analysis.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language query describing the outlier detection needed"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema"
+      }
+    ]
+  },
+  {
+    "name": "get_changed_data",
+    "description": "Identifies significant changes and variations in data over time.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language query describing the change detection needed"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema"
+      }
+    ]
+  },
+  {
+    "name": "get_pareto_data",
+    "description": "Performs Pareto analysis (80/20 rule) to identify key contributing factors.",
+    "arguments": [
+      {
+        "name": "userQuery",
+        "type": "string",
+        "desc": "Natural language query describing the Pareto analysis needed"
+      },
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema"
+      }
+    ]
+  },
+  {
+    "name": "get_schema_metadata",
+    "description": "Retrieves detailed schema information for a specific dataset including column definitions, data types, and constraints.",
+    "arguments": [
+      {
+        "name": "schemaId",
+        "type": "integer",
+        "desc": "Integer identifier for the dataset schema"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adding Lumenore Analytics MCP Server - provides AI assistants with access to business intelligence and natural language query capabilities across 273 datasets.

### Type of MCP Server
- [x] Local MCP Server (Docker-built image)

### Checklist
- [x] I have read the contributing guidelines
- [x] My MCP server has a valid open-source license (MIT)
- [x] I have created server.yaml with all required fields
- [x] I have added tools.json
- [x] I have added readme.md
- [x] My GitHub repository contains a Dockerfile
- [x] All required environment variables are documented

### Additional Information
- **Category**: Analytics
- **License**: MIT
- **Repository**: https://github.com/Lumenore-Platform/lumenore-mcp
- **Tools**: 8 analytics tools (NLQ, trends, predictions, correlations, outliers, change detection, Pareto analysis)
- **Datasets**: 273 business intelligence datasets
- **Authentication**: Client credentials (LUMENORE_CLIENT_ID, LUMENORE_SECRET)