### PR TITLE
Remove DuckDuckGo logo and add unofficial disclaimer

### DIFF
--- a/servers/duckduckgo/server.yaml
+++ b/servers/duckduckgo/server.yaml
@@ -7,7 +7,7 @@ meta:
     - duckduckgo
     - devops
 about:
-  title: DuckDuckGo Search
+  title: DuckDuckGo
   description: "Community-maintained MCP server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo."
 source:
   project: https://github.com/nickclyde/duckduckgo-mcp-server


### PR DESCRIPTION
## Summary
- Remove DuckDuckGo trademarked logo from server listing
- Add disclaimer that the server is community-maintained and not affiliated with DuckDuckGo

Ref: https://docker.atlassian.net/browse/CSESC-1266