### PR TITLE
Add LimitGuard Trust Intelligence remote MCP server

### DIFF
--- a/servers/limitguard-trust-intelligence/server.yaml
+++ b/servers/limitguard-trust-intelligence/server.yaml
@@ -1,0 +1,22 @@
+name: limitguard-trust-intelligence
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: security
+  tags:
+    - security
+    - compliance
+    - kyb
+    - sanctions
+    - trust
+    - risk-scoring
+    - europe
+    - remote
+about:
+  title: LimitGuard Trust Intelligence
+  description: Entity verification, sanctions screening, and trust scoring for AI agents. Includes KVK/CBE registry checks, OpenSanctions watchlist screening, domain verification, and blockchain wallet risk analysis. Pay-per-call via x402 micropayments (USDC).
+  icon: https://limitguard.ai/favicon.svg
+remote:
+  transport_type: streamable-http
+  url: https://api.limitguard.ai/mcp


### PR DESCRIPTION
## Summary

Adds LimitGuard Trust Intelligence as a remote MCP server entry.

**Type:** Remote (Streamable HTTP)
**URL:** `https://api.limitguard.ai/mcp`
**Category:** Security

## What it does

LimitGuard provides entity trust verification for AI agents:

- **check_entity** — Full entity trust check (KVK/CBE registry, sanctions, domain, risk scoring)
- **check_agent** — Verify AI agent identity and reputation
- **trust_score** — Entity trust score (0-100) with cluster assignment
- **verify_wallet** — Blockchain wallet address verification and risk flags
- **risk_score** — Quick risk score for entity name + country pair

## Auth

x402 micropayment protocol (USDC on Base or Solana). No API key or subscription needed — AI agents pay per call.

## Discovery

- MCP Tools: https://api.limitguard.ai/.well-known/mcp.json
- x402 Pricing: https://api.limitguard.ai/.well-known/x402.json
- Health: https://api.limitguard.ai/health
- Status: https://status.limitguard.ai

## License

MIT — https://github.com/JWconsultancy1234/limitguard-mcp/blob/main/LICENSE