### PR TITLE
Add tapps-mcp and docs-mcp servers

### DIFF
--- a/servers/docs-mcp/server.yaml
+++ b/servers/docs-mcp/server.yaml
@@ -18,6 +18,6 @@ about:
   icon: https://raw.githubusercontent.com/wtthornton/TappsMCP/master/docs/icon.png
 source:
   project: https://github.com/wtthornton/TappsMCP
-  commit: 7866f8f87758b2cc97f4b9fd751f4a8a2af936a0
+  commit: a435701fcae7b0c01951fd9e76b5e675d408e100
 config:
   description: "Mount your project directory to /workspace. Git required for history features."

--- a/servers/tapps-mcp/server.yaml
+++ b/servers/tapps-mcp/server.yaml
@@ -18,6 +18,6 @@ about:
   icon: https://raw.githubusercontent.com/wtthornton/TappsMCP/master/docs/icon.png
 source:
   project: https://github.com/wtthornton/TappsMCP
-  commit: 7866f8f87758b2cc97f4b9fd751f4a8a2af936a0
+  commit: a435701fcae7b0c01951fd9e76b5e675d408e100
 config:
   description: "Mount your project directory to /workspace."


### PR DESCRIPTION
## Summary

- Adds **tapps-mcp**: Deterministic code quality MCP server with 28 tools for AI coding assistants. Scores Python files across 7 categories, runs security scans, enforces quality gates, looks up library docs, and consults 17 domain experts. Zero LLM calls in the tool chain.
- Adds **docs-mcp**: Documentation MCP server with 22 tools for automated generation, validation, and maintenance. Generates READMEs, API references, changelogs, ADRs, onboarding guides, and diagrams.

Both are Python 3.12+ servers distributed as GHCR images with multi-arch support (amd64/arm64), cosign signatures, and SBOMs.

**Source:** https://github.com/wtthornton/TappsMCP
**License:** MIT
**Images:** `ghcr.io/wtthornton/tapps-mcp`, `ghcr.io/wtthornton/docs-mcp`

## Test plan

- [ ] CI validation passes (`task build`, `task catalog`)
- [ ] Images pull successfully from GHCR
- [ ] Both servers start in stdio mode and respond to MCP tool listing