### PR TITLE
Add pancake-mcp server

### DIFF
--- a/servers/pancake-mcp/readme.md
+++ b/servers/pancake-mcp/readme.md
@@ -1,0 +1,7 @@
+# Pancake POS MCP Server
+
+Access your Pancake POS shop data including orders, warehouses, shipping, and customer conversations.
+
+Documentation: https://github.com/lynguyenvu/pancake-mcp-server
+
+Support: Create an issue in the repository if you encounter any problems.

--- a/servers/pancake-mcp/server.yaml
+++ b/servers/pancake-mcp/server.yaml
@@ -1,0 +1,52 @@
+name: pancake-mcp
+image: lynguyenvu/pancake-mcp
+type: server
+meta:
+  category: business
+  tags:
+    - pos
+    - ecommerce
+    - vietnam
+    - business
+about:
+  title: Pancake POS MCP
+  description: Tools for managing Pancake POS shop: orders, warehouses, shipping, returns, and geographic address data for Vietnam
+  icon: https://pancake.biz/favicon.ico
+source:
+  project: https://github.com/lynguyenvu/pancake-mcp-server
+  commit: main
+config:
+  description: Configure your Pancake POS API connection
+  secrets:
+    - name: pancake-mcp.api_key
+      env: PANCAKE_API_KEY
+      example: "<your_pos_api_key>"
+    - name: pancake-mcp.access_token
+      env: PANCAKE_ACCESS_TOKEN
+      example: "<your_chat_access_token>"
+  env:
+    - name: PANCAKE_API_BASE_URL
+      example: "https://pos.pages.fm/api/v1"
+      value: "{{pancake-mcp.api_base_url}}"
+    - name: MCP_HOST
+      example: "0.0.0.0"
+      value: "{{pancake-mcp.mcp_host}}"
+    - name: MCP_PORT
+      example: "8000"
+      value: "{{pancake-mcp.mcp_port}}"
+  parameters:
+    type: object
+    properties:
+      api_base_url:
+        type: string
+        default: "https://pos.pages.fm/api/v1"
+      mcp_host:
+        type: string
+        default: "0.0.0.0"
+      mcp_port:
+        type: string
+        default: "8000"
+    required:
+      - api_base_url
+      - mcp_host
+      - mcp_port

