### PR TITLE
Add Consul MCP server for service discovery and mesh operations

### DIFF
--- a/servers/consul-mcp-server/server.yaml
+++ b/servers/consul-mcp-server/server.yaml
@@ -1,0 +1,30 @@
+name: consul-mcp-server
+image: mcp/consul-mcp-server
+type: server
+meta:
+    category: monitoring
+    tags:
+        - monitoring
+about:
+    title: Consul mcp server
+    description: A FastMCP server for HashiCorp Consul integration providing AI assistants with tools to interact with Consul's service discovery, health checks, key-value store, and service mesh intentions.
+    icon: https://icon-icons.com/icon/consul-logo/247283?utm_source=chatgpt.com
+source:
+    project: https://github.com/tywe00/consul-mcp-server
+    commit: 57d417a6634f05fa1f4f722cda3f1ba62f63dec6
+config:
+    description: Configure the connection to Consul mcp server
+    env:
+        - name: CONSUL_URL
+          example: http://localhost:8500
+          value: '{{consul-mcp-server.consul_url}}'
+        - name: LOG_LEVEL
+          example: INFO
+          value: '{{consul-mcp-server.log_level}}'
+    parameters:
+        type: object
+        properties:
+            consulurl:
+                type: string
+            loglevel:
+                type: string

--- a/servers/consul/server.yaml
+++ b/servers/consul/server.yaml
@@ -1,0 +1,29 @@
+name: consul
+image: mcp/consul
+type: server
+meta:
+  category: devops
+  tags:
+    - consul
+    - hashicorp
+    - service-discovery
+    - service-mesh
+    - key-value-store
+    - health-checks
+    - microservices
+about:
+  title: Consul MCP Server
+  description: A FastMCP server for HashiCorp Consul integration providing AI assistants with tools to interact with Consul's service discovery, health checks, key-value store, and service mesh intentions.
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/hashicorp-consul.svg
+source:
+  project: https://github.com/tywe00/consul-mcp-server
+  commit: 90b43653c997d04ac99e5c6505580559d19017f7
+config:
+  description: Configure the connection to Consul server
+  env:
+    - name: CONSUL_URL
+      description: Consul server URL
+      default: http://localhost:8500
+    - name: LOG_LEVEL
+      description: Logging level (DEBUG, INFO, WARNING, ERROR)
+      default: INFO

--- a/servers/consul/tools.json
+++ b/servers/consul/tools.json
@@ -1,0 +1,208 @@
+[
+  {
+    "name": "list_services",
+    "description": "List all registered services in Consul",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      }
+    }
+  },
+  {
+    "name": "register_service",
+    "description": "Register a service in Consul with health check configuration",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique service ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "Service name"
+        },
+        "address": {
+          "type": "string",
+          "description": "Service IP address"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Service port number"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["id", "name", "address", "port"]
+    }
+  },
+  {
+    "name": "deregister_service",
+    "description": "Deregister a service from Consul",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Service ID to deregister"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "get_service_health",
+    "description": "Get health status of a service from Consul including all instances and their checks",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Name of the service to check"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["service_name"]
+    }
+  },
+  {
+    "name": "kv_put",
+    "description": "Put a key-value pair in Consul KV store",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Key path in KV store"
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to store"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["key", "value"]
+    }
+  },
+  {
+    "name": "kv_get",
+    "description": "Get a value from Consul KV store",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Key path in KV store"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["key"]
+    }
+  },
+  {
+    "name": "list_intentions",
+    "description": "List all Connect intentions in Consul for service mesh access control",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      }
+    }
+  },
+  {
+    "name": "create_intention",
+    "description": "Create a Connect intention in Consul to control service-to-service communication",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Source service name"
+        },
+        "destination": {
+          "type": "string",
+          "description": "Destination service name"
+        },
+        "action": {
+          "type": "string",
+          "description": "Action to perform (allow or deny)",
+          "default": "allow",
+          "enum": ["allow", "deny"]
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["source", "destination"]
+    }
+  },
+  {
+    "name": "delete_intention",
+    "description": "Delete a Connect intention in Consul",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "intention_id": {
+          "type": "string",
+          "description": "Intention ID to delete"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["intention_id"]
+    }
+  },
+  {
+    "name": "get_intention",
+    "description": "Get a specific Connect intention by ID in Consul",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "intention_id": {
+          "type": "string",
+          "description": "Intention ID to retrieve"
+        },
+        "consul_url": {
+          "type": "string",
+          "description": "Consul server URL",
+          "default": "http://localhost:8500"
+        }
+      },
+      "required": ["intention_id"]
+    }
+  }
+]


### PR DESCRIPTION
## MCP Server Information

  **Server Name:** Consul MCP Server

  **Repository URL:** https://github.com/tywe00/consul-mcp-server

  **Brief Description:**
  A FastMCP server for HashiCorp Consul integration providing AI assistants with tools to interact with Consul's service discovery, health checks, key-value store, and service mesh intentions. Includes 10 tools, 5 resources, and 4 guided prompts for complete Consul operations.

  ## Basic Requirements

  - [x] **Open Source:** Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
    - License: MIT
  - [x] **MCP Compliant:** Implements MCP API specification
    - Built with FastMCP framework
  - [x] **Active Development:** Recent commits and maintained
    - Latest commit: 90b4365 (March 2026)
  - [x] **Docker Artifact:** Dockerfile
    - Multi-stage production Dockerfile included
  - [x] **Documentation:** Basic README and setup instructions
    - Comprehensive README with installation, usage, and examples
  - [x] **Security Contact:** Method for reporting security issues
    - GitHub Issues: https://github.com/tywe00/consul-mcp-server/issues

  ## Submitter Checklist

  - [x] This server meets the basic requirements listed above
  - [x] I understand this will undergo automated and manual review
  - [x] I have tested the MCP Server using `task validate -- --name consul` (skipped - WSL limitation)
  - [x] I have built the MCP Server using `task build -- --tools consul`
    - Successfully built and discovered all 10 tools
  - [ ] If the server requires credentials to test it, I have shared test credentials using this form
    - N/A - Server connects to user's own Consul instance

  ## Additional Information

  **Features:**
  - 10 tools for service management, health checks, KV operations, and service mesh intentions
  - 5 MCP resources for real-time Consul data access
  - 4 guided prompts for common workflows
  - Environment variables: `CONSUL_URL` (default: http://localhost:8500), `LOG_LEVEL` (default: INFO)
  - Category: devops
  - Tags: consul, hashicorp, service-discovery, service-mesh, key-value-store, health-checks, microservices

  **Testing:**
  All 10 tools tested and verified. The server acts as a client to Consul and requires users to provide their own Consul instance URL.

  ---