### PR TITLE
feat: add DeFi MCP Server — token prices, multi-chain balances, gas, DEX quotes

### DIFF
--- a/servers/defi-mcp/readme.md
+++ b/servers/defi-mcp/readme.md
@@ -1,0 +1,1 @@
+Docs: https://agent-gateway-kappa.vercel.app

--- a/servers/defi-mcp/server.yaml
+++ b/servers/defi-mcp/server.yaml
@@ -1,0 +1,24 @@
+name: defi-mcp
+type: remote
+meta:
+  category: finance
+  tags:
+    - defi
+    - crypto
+    - blockchain
+    - finance
+    - remote
+about:
+  title: DeFi MCP Server
+  description: Real-time DeFi and crypto data for AI agents — token prices (38+ tokens), multi-chain wallet balances across 6 EVM chains, gas estimates, DEX swap quotes via 1inch (EVM) and Jupiter (Solana), and on-chain analytics.
+  icon: https://www.google.com/s2/favicons?domain=agent-gateway-kappa.vercel.app&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://agent-gateway-kappa.vercel.app/v1/defi-mcp
+  headers:
+    Authorization: "Bearer ${DEFI_MCP_API_KEY}"
+config:
+  secrets:
+    - name: defi-mcp.api_key
+      env: DEFI_MCP_API_KEY
+      example: gw_your_api_key_here

--- a/servers/defi-mcp/tools.json
+++ b/servers/defi-mcp/tools.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "get_token_price",
+    "description": "Get current price(s) for one or more tokens from CoinGecko",
+    "arguments": []
+  },
+  {
+    "name": "search_tokens",
+    "description": "Search for tokens by name or symbol",
+    "arguments": []
+  },
+  {
+    "name": "get_token_info",
+    "description": "Get full token metadata and market data",
+    "arguments": []
+  },
+  {
+    "name": "get_top_tokens",
+    "description": "Get top N tokens ranked by market cap",
+    "arguments": []
+  },
+  {
+    "name": "get_eth_balance",
+    "description": "Get native ETH balance for any Ethereum wallet address",
+    "arguments": []
+  },
+  {
+    "name": "get_token_balance",
+    "description": "Get ERC-20 token balance for a wallet",
+    "arguments": []
+  },
+  {
+    "name": "get_wallet_holdings",
+    "description": "Get all ERC-20 tokens a wallet has interacted with",
+    "arguments": []
+  },
+  {
+    "name": "get_multichain_balance",
+    "description": "Get native token balance across 6 EVM chains simultaneously",
+    "arguments": []
+  },
+  {
+    "name": "get_eth_gas",
+    "description": "Get current Ethereum gas prices (EIP-1559)",
+    "arguments": []
+  },
+  {
+    "name": "get_multichain_gas",
+    "description": "Get current gas prices across 6 EVM chains",
+    "arguments": []
+  },
+  {
+    "name": "get_dex_quote_eth",
+    "description": "Get a DEX swap quote from 1inch for any EVM chain",
+    "arguments": []
+  },
+  {
+    "name": "get_dex_quote_sol",
+    "description": "Get a DEX swap quote from Jupiter for Solana tokens",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** defi-mcp
**Remote URL:** https://agent-gateway-kappa.vercel.app/v1/defi-mcp
**Brief Description:** Real-time DeFi and crypto data MCP server — token prices (38+ tokens via CoinGecko), multi-chain wallet balances (6 EVM chains), gas estimates, and DEX swap quotes via 1inch (EVM) and Jupiter (Solana).

## Basic Requirements

- [x] **MCP Compliant**: Implements MCP API specification (streamable-http transport)
- [x] **Documentation**: API catalog and setup instructions at https://agent-gateway-kappa.vercel.app
- [x] **Active Development**: Actively maintained production service

## Type

This is a **remote MCP server** (type: remote, transport: streamable-http). No Dockerfile required — it runs as a hosted service.

## Tools Available

| Tool | Description |
|------|-------------|
| `get_token_price` | Current price(s) for one or more tokens (CoinGecko) |
| `search_tokens` | Search tokens by name or symbol |
| `get_token_info` | Full token metadata, market data, contract addresses |
| `get_top_tokens` | Top N tokens by market cap |
| `get_eth_balance` | Native ETH balance for any EVM wallet |
| `get_token_balance` | ERC-20 token balance for a wallet |
| `get_wallet_holdings` | All ERC-20 tokens a wallet has interacted with |
| `get_multichain_balance` | Native balance across 6 EVM chains simultaneously |
| `get_eth_gas` | Ethereum gas prices (EIP-1559) |
| `get_multichain_gas` | Gas prices across Ethereum, BSC, Polygon, Arbitrum, Optimism, Base |
| `get_dex_quote_eth` | DEX swap quote via 1inch for any EVM chain |
| `get_dex_quote_sol` | DEX swap quote via Jupiter for Solana |

## Authentication

Requires an API key passed as `Authorization: Bearer <key>`. Free tier keys available at https://agent-gateway-kappa.vercel.app.

If test credentials are needed for review, I can provide them via the [credentials form](https://forms.gle/6Lw3nsvu2d6nFg8e6).

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review