--- a/servers/pancake-mcp/tools.json
+++ b/servers/pancake-mcp/tools.json
@@ -1,0 +1,320 @@
+[
+  {
+    "name": "get_shops",
+    "description": "Get list of all shops in the Pancake POS system",
+    "arguments": []
+  },
+  {
+    "name": "get_provinces",
+    "description": "Get list of Vietnamese provinces",
+    "arguments": []
+  },
+  {
+    "name": "get_districts",
+    "description": "Get districts within a specific province",
+    "arguments": [
+      {
+        "name": "province_code",
+        "type": "string",
+        "desc": "The province code to get districts for"
+      }
+    ]
+  },
+  {
+    "name": "get_communes",
+    "description": "Get communes within a specific district",
+    "arguments": [
+      {
+        "name": "district_code",
+        "type": "string",
+        "desc": "The district code to get communes for"
+      }
+    ]
+  },
+  {
+    "name": "get_payment_methods",
+    "description": "Get available payment methods",
+    "arguments": []
+  },
+  {
+    "name": "search_orders",
+    "description": "Search orders with various filters",
+    "arguments": [
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "Filter by order status"
+      },
+      {
+        "name": "date_from",
+        "type": "string",
+        "desc": "Filter orders from this date (YYYY-MM-DD)"
+      },
+      {
+        "name": "date_to",
+        "type": "string",
+        "desc": "Filter orders to this date (YYYY-MM-DD)"
+      },
+      {
+        "name": "tags",
+        "type": "string",
+        "desc": "Filter by tags"
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "Filter by order source"
+      }
+    ]
+  },
+  {
+    "name": "get_order",
+    "description": "Get details of a specific order",
+    "arguments": [
+      {
+        "name": "order_id",
+        "type": "string",
+        "desc": "The ID of the order to retrieve"
+      }
+    ]
+  },
+  {
+    "name": "create_order",
+    "description": "Create a new order",
+    "arguments": [
+      {
+        "name": "customer_name",
+        "type": "string",
+        "desc": "Customer name"
+      },
+      {
+        "name": "phone",
+        "type": "string",
+        "desc": "Customer phone number"
+      },
+      {
+        "name": "line_items",
+        "type": "array",
+        "desc": "Array of line items in the order"
+      }
+    ]
+  },
+  {
+    "name": "update_order",
+    "description": "Update an existing order",
+    "arguments": [
+      {
+        "name": "order_id",
+        "type": "string",
+        "desc": "ID of the order to update"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "New status for the order"
+      }
+    ]
+  },
+  {
+    "name": "get_order_tags",
+    "description": "Get available order tags",
+    "arguments": []
+  },
+  {
+    "name": "get_order_sources",
+    "description": "Get available order sources",
+    "arguments": []
+  },
+  {
+    "name": "get_active_promotions",
+    "description": "Get currently active promotions",
+    "arguments": []
+  },
+  {
+    "name": "list_warehouses",
+    "description": "List all warehouses",
+    "arguments": [
+      {
+        "name": "shop_id",
+        "type": "string",
+        "desc": "ID of the shop to list warehouses for"
+      }
+    ]
+  },
+  {
+    "name": "create_warehouse",
+    "description": "Create a new warehouse",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Warehouse name"
+      },
+      {
+        "name": "location",
+        "type": "string",
+        "desc": "Warehouse location"
+      }
+    ]
+  },
+  {
+    "name": "update_warehouse",
+    "description": "Update warehouse information",
+    "arguments": [
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "ID of the warehouse to update"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "New warehouse name"
+      }
+    ]
+  },
+  {
+    "name": "get_inventory_history",
+    "description": "Get inventory movement history",
+    "arguments": [
+      {
+        "name": "warehouse_id",
+        "type": "string",
+        "desc": "ID of the warehouse"
+      },
+      {
+        "name": "product_id",
+        "type": "string",
+        "desc": "ID of the product to filter by"
+      },
+      {
+        "name": "date_from",
+        "type": "string",
+        "desc": "Filter from this date (YYYY-MM-DD)"
+      },
+      {
+        "name": "date_to",
+        "type": "string",
+        "desc": "Filter to this date (YYYY-MM-DD)"
+      }
+    ]
+  },
+  {
+    "name": "arrange_shipment",
+    "description": "Arrange shipment for an order",
+    "arguments": [
+      {
+        "name": "order_id",
+        "type": "string",
+        "desc": "ID of the order to arrange shipment for"
+      }
+    ]
+  },
+  {
+    "name": "get_tracking_url",
+    "description": "Get tracking URL for an order",
+    "arguments": [
+      {
+        "name": "order_id",
+        "type": "string",
+        "desc": "ID of the order to get tracking for"
+      }
+    ]
+  },
+  {
+    "name": "list_return_orders",
+    "description": "List return orders",
+    "arguments": []
+  },
+  {
+    "name": "create_return_order",
+    "description": "Create a return order",
+    "arguments": [
+      {
+        "name": "original_order_id",
+        "type": "string",
+        "desc": "ID of the original order"
+      },
+      {
+        "name": "reason",
+        "type": "string",
+        "desc": "Reason for return"
+      }
+    ]
+  },
+  {
+    "name": "list_conversations",
+    "description": "List customer conversations",
+    "arguments": [
+      {
+        "name": "page_id",
+        "type": "string",
+        "desc": "Facebook page ID to filter conversations"
+      }
+    ]
+  },
+  {
+    "name": "get_conversation",
+    "description": "Get details of a specific conversation",
+    "arguments": [
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "ID of the conversation to retrieve"
+      }
+    ]
+  },
+  {
+    "name": "get_messages",
+    "description": "Get messages in a conversation",
+    "arguments": [
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "ID of the conversation"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "Number of messages to retrieve"
+      }
+    ]
+  },
+  {
+    "name": "send_message",
+    "description": "Send a message in a conversation",
+    "arguments": [
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "ID of the conversation"
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "Message content"
+      }
+    ]
+  },
+  {
+    "name": "update_conversation",
+    "description": "Update conversation status/tags",
+    "arguments": [
+      {
+        "name": "conversation_id",
+        "type": "string",
+        "desc": "ID of the conversation to update"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "New status for the conversation"
+      },
+      {
+        "name": "tags",
+        "type": "array",
+        "desc": "Tags to add to the conversation"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Add Pancake POS MCP server to the registry

  This adds a server for managing Pancake POS shop:
  - 25 MCP tools for orders, warehouses, shipping, and conversations
  - Supports Vietnamese address data
  - Includes API key and access token authentication

  For more details: https://github.com/lynguyenvu/pancake-mcp-server