### PR TITLE
Add default Docker icon for DuckDuckGo server

### DIFF
--- a/servers/duckduckgo/server.yaml
+++ b/servers/duckduckgo/server.yaml
@@ -8,6 +8,7 @@ meta:
     - devops
 about:
   title: DuckDuckGo
+  icon: https://avatars.githubusercontent.com/u/5429470?s=200&v=4
   description: "Community-maintained MCP server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo."
 source:
   project: https://github.com/nickclyde/duckduckgo-mcp-server


### PR DESCRIPTION
## Summary
- Add Docker logo as default icon for DuckDuckGo server to replace removed trademarked logo

Ref: https://docker.atlassian.net/browse/CSESC-1266