### PR TITLE
Add AFFiNE MCP server

### DIFF
--- a/servers/affine-mcp/server.yaml
+++ b/servers/affine-mcp/server.yaml
@@ -1,0 +1,47 @@
+name: affine-mcp
+image: emmabyteeng/affine-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - knowledge-base
+    - wiki
+    - documents
+about:
+  title: AFFiNE
+  description: Read, write, search, and manage docs, tables, diagrams, and comments in self-hosted AFFiNE instances
+  icon: https://www.google.com/s2/favicons?domain=affine.pro&sz=64
+source:
+  project: https://github.com/emmabyte-engineering/affine-mcp
+  commit: 6c2919d947a817f2a005c996d7ee322502536ac2
+run:
+  env:
+    AFFINE_BASE_URL: "{{affine-mcp.base_url}}"
+    AFFINE_EMAIL: "{{affine-mcp.email}}"
+    AFFINE_PASSWORD: "{{affine-mcp.password}}"
+config:
+  description: Configure the connection to your self-hosted AFFiNE instance
+  secrets:
+    - name: affine-mcp.password
+      env: AFFINE_PASSWORD
+      example: your-password
+  env:
+    - name: AFFINE_BASE_URL
+      example: http://localhost:3010
+      value: "{{affine-mcp.base_url}}"
+    - name: AFFINE_EMAIL
+      example: user@example.com
+      value: "{{affine-mcp.email}}"
+  parameters:
+    type: object
+    properties:
+      base_url:
+        type: string
+        description: URL of your self-hosted AFFiNE instance
+      email:
+        type: string
+        description: Email address for authentication
+    required:
+      - base_url
+      - email

--- a/servers/affine-mcp/tools.json
+++ b/servers/affine-mcp/tools.json
@@ -1,0 +1,163 @@
+[
+  {
+    "name": "list_workspaces",
+    "description": "List all workspaces accessible to the authenticated user",
+    "arguments": []
+  },
+  {
+    "name": "get_workspace",
+    "description": "Get details for a specific workspace",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" }
+    ]
+  },
+  {
+    "name": "list_docs",
+    "description": "List documents in a workspace with pagination",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "first", "type": "number", "desc": "Number of docs to return (default 20)" },
+      { "name": "after", "type": "string", "desc": "Cursor for pagination" }
+    ]
+  },
+  {
+    "name": "get_doc",
+    "description": "Get metadata for a specific document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" }
+    ]
+  },
+  {
+    "name": "read_doc",
+    "description": "Read the full content of a document, returned as markdown",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" }
+    ]
+  },
+  {
+    "name": "read_multiple_docs",
+    "description": "Read multiple documents at once. Returns each doc's title and markdown content.",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docIds", "type": "array", "desc": "Array of document IDs to read" }
+    ]
+  },
+  {
+    "name": "search_docs",
+    "description": "Search for documents containing a text query",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "query", "type": "string", "desc": "Text to search for" },
+      { "name": "maxResults", "type": "number", "desc": "Maximum number of results (default 10)" }
+    ]
+  },
+  {
+    "name": "create_doc",
+    "description": "Create a new document with optional markdown content",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "title", "type": "string", "desc": "Document title" },
+      { "name": "markdown", "type": "string", "desc": "Optional markdown content" }
+    ]
+  },
+  {
+    "name": "append_to_doc",
+    "description": "Append markdown content to the end of an existing document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" },
+      { "name": "markdown", "type": "string", "desc": "Markdown content to append" }
+    ]
+  },
+  {
+    "name": "replace_doc_content",
+    "description": "Replace the entire content of a document with new markdown",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" },
+      { "name": "markdown", "type": "string", "desc": "New markdown content" },
+      { "name": "title", "type": "string", "desc": "Optional new title" }
+    ]
+  },
+  {
+    "name": "delete_doc",
+    "description": "Delete a document from a workspace",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID to delete" }
+    ]
+  },
+  {
+    "name": "get_mermaid_diagrams",
+    "description": "Get all mermaid diagrams from a document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" }
+    ]
+  },
+  {
+    "name": "update_mermaid_diagram",
+    "description": "Update an existing mermaid diagram in a document by its block ID",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" },
+      { "name": "blockId", "type": "string", "desc": "The block ID of the mermaid diagram" },
+      { "name": "code", "type": "string", "desc": "New mermaid diagram code" }
+    ]
+  },
+  {
+    "name": "insert_mermaid_diagram",
+    "description": "Insert a new mermaid diagram at the end of a document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" },
+      { "name": "code", "type": "string", "desc": "Mermaid diagram code" }
+    ]
+  },
+  {
+    "name": "get_doc_link_graph",
+    "description": "Get the link graph for all documents in a workspace",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" }
+    ]
+  },
+  {
+    "name": "get_tables",
+    "description": "Get all tables from a document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" }
+    ]
+  },
+  {
+    "name": "insert_table",
+    "description": "Insert a new table at the end of a document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" },
+      { "name": "headers", "type": "array", "desc": "Column header names" },
+      { "name": "rows", "type": "array", "desc": "Array of rows, each row is an array of cell values" }
+    ]
+  },
+  {
+    "name": "update_table",
+    "description": "Replace an existing table's content by its block ID",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" },
+      { "name": "blockId", "type": "string", "desc": "The block ID of the table" },
+      { "name": "headers", "type": "array", "desc": "New column header names" },
+      { "name": "rows", "type": "array", "desc": "New rows, each row is an array of cell values" }
+    ]
+  },
+  {
+    "name": "get_comments",
+    "description": "Get all comments on a document",
+    "arguments": [
+      { "name": "workspaceId", "type": "string", "desc": "The workspace ID" },
+      { "name": "docId", "type": "string", "desc": "The document ID" }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** affine-mcp
**Repository URL:** https://github.com/emmabyte-engineering/affine-mcp
**Brief Description:** MCP server for self-hosted AFFiNE instances — read, write, search, and manage docs, tables, diagrams, and comments

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name affine-mcp`
- [x] I have built the MCP Server using `task build -- --tools --pull-community affine-mcp`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Details

AFFiNE MCP provides 19 tools for interacting with self-hosted AFFiNE instances:

- **Workspace management**: list and inspect workspaces
- **Document CRUD**: list, read, create, append, replace, delete docs
- **Bulk operations**: read multiple docs at once, search across all docs
- **Mermaid diagrams**: get, insert, and update diagrams within docs
- **Tables**: get, insert, and update structured tables
- **Comments**: read comment threads and replies
- **Link graph**: discover document relationships and orphaned docs

The server connects to AFFiNE via its GraphQL API and WebSocket/Yjs CRDT protocol. It includes a comprehensive test suite (46 unit tests + 41 e2e tests against a real AFFiNE instance) and CI/CD via GitHub Actions.

**Docker Hub**: [`emmabyteeng/affine-mcp`](https://hub.docker.com/r/emmabyteeng/affine-mcp)
**npm**: [`@emmabyte-eng/affine-mcp`](https://www.npmjs.com/package/@emmabyte-eng/affine-mcp)