### PR TITLE
Update version of fetch reference server

### DIFF
--- a/servers/fetch/server.yaml
+++ b/servers/fetch/server.yaml
@@ -12,6 +12,6 @@ about:
   icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
 source:
   project: https://github.com/modelcontextprotocol/servers
-  branch: 2025.4.24
-  commit: b4ee623039a6c60053ce67269701ad9e95073306
+  branch: main
+  commit: 04cce79b4c2bbaa313095e9c2a466381f5fd1e64
   directory: src/fetch


### PR DESCRIPTION
This is needed so we can run fetch in streaming mode (requires mcp sdk version 1.8+ and the current image uses 1.2.0)