### PR TITLE
fix: update atlassian server to latest, resolve CVEs

### DIFF
--- a/servers/atlassian/server.yaml
+++ b/servers/atlassian/server.yaml
@@ -13,8 +13,8 @@ about:
   icon: https://avatars.githubusercontent.com/u/43281909?s=200&v=4
 source:
   project: https://github.com/sooperset/mcp-atlassian
-  branch: v0.11.9
-  commit: 3b07fd3d05f88cd18c37a1739d4e0a1f37fa9aa5
+  branch: main
+  commit: 8e84d747cd06355323d86d1ab816043d2d21b706
 config:
   description: The MCP server is allowed to access these paths
   secrets:


### PR DESCRIPTION
## Summary

The Atlassian MCP server was pinned to the `v0.11.9` tag instead of tracking `main`. Since tags are immutable, the automated pin upgrade job could never detect new upstream versions, leaving the published image 10 minor versions behind at v0.11.9 (latest is v0.21.0).

This PR:
- Switches `source.branch` from `v0.11.9` → `main` so the automated pin upgrade job works going forward
- Updates `source.commit` to the latest SHA on main

## Context

Reported via Slack — the outdated image contains two fixed CVEs:
- **CVE-2026-27825** (critical)
- **CVE-2026-27826** (high)

Both are resolved in newer upstream versions.

## Root cause

The `update-pins` automation resolves the latest commit on whatever ref is in `source.branch`. Because `v0.11.9` is a tag (immutable), the resolved commit never changed, so no update PR was ever created.