### PR TITLE
Add MoldSim MCP — injection molding simulation knowledge

### DIFF
--- a/servers/moldsim-mcp/server.yaml
+++ b/servers/moldsim-mcp/server.yaml
@@ -1,0 +1,19 @@
+name: moldsim-mcp
+image: mcp/moldsim-mcp
+type: server
+meta:
+  category: tools
+  tags:
+    - injection-molding
+    - simulation
+    - manufacturing
+    - materials
+    - engineering
+    - cae
+about:
+  title: MoldSim MCP
+  description: Injection molding simulation knowledge for AI — material properties (Cross-WLF, PVT, thermal), process validation, DFM analysis, troubleshooting, and simulation spec generation.
+  icon: https://raw.githubusercontent.com/kobzevvv/moldsim-mcp/main/logo.png
+source:
+  project: https://github.com/kobzevvv/moldsim-mcp
+  commit: fb89f2fc1a3c28335f9e4b6236a50cd95d46a1a3

--- a/servers/moldsim-mcp/tools.json
+++ b/servers/moldsim-mcp/tools.json
@@ -1,0 +1,91 @@
+[
+    {
+        "name": "query_simulation_knowledge",
+        "description": "Search injection molding simulation knowledge base. Covers troubleshooting (defects, simulation issues), DFM rules, mesh guidelines, and process parameter recommendations.",
+        "arguments": [
+            {
+                "name": "question",
+                "type": "string",
+                "desc": "Your question about injection molding simulation"
+            },
+            {
+                "name": "context",
+                "type": "string",
+                "desc": "Additional context (material, part type, defect observed)"
+            }
+        ]
+    },
+    {
+        "name": "get_material_properties",
+        "description": "Look up material properties for injection molding simulation. Returns Cross-WLF viscosity model, 2-domain Tait PVT, thermal properties, processing window, and mechanical data.",
+        "arguments": [
+            {
+                "name": "material",
+                "type": "string",
+                "desc": "Material name, family, or ID (e.g., PA66-GF30, PC, ABS, pp-homo)"
+            },
+            {
+                "name": "properties",
+                "type": "string",
+                "desc": "Filter to specific property groups: cross_wlf, pvt, thermal, processing, mechanical. Omit for all properties."
+            }
+        ]
+    },
+    {
+        "name": "validate_process_parameters",
+        "description": "Validate injection molding process parameters against material processing window. Checks melt/mold temperature, estimates shear rate, calculates cooling time, and flags out-of-range values.",
+        "arguments": [
+            {
+                "name": "material",
+                "type": "string",
+                "desc": "Material name or ID (e.g., PA66-GF30, ABS)"
+            },
+            {
+                "name": "melt_temp_C",
+                "type": "number",
+                "desc": "Melt temperature in degrees Celsius"
+            },
+            {
+                "name": "mold_temp_C",
+                "type": "number",
+                "desc": "Mold temperature in degrees Celsius"
+            },
+            {
+                "name": "injection_speed_mm_s",
+                "type": "number",
+                "desc": "Injection speed in mm/s"
+            },
+            {
+                "name": "packing_pressure_MPa",
+                "type": "number",
+                "desc": "Packing pressure in MPa"
+            },
+            {
+                "name": "wall_thickness_mm",
+                "type": "number",
+                "desc": "Nominal wall thickness in mm"
+            },
+            {
+                "name": "cooling_time_s",
+                "type": "number",
+                "desc": "Cooling time in seconds"
+            }
+        ]
+    },
+    {
+        "name": "generate_simulation_spec",
+        "description": "Generate a structured simulation specification from a natural language description. Outputs analysis types, process conditions, mesh recommendations, and expected results.",
+        "arguments": [
+            {
+                "name": "description",
+                "type": "string",
+                "desc": "Describe the part, material, and what you want to analyze"
+            },
+            {
+                "name": "cad_format",
+                "type": "string",
+                "desc": "CAD file format if known (e.g., STEP, STL, Parasolid, IGES)"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Summary

Adds **MoldSim MCP** — an MCP server providing injection molding simulation knowledge for AI agents.

### What it does

- **Material properties lookup**: Cross-WLF viscosity, 2-domain Tait PVT, thermal, processing window, and mechanical data for 20+ engineering plastics
- **Process parameter validation**: Checks melt/mold temperature, shear rate, cooling time against material-specific processing windows
- **Simulation knowledge base**: Troubleshooting defects, DFM rules, mesh guidelines, process recommendations (RAG-powered)
- **Simulation spec generation**: Converts natural language descriptions into structured simulation specifications

### Server info

| Field | Value |
|-------|-------|
| **Name** | moldsim-mcp |
| **npm** | [moldsim-mcp](https://www.npmjs.com/package/moldsim-mcp) |
| **GitHub** | [kobzevvv/moldsim-mcp](https://github.com/kobzevvv/moldsim-mcp) |
| **License** | MIT |
| **Category** | tools |
| **Transport** | stdio |

### Files added

- `servers/moldsim-mcp/server.yaml` — server metadata and source reference
- `servers/moldsim-mcp/tools.json` — tool definitions (4 tools, no configuration required)

### Notes

- No environment variables or secrets needed — the server is a self-contained knowledge base
- Dockerfile is included in the source repository
- `tools.json` is provided to avoid build-time tool listing issues