### PR TITLE
feat: add Tesserin MCP server

### DIFF
--- a/servers/tesserin/readme.md
+++ b/servers/tesserin/readme.md
@@ -1,0 +1,24 @@
+# Tesserin MCP Server
+
+For full documentation, setup instructions, and configuration options, see the project repository:
+
+https://github.com/AnvinX1/Tesserin-pro
+
+## Prerequisites
+
+Tesserin must be running locally. The MCP server connects to the Tesserin REST API (default: `http://localhost:9960`).
+
+Obtain your API token from **Settings → Connections → API Access** inside the Tesserin app.
+
+## Quick start
+
+```bash
+export TESSERIN_API_TOKEN=tsk_your_token_here
+docker run --rm -i \
+  --add-host=host.docker.internal:host-gateway \
+  -e TESSERIN_API_TOKEN \
+  -e TESSERIN_API_URL=http://host.docker.internal:9960 \
+  mcp/tesserin
+```
+
+Or with docker compose (see `docker-compose.yml` in the repository).

--- a/servers/tesserin/server.yaml
+++ b/servers/tesserin/server.yaml
@@ -1,0 +1,29 @@
+name: tesserin
+image: mcp/tesserin
+type: server
+meta:
+  category: productivity
+  tags:
+    - notes
+    - pkm
+    - knowledge-management
+    - productivity
+    - ai
+about:
+  title: Tesserin
+  description: AI-powered knowledge management and note-taking. Manage notes, tags, tasks, folders, and knowledge graphs. Includes RAG context search, wiki-links, and local AI (Ollama) integration.
+  icon: https://avatars.githubusercontent.com/u/AnvinX1?s=200&v=4
+source:
+  project: https://github.com/AnvinX1/Tesserin-pro
+  commit: 2c21bce4b3dae418a9e9a3da8c68641b357288e9
+  dockerfile: tesserin-mcp-server/Dockerfile
+config:
+  description: Configure connection to your local Tesserin vault
+  secrets:
+    - name: tesserin.api_token
+      env: TESSERIN_API_TOKEN
+      example: tsk_your_token_here
+  env:
+    - name: TESSERIN_API_URL
+      example: http://host.docker.internal:9960
+      value: http://host.docker.internal:9960

