### PR TITLE
Update ThingsBoard MCP Server Commit Reference and Configuration

### DIFF
--- a/servers/thingsboard/server.yaml
+++ b/servers/thingsboard/server.yaml
@@ -21,14 +21,12 @@ about:
   icon: https://avatars.githubusercontent.com/u/24291394?v=4
 source:
   project: https://github.com/thingsboard/thingsboard-mcp
-  commit: adac2d247c408487ef1f99ebb65f8889792dc632
+  commit: e2cf79bd826599c39d76b6a58f576da3cd00ed12
 config:
   description: Configure the connection to ThingsBoard
   secrets:
-    - name: thingsboard.username
-      env: THINGSBOARD_USERNAME
-    - name: thingsboard.password
-      env: THINGSBOARD_PASSWORD
+    - name: thingsboard.api-key
+      env: THINGSBOARD_API_KEY
   env:
     - name: THINGSBOARD_URL
       example: https://demo.thingsboard.io


### PR DESCRIPTION
* Updated ThingsBoard MCP Server from **v1.0.0** to **v2.1.0**
* Use **api_key** instead of **username** and **password** as authentication method

