### PR TITLE
feat: add jobcontextmcp MCP server

### DIFF
--- a/servers/jobcontextmcp/readme.md
+++ b/servers/jobcontextmcp/readme.md
@@ -1,0 +1,1 @@
+[jobContextMCP Documentation](https://github.com/JustLikeFrank3/jobContextMCP)

--- a/servers/jobcontextmcp/server.yaml
+++ b/servers/jobcontextmcp/server.yaml
@@ -1,0 +1,32 @@
+name: jobcontextmcp
+image: docker.io/justlikefrank3/jobcontextmcp:latest
+type: server
+meta:
+  category: productivity
+  tags:
+    - career
+    - job-search
+    - resume
+    - ai
+    - productivity
+about:
+  title: jobContextMCP
+  description: AI-powered job search context server. Manage your master resume, generate tailored resumes and cover letters, track applications and rejections, prep for interviews, analyze compensation, and maintain long-term career memory with RAG over your workspace and Claude.
+  icon: https://avatars.githubusercontent.com/u/JustLikeFrank3
+source:
+  project: https://github.com/JustLikeFrank3/jobContextMCP
+  commit: c9d73325e26b7d75331b5eb956fe2f37ce2d2d1f
+config:
+  description: |
+    jobContextMCP requires a config.json file and two data directories:
+    - Mount your config.json (copy config.example.json and fill in paths + OpenAI API key) to /app/config.json
+    - Mount your resume workspace folder (containing resumes, cover letters, job assessments) to /workspace
+    - Mount your data folder (containing personal_context.json, tone_samples.json, etc.) to /app/data
+    See https://github.com/JustLikeFrank3/jobContextMCP for setup instructions.
+  volumes:
+    - path: /app/config.json
+      description: "config.json — workspace paths and OpenAI API key. Copy config.example.json and fill in your values."
+    - path: /workspace
+      description: "Resume workspace folder containing resumes, cover letters, and job assessment files."
+    - path: /app/data
+      description: "Personal context data folder (applications, tone samples, STAR stories, mental health log)."

--- a/servers/jobcontextmcp/tools.json
+++ b/servers/jobcontextmcp/tools.json
@@ -1,0 +1,284 @@
+[
+  {
+    "name": "get_session_context",
+    "description": "Returns the full master resume and professional background for the current session",
+    "arguments": []
+  },
+  {
+    "name": "get_personal_context",
+    "description": "Returns structured personal context including job search status, target roles, preferences, and career narrative",
+    "arguments": []
+  },
+  {
+    "name": "get_tone_profile",
+    "description": "Returns the user's writing tone profile and writing rules derived from their tone samples",
+    "arguments": []
+  },
+  {
+    "name": "get_daily_digest",
+    "description": "Returns a summary of today's job search activity including applications, rejections, and action items",
+    "arguments": []
+  },
+  {
+    "name": "get_daily_checkin_nudge",
+    "description": "Returns a personalized check-in nudge based on recent job search activity and mental health log",
+    "arguments": []
+  },
+  {
+    "name": "get_job_hunt_status",
+    "description": "Returns current job hunt status including active applications, pipeline, and recent events",
+    "arguments": []
+  },
+  {
+    "name": "generate_resume",
+    "description": "Generates a tailored resume for a specific company and role based on the master resume and job description",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Target company name" },
+      { "name": "role", "type": "string", "desc": "Target job title" },
+      { "name": "job_description", "type": "string", "desc": "Full or summarized job description" },
+      { "name": "output_filename", "type": "string", "desc": "Output filename for the resume" }
+    ]
+  },
+  {
+    "name": "generate_cover_letter",
+    "description": "Generates a tailored cover letter for a specific company and role using the user's tone profile",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Target company name" },
+      { "name": "role", "type": "string", "desc": "Target job title" },
+      { "name": "job_description", "type": "string", "desc": "Full or summarized job description" },
+      { "name": "hiring_manager", "type": "string", "desc": "Hiring manager name (optional)" }
+    ]
+  },
+  {
+    "name": "export_resume_pdf",
+    "description": "Exports a resume text file to a styled PDF using the resume HTML template",
+    "arguments": [
+      { "name": "filename", "type": "string", "desc": "Source resume .txt filename in the workspace" },
+      { "name": "output_filename", "type": "string", "desc": "Output PDF filename (optional)" }
+    ]
+  },
+  {
+    "name": "export_cover_letter_pdf",
+    "description": "Exports a cover letter text file to a styled PDF using the cover letter HTML template",
+    "arguments": [
+      { "name": "filename", "type": "string", "desc": "Source cover letter .txt filename in the workspace" },
+      { "name": "output_filename", "type": "string", "desc": "Output PDF filename (optional)" }
+    ]
+  },
+  {
+    "name": "log_application_event",
+    "description": "Logs a job application event (applied, phone screen, interview, offer, rejection) to the tracker",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Company name" },
+      { "name": "role", "type": "string", "desc": "Job title" },
+      { "name": "event", "type": "string", "desc": "Event type: applied | screen | interview | offer | rejected" },
+      { "name": "notes", "type": "string", "desc": "Optional notes about the event" }
+    ]
+  },
+  {
+    "name": "update_application",
+    "description": "Updates status or notes on an existing job application",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Company name" },
+      { "name": "role", "type": "string", "desc": "Job title" },
+      { "name": "status", "type": "string", "desc": "New status" },
+      { "name": "notes", "type": "string", "desc": "Optional updated notes" }
+    ]
+  },
+  {
+    "name": "log_rejection",
+    "description": "Logs a job rejection with optional notes and lessons learned",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Company name" },
+      { "name": "role", "type": "string", "desc": "Job title" },
+      { "name": "reason", "type": "string", "desc": "Rejection reason or notes (optional)" }
+    ]
+  },
+  {
+    "name": "get_rejections",
+    "description": "Returns the rejection log with patterns and lessons learned",
+    "arguments": []
+  },
+  {
+    "name": "generate_interview_prep_context",
+    "description": "Generates interview prep context document for a specific company and role",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Target company name" },
+      { "name": "role", "type": "string", "desc": "Target job title" },
+      { "name": "job_description", "type": "string", "desc": "Full or summarized job description" }
+    ]
+  },
+  {
+    "name": "get_interview_quick_reference",
+    "description": "Returns the interview quick reference sheet for same-day prep",
+    "arguments": []
+  },
+  {
+    "name": "get_star_story_context",
+    "description": "Returns STAR-format stories from the personal story bank for interview prep",
+    "arguments": [
+      { "name": "topic", "type": "string", "desc": "Optional topic filter (e.g. leadership, conflict, technical)" }
+    ]
+  },
+  {
+    "name": "log_personal_story",
+    "description": "Logs a new STAR-format story to the personal story bank",
+    "arguments": [
+      { "name": "title", "type": "string", "desc": "Story title" },
+      { "name": "situation", "type": "string", "desc": "Situation context" },
+      { "name": "task", "type": "string", "desc": "What was your task or responsibility" },
+      { "name": "action", "type": "string", "desc": "Actions you took" },
+      { "name": "result", "type": "string", "desc": "Measurable outcome" }
+    ]
+  },
+  {
+    "name": "ingest_anecdote",
+    "description": "Ingests a raw career anecdote or story and structures it into a STAR format",
+    "arguments": [
+      { "name": "anecdote", "type": "string", "desc": "Raw anecdote text to structure" }
+    ]
+  },
+  {
+    "name": "get_mental_health_log",
+    "description": "Returns the mental health and energy log for the job search period",
+    "arguments": []
+  },
+  {
+    "name": "log_mental_health_checkin",
+    "description": "Logs a mental health check-in with mood, energy level, and notes",
+    "arguments": [
+      { "name": "mood", "type": "string", "desc": "Mood descriptor" },
+      { "name": "energy", "type": "number", "desc": "Energy level 1-10" },
+      { "name": "notes", "type": "string", "desc": "Optional free-text notes" }
+    ]
+  },
+  {
+    "name": "get_people",
+    "description": "Returns the people/networking log including contacts, referrals, and relationships",
+    "arguments": []
+  },
+  {
+    "name": "log_person",
+    "description": "Adds or updates a person in the networking log",
+    "arguments": [
+      { "name": "name", "type": "string", "desc": "Person's name" },
+      { "name": "company", "type": "string", "desc": "Their company" },
+      { "name": "relationship", "type": "string", "desc": "Relationship context" },
+      { "name": "notes", "type": "string", "desc": "Optional notes" }
+    ]
+  },
+  {
+    "name": "draft_outreach_message",
+    "description": "Drafts a personalized outreach or follow-up message for a specific contact",
+    "arguments": [
+      { "name": "name", "type": "string", "desc": "Recipient's name" },
+      { "name": "context", "type": "string", "desc": "Context for the outreach (referral request, follow-up, coffee chat, etc.)" }
+    ]
+  },
+  {
+    "name": "get_linkedin_posts",
+    "description": "Returns the LinkedIn post log including drafts, published posts, and engagement metrics",
+    "arguments": []
+  },
+  {
+    "name": "log_linkedin_post",
+    "description": "Logs a new LinkedIn post draft or published post to the post tracker",
+    "arguments": [
+      { "name": "title", "type": "string", "desc": "Post title or topic" },
+      { "name": "content", "type": "string", "desc": "Post content" },
+      { "name": "status", "type": "string", "desc": "draft | published" }
+    ]
+  },
+  {
+    "name": "log_tone_sample",
+    "description": "Adds a writing sample to the tone profile for voice calibration",
+    "arguments": [
+      { "name": "sample", "type": "string", "desc": "Writing sample text" },
+      { "name": "source", "type": "string", "desc": "Source of the sample (LinkedIn post, cover letter, etc.)" }
+    ]
+  },
+  {
+    "name": "scan_materials_for_tone",
+    "description": "Scans resume and writing materials in the workspace to build or update the tone profile",
+    "arguments": []
+  },
+  {
+    "name": "scan_project_for_skills",
+    "description": "Scans a side project folder and extracts skills, technologies, and contributions",
+    "arguments": [
+      { "name": "project_path", "type": "string", "desc": "Path to the project folder (optional, uses configured paths)" }
+    ]
+  },
+  {
+    "name": "search_materials",
+    "description": "Semantic RAG search over the resume workspace and data using OpenAI embeddings and FAISS",
+    "arguments": [
+      { "name": "query", "type": "string", "desc": "Natural language search query" },
+      { "name": "top_k", "type": "number", "desc": "Number of results to return (default 5)" }
+    ]
+  },
+  {
+    "name": "list_existing_materials",
+    "description": "Lists all resume, cover letter, and job assessment files in the workspace",
+    "arguments": []
+  },
+  {
+    "name": "check_workspace",
+    "description": "Validates the workspace configuration and confirms all required files and folders are accessible",
+    "arguments": []
+  },
+  {
+    "name": "get_customization_strategy",
+    "description": "Returns strategy for customizing a resume or cover letter for a specific role based on a saved job assessment",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Target company name" },
+      { "name": "role", "type": "string", "desc": "Target role title" }
+    ]
+  },
+  {
+    "name": "get_compensation_comparison",
+    "description": "Returns compensation data and comparisons across active applications and market data",
+    "arguments": []
+  },
+  {
+    "name": "update_compensation",
+    "description": "Updates compensation data for an application (base, equity, bonus, total comp)",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Company name" },
+      { "name": "base", "type": "number", "desc": "Base salary" },
+      { "name": "equity", "type": "string", "desc": "Equity details (optional)" },
+      { "name": "bonus", "type": "string", "desc": "Bonus details (optional)" }
+    ]
+  },
+  {
+    "name": "get_hbdi_profile",
+    "description": "Returns the HBDI cognitive profile and thinking preference analysis",
+    "arguments": []
+  },
+  {
+    "name": "run_hbdi_assessment",
+    "description": "Runs an interactive HBDI (Herrmann Brain Dominance Instrument) cognitive style assessment",
+    "arguments": []
+  },
+  {
+    "name": "get_leetcode_cheatsheet",
+    "description": "Returns the LeetCode problem-solving cheatsheet and study notes",
+    "arguments": []
+  },
+  {
+    "name": "get_existing_prep_file",
+    "description": "Returns an existing interview prep document for a specific company",
+    "arguments": [
+      { "name": "company", "type": "string", "desc": "Company name to retrieve prep doc for" }
+    ]
+  },
+  {
+    "name": "update_post_metrics",
+    "description": "Updates engagement metrics (views, likes, comments) for a logged LinkedIn post",
+    "arguments": [
+      { "name": "post_id", "type": "string", "desc": "Post identifier" },
+      { "name": "views", "type": "number", "desc": "View count" },
+      { "name": "likes", "type": "number", "desc": "Like count" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Adds jobContextMCP — an AI-powered job search context MCP server built with FastMCP and Claude.

## Server details
- **Type:** Local (containerized)
- **Category:** productivity
- **Image:** docker.io/justlikefrank3/jobcontextmcp:latest
- **Source:** https://github.com/JustLikeFrank3/jobContextMCP

## What it does
Manage an entire job search through Claude: generate tailored resumes and cover letters, track applications and rejections, run interview prep, analyze compensation, maintain long-term career memory with RAG over a personal workspace, and more. 38 tools total.

## Setup
Bring-your-own-data pattern — users mount their own workspace folder, data folder, and config.json. No sensitive data ships in the image.

## Checklist
- [x] `server.yaml` included
- [x] `tools.json` included (avoids CI needing to run the server)
- [x] `readme.md` included
- [x] Image is public on Docker Hub
- [x] MIT license