### PR TITLE
Add AgentDeals — developer infrastructure deals MCP server

### DIFF
--- a/servers/agentdeals/server.yaml
+++ b/servers/agentdeals/server.yaml
@@ -1,0 +1,19 @@
+name: agentdeals
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: cost-management
+  tags:
+    - cost-management
+    - developer-tools
+    - deals
+    - free-tiers
+    - remote
+about:
+  title: AgentDeals
+  description: Search and discover free tiers, startup credits, and pricing changes across 250+ developer infrastructure deals in 38 categories. Track which free tiers are disappearing and find the best deals for your stack.
+  icon: https://raw.githubusercontent.com/robhunter/agentdeals/main/assets/logo-400.png
+remote:
+  transport_type: streamable-http
+  url: https://agentdeals-production.up.railway.app/mcp


### PR DESCRIPTION
## What

Adds AgentDeals, a remote MCP server that aggregates free tiers, startup credits, and pricing changes across 250+ developer infrastructure deals in 38 categories.

## Details

- **Type:** Remote (streamable-http)
- **URL:** https://agentdeals-production.up.railway.app/mcp
- **Auth:** None required
- **Tools:** 4 — `search_offers` (with pagination, sorting, eligibility filtering), `list_categories`, `get_offer_details`, `get_deal_changes`
- **Data:** 252 offers across 38 categories, 38 tracked pricing changes
- **Source:** https://github.com/robhunter/agentdeals
- **Registry:** Listed on Official MCP Registry (`io.github.robhunter/agentdeals`)

## Why

Developer free tiers are disappearing rapidly (Postman, LocalStack, HCP Terraform, and others making changes in March 2026 alone). AgentDeals helps developers and AI agents discover the best deals for their stack and track which free tiers are being removed or degraded.

## Verification

The server is live and can be tested:

```bash
curl -X POST https://agentdeals-production.up.railway.app/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
```

Health check: https://agentdeals-production.up.railway.app/health