### PR TITLE
Add Transloadit MCP server (local + remote)

### DIFF
--- a/servers/transloadit-remote/readme.md
+++ b/servers/transloadit-remote/readme.md
@@ -1,0 +1,1 @@
+Docs: https://transloadit.com/docs/sdks/mcp-server/

--- a/servers/transloadit-remote/server.yaml
+++ b/servers/transloadit-remote/server.yaml
@@ -1,0 +1,20 @@
+name: transloadit-remote
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: media
+  tags:
+    - media
+    - video
+    - image
+    - audio
+    - file-processing
+    - remote
+about:
+  title: Transloadit
+  description: Process video, audio, images, and documents with 86+ cloud media processing robots. Create Assemblies, lint instructions, discover Robots and Templates.
+  icon: https://www.google.com/s2/favicons?domain=transloadit.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://api2.transloadit.com/mcp

--- a/servers/transloadit-remote/tools.json
+++ b/servers/transloadit-remote/tools.json
@@ -1,0 +1,134 @@
+[
+  {
+    "name": "transloadit_lint_assembly_instructions",
+    "description": "Lint Assembly Instructions without creating an Assembly. Returns structured issues.",
+    "arguments": [
+      {
+        "name": "instructions",
+        "type": "object",
+        "desc": "Assembly Instructions to validate"
+      },
+      {
+        "name": "strict",
+        "type": "boolean",
+        "desc": "Enable strict mode"
+      },
+      {
+        "name": "return_fixed",
+        "type": "boolean",
+        "desc": "Return normalized instructions"
+      }
+    ]
+  },
+  {
+    "name": "transloadit_create_assembly",
+    "description": "Create or resume an Assembly, optionally uploading files and waiting for completion.",
+    "arguments": [
+      {
+        "name": "instructions",
+        "type": "object",
+        "desc": "Assembly Instructions or template_id"
+      },
+      {
+        "name": "files",
+        "type": "array",
+        "desc": "Files to upload (path, base64, or URL)"
+      },
+      {
+        "name": "wait_for_completion",
+        "type": "boolean",
+        "desc": "Wait for Assembly to complete"
+      }
+    ]
+  },
+  {
+    "name": "transloadit_get_assembly_status",
+    "description": "Fetch the latest Assembly status by URL or ID.",
+    "arguments": [
+      {
+        "name": "assembly_url",
+        "type": "string",
+        "desc": "Assembly status URL"
+      },
+      {
+        "name": "assembly_id",
+        "type": "string",
+        "desc": "Assembly ID"
+      }
+    ]
+  },
+  {
+    "name": "transloadit_wait_for_assembly",
+    "description": "Polls until the Assembly completes or timeout is reached.",
+    "arguments": [
+      {
+        "name": "assembly_url",
+        "type": "string",
+        "desc": "Assembly status URL"
+      },
+      {
+        "name": "assembly_id",
+        "type": "string",
+        "desc": "Assembly ID"
+      },
+      {
+        "name": "timeout_ms",
+        "type": "integer",
+        "desc": "Timeout in milliseconds"
+      }
+    ]
+  },
+  {
+    "name": "transloadit_list_robots",
+    "description": "Returns a filtered list of robots with short summaries.",
+    "arguments": [
+      {
+        "name": "category",
+        "type": "string",
+        "desc": "Filter by category"
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "desc": "Search term"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of results"
+      }
+    ]
+  },
+  {
+    "name": "transloadit_get_robot_help",
+    "description": "Returns a robot summary and parameter details.",
+    "arguments": [
+      {
+        "name": "robot_name",
+        "type": "string",
+        "desc": "Robot slug, e.g. /video/encode"
+      },
+      {
+        "name": "detail_level",
+        "type": "string",
+        "desc": "Level of detail: summary, params, or examples"
+      }
+    ]
+  },
+  {
+    "name": "transloadit_list_templates",
+    "description": "List Assembly Templates (owned and/or builtin).",
+    "arguments": [
+      {
+        "name": "include_builtin",
+        "type": "string",
+        "desc": "Include builtin templates: all, latest, exclusively-all, exclusively-latest"
+      },
+      {
+        "name": "include_content",
+        "type": "boolean",
+        "desc": "Include template content in response"
+      }
+    ]
+  }
+]

--- a/servers/transloadit/server.yaml
+++ b/servers/transloadit/server.yaml
@@ -1,0 +1,31 @@
+name: transloadit
+image: mcp/transloadit
+type: server
+meta:
+  category: media
+  tags:
+    - media
+    - video
+    - image
+    - audio
+    - document-processing
+    - file-processing
+    - transcoding
+about:
+  title: Transloadit
+  description: Process video, audio, images, and documents with 86+ cloud media processing robots. Create Assemblies, lint instructions, discover Robots and Templates.
+  icon: https://www.google.com/s2/favicons?domain=transloadit.com&sz=64
+source:
+  project: https://github.com/transloadit/node-sdk
+  branch: main
+  commit: 997b9177f6c4a22855c863539d9ed8dc2013a13b
+  directory: packages/mcp-server
+config:
+  description: Configure Transloadit API credentials
+  secrets:
+    - name: transloadit.transloadit_key
+      env: TRANSLOADIT_KEY
+      example: YOUR_TRANSLOADIT_AUTH_KEY
+    - name: transloadit.transloadit_secret
+      env: TRANSLOADIT_SECRET
+      example: YOUR_TRANSLOADIT_AUTH_SECRET


### PR DESCRIPTION
## Summary
- **Local server** (`servers/transloadit/`): Containerized MCP server for media processing (video, audio, images, documents) with 86+ cloud robots. Builds from `packages/mcp-server/Dockerfile` in [transloadit/node-sdk](https://github.com/transloadit/node-sdk).
- **Remote server** (`servers/transloadit-remote/`): Hosted endpoint at `https://api2.transloadit.com/mcp` using streamable-http transport.

## Server details
- **npm package**: [@transloadit/mcp-server](https://www.npmjs.com/package/@transloadit/mcp-server)
- **Source**: https://github.com/transloadit/node-sdk/tree/main/packages/mcp-server
- **Docs**: https://transloadit.com/docs/sdks/mcp-server/
- **License**: MIT
- **7 tools**: lint instructions, create assemblies, get status, wait for completion, list robots, get robot help, list templates

## Test credentials
Will share via the Google Form.