--- a/servers/tesserin/tools.json
+++ b/servers/tesserin/tools.json
@@ -1,0 +1,239 @@
+[
+  {
+    "name": "list_notes",
+    "description": "List notes in the Tesserin vault, optionally filtered by folder or tag.",
+    "arguments": [
+      { "name": "folder_id", "type": "string", "desc": "Filter by folder ID (optional)" },
+      { "name": "tag",       "type": "string", "desc": "Filter by tag name (optional)" },
+      { "name": "limit",     "type": "string", "desc": "Max number of notes to return, 1-200 (default: 20)" }
+    ]
+  },
+  {
+    "name": "get_note",
+    "description": "Retrieve the full content and metadata of a single note by its ID.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID" }
+    ]
+  },
+  {
+    "name": "search_notes",
+    "description": "Full-text search across all notes in the vault.",
+    "arguments": [
+      { "name": "query", "type": "string", "desc": "Search query text" },
+      { "name": "limit", "type": "string", "desc": "Max number of results, 1-100 (default: 10)" }
+    ]
+  },
+  {
+    "name": "create_note",
+    "description": "Create a new note in the Tesserin vault.",
+    "arguments": [
+      { "name": "title",     "type": "string", "desc": "Note title (required)" },
+      { "name": "content",   "type": "string", "desc": "Note content in Markdown (optional)" },
+      { "name": "folder_id", "type": "string", "desc": "Target folder ID (optional)" },
+      { "name": "tags",      "type": "string", "desc": "Comma-separated list of tag names (optional)" }
+    ]
+  },
+  {
+    "name": "update_note",
+    "description": "Update the title, content, or tags of an existing note.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID (required)" },
+      { "name": "title",   "type": "string", "desc": "New title (optional)" },
+      { "name": "content", "type": "string", "desc": "New content in Markdown (optional)" },
+      { "name": "tags",    "type": "string", "desc": "Comma-separated tag names to replace existing tags (optional)" }
+    ]
+  },
+  {
+    "name": "delete_note",
+    "description": "Permanently delete a note from the vault by its ID. Cannot be undone.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID to delete" }
+    ]
+  },
+  {
+    "name": "append_to_note",
+    "description": "Append text to the end of an existing note without overwriting it.",
+    "arguments": [
+      { "name": "note_id",  "type": "string", "desc": "The note ID" },
+      { "name": "content",  "type": "string", "desc": "Text to append" }
+    ]
+  },
+  {
+    "name": "pin_note",
+    "description": "Pin or unpin a note.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID" },
+      { "name": "pinned",  "type": "string", "desc": "true to pin, false to unpin (default: true)" }
+    ]
+  },
+  {
+    "name": "archive_note",
+    "description": "Archive or unarchive a note.",
+    "arguments": [
+      { "name": "note_id",  "type": "string", "desc": "The note ID" },
+      { "name": "archived", "type": "string", "desc": "true to archive, false to unarchive (default: true)" }
+    ]
+  },
+  {
+    "name": "get_recent_notes",
+    "description": "Get the most recently modified notes.",
+    "arguments": [
+      { "name": "limit", "type": "string", "desc": "Max number of notes, 1-50 (default: 10)" }
+    ]
+  },
+  {
+    "name": "list_tags",
+    "description": "List all tags in the Tesserin vault.",
+    "arguments": []
+  },
+  {
+    "name": "create_tag",
+    "description": "Create a new tag with an optional hex color.",
+    "arguments": [
+      { "name": "name",  "type": "string", "desc": "Tag name (required)" },
+      { "name": "color", "type": "string", "desc": "Hex color code, #RGB or #RRGGBB (default: #6366f1)" }
+    ]
+  },
+  {
+    "name": "delete_tag",
+    "description": "Permanently delete a tag from the vault by its ID.",
+    "arguments": [
+      { "name": "tag_id", "type": "string", "desc": "The tag ID to delete" }
+    ]
+  },
+  {
+    "name": "list_tasks",
+    "description": "List kanban tasks, optionally filtered by status or priority.",
+    "arguments": [
+      { "name": "status",   "type": "string", "desc": "Filter by status: todo, in-progress, done (optional)" },
+      { "name": "priority", "type": "string", "desc": "Filter by priority: 0-3 (optional)" }
+    ]
+  },
+  {
+    "name": "create_task",
+    "description": "Create a new kanban task. priority: 0=none, 1=low, 2=medium, 3=high.",
+    "arguments": [
+      { "name": "title",       "type": "string", "desc": "Task title (required)" },
+      { "name": "description", "type": "string", "desc": "Task description (optional)" },
+      { "name": "priority",    "type": "string", "desc": "Priority 0-3 (default: 1)" },
+      { "name": "due_date",    "type": "string", "desc": "Due date string (optional)" }
+    ]
+  },
+  {
+    "name": "update_task",
+    "description": "Update an existing kanban task. status: todo|in-progress|done.",
+    "arguments": [
+      { "name": "task_id",  "type": "string", "desc": "The task ID (required)" },
+      { "name": "title",    "type": "string", "desc": "New title (optional)" },
+      { "name": "status",   "type": "string", "desc": "New status: todo, in-progress, done (optional)" },
+      { "name": "priority", "type": "string", "desc": "New priority 0-3 (optional)" },
+      { "name": "due_date", "type": "string", "desc": "New due date string (optional)" }
+    ]
+  },
+  {
+    "name": "delete_task",
+    "description": "Permanently delete a kanban task by its ID. Cannot be undone.",
+    "arguments": [
+      { "name": "task_id", "type": "string", "desc": "The task ID to delete" }
+    ]
+  },
+  {
+    "name": "list_folders",
+    "description": "List all folders in the Tesserin vault.",
+    "arguments": []
+  },
+  {
+    "name": "create_folder",
+    "description": "Create a new folder, optionally nested inside another folder.",
+    "arguments": [
+      { "name": "name",      "type": "string", "desc": "Folder name (required)" },
+      { "name": "parent_id", "type": "string", "desc": "Parent folder ID for nesting (optional)" }
+    ]
+  },
+  {
+    "name": "delete_folder",
+    "description": "Delete a folder by its ID. Notes inside may be moved to root.",
+    "arguments": [
+      { "name": "folder_id", "type": "string", "desc": "The folder ID to delete" }
+    ]
+  },
+  {
+    "name": "get_knowledge_graph",
+    "description": "Retrieve the full knowledge graph (nodes and edges) for the vault.",
+    "arguments": []
+  },
+  {
+    "name": "search_vault_context",
+    "description": "Search the vault and return context-rich RAG chunks for AI use.",
+    "arguments": [
+      { "name": "query",      "type": "string", "desc": "Search query (required)" },
+      { "name": "max_chunks", "type": "string", "desc": "Max chunks to return, 1-50 (default: 10)" }
+    ]
+  },
+  {
+    "name": "get_vault_context",
+    "description": "Get rich context from the vault about a topic for AI reasoning.",
+    "arguments": [
+      { "name": "topic",     "type": "string", "desc": "Topic to retrieve context for (required)" },
+      { "name": "max_notes", "type": "string", "desc": "Max notes to include, 1-20 (default: 5)" }
+    ]
+  },
+  {
+    "name": "export_vault",
+    "description": "Export all vault data as JSON or Markdown.",
+    "arguments": [
+      { "name": "format", "type": "string", "desc": "Export format: json or markdown (default: json)" }
+    ]
+  },
+  {
+    "name": "get_note_with_connections",
+    "description": "Get a note along with all its backlinks and outgoing wiki-links.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID" }
+    ]
+  },
+  {
+    "name": "get_vault_summary",
+    "description": "Get a high-level summary of vault stats: note count, tag count, task count, folder count, link count.",
+    "arguments": []
+  },
+  {
+    "name": "ai_chat",
+    "description": "Send a message to Tesserin's local AI (Ollama) and get a response.",
+    "arguments": [
+      { "name": "message", "type": "string", "desc": "The message to send (required)" },
+      { "name": "model",   "type": "string", "desc": "Ollama model name to use (optional, uses vault default)" }
+    ]
+  },
+  {
+    "name": "ai_summarize",
+    "description": "Ask Tesserin AI to summarise a note by its ID.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID to summarise" }
+    ]
+  },
+  {
+    "name": "ai_generate_tags",
+    "description": "Ask Tesserin AI to suggest tags for a note.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID to generate tags for" }
+    ]
+  },
+  {
+    "name": "ai_suggest_links",
+    "description": "Ask Tesserin AI to suggest related notes that could be wiki-linked.",
+    "arguments": [
+      { "name": "note_id", "type": "string", "desc": "The note ID to suggest links for" }
+    ]
+  },
+  {
+    "name": "list_templates",
+    "description": "List all note templates available in the vault.",
+    "arguments": []
+  },
+  {
+    "name": "check_health",
+    "description": "Check that the Tesserin API server is reachable and healthy.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## Tesserin MCP Server

AI-powered knowledge management and note-taking system.

### What this adds
A local MCP server that connects to a running Tesserin instance over its REST API.

**32 tools** covering:
- Notes — list, get, search, create, update, delete, append, pin, archive, recent
- Tags — list, create, delete
- Tasks — list, create, update, delete
- Folders — list, create, delete
- Knowledge graph — get, search context, vault context, note connections, vault summary
- Export — full vault export
- AI — chat, summarise, generate tags, suggest links
- Templates — list
- Health — check

### Configuration
| Field | Value |
|---|---|
| Secret | `TESSERIN_API_TOKEN` — generated in Tesserin Settings → API |
| Env | `TESSERIN_API_URL` — default `http://host.docker.internal:9960` |

### Local validation
- `task build --tools tesserin` ✅ — image built as `mcp/tesserin`, 32 tools found
- `task catalog tesserin` ✅ — catalog.yaml generated

### Source
- Repo: https://github.com/AnvinX1/Tesserin-pro (public, MIT)
- Dockerfile: `tesserin-mcp-server/Dockerfile`
- Commit: `2c21bce4b3dae418a9e9a3da8c68641b357288e9`