### PR TITLE
Add 5 MCP servers by n24q02m: better-notion, wet, mnemo, better-email, better-godot

### DIFF
--- a/servers/better-email-mcp/server.yaml
+++ b/servers/better-email-mcp/server.yaml
@@ -1,0 +1,22 @@
+name: better-email-mcp
+image: n24q02m/better-email-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - communication
+    - email
+    - imap
+    - smtp
+about:
+  title: Better Email MCP
+  description: IMAP/SMTP MCP server for Email optimized for AI agents. 5 composite tools with 15 actions for search, read, send, reply, forward, and organize emails. Multi-account support with App Passwords (no OAuth2). Auto-discovers Gmail, Outlook, Yahoo, iCloud, Zoho, ProtonMail.
+  icon: https://www.google.com/s2/favicons?domain=gmail.com&sz=64
+source:
+  project: https://github.com/n24q02m/better-email-mcp
+config:
+  description: Configure email account credentials
+  secrets:
+    - name: better-email-mcp.email_credentials
+      env: EMAIL_CREDENTIALS
+      example: user@gmail.com:abcd-efgh-ijkl-mnop

--- a/servers/better-email-mcp/server.yaml
+++ b/servers/better-email-mcp/server.yaml
@@ -1,5 +1,5 @@
 name: better-email-mcp
-image: n24q02m/better-email-mcp
+image: mcp/better-email-mcp
 type: server
 meta:
   category: communication
@@ -14,6 +14,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=gmail.com&sz=64
 source:
   project: https://github.com/n24q02m/better-email-mcp
+  commit: 5065fd027494f1d94aa1463a9006093e54120a4c
 config:
   description: Configure email account credentials
   secrets:

--- a/servers/better-godot-mcp/server.yaml
+++ b/servers/better-godot-mcp/server.yaml
@@ -1,0 +1,26 @@
+name: better-godot-mcp
+image: n24q02m/better-godot-mcp
+type: server
+meta:
+  category: dev-tools
+  tags:
+    - dev-tools
+    - game-development
+    - godot
+about:
+  title: Better Godot MCP
+  description: Composite MCP server for Godot Engine 4.x with 18 tools for scenes, nodes, GDScript, shaders, animation, tilemap, physics, audio, navigation, UI, input mapping, and signals. Structured tool calls handle .tscn file format correctly instead of raw text editing.
+  icon: https://www.google.com/s2/favicons?domain=godotengine.org&sz=64
+source:
+  project: https://github.com/n24q02m/better-godot-mcp
+config:
+  description: Configure Godot project path (optional - can also pass via tool parameters)
+  env:
+    - name: GODOT_PROJECT_PATH
+      example: /path/to/godot/project
+      value: "{{better-godot-mcp.godot_project_path}}"
+  parameters:
+    type: object
+    properties:
+      godot_project_path:
+        type: string

--- a/servers/better-godot-mcp/server.yaml
+++ b/servers/better-godot-mcp/server.yaml
@@ -1,5 +1,5 @@
 name: better-godot-mcp
-image: n24q02m/better-godot-mcp
+image: mcp/better-godot-mcp
 type: server
 meta:
   category: dev-tools
@@ -13,6 +13,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=godotengine.org&sz=64
 source:
   project: https://github.com/n24q02m/better-godot-mcp
+  commit: 797561d76c1fef3e971425cac04b8d3293efe6b2
 config:
   description: Configure Godot project path (optional - can also pass via tool parameters)
   env:

--- a/servers/better-notion-mcp/server.yaml
+++ b/servers/better-notion-mcp/server.yaml
@@ -1,5 +1,5 @@
 name: better-notion-mcp
-image: n24q02m/better-notion-mcp
+image: mcp/better-notion-mcp
 type: server
 meta:
   category: productivity
@@ -13,6 +13,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=notion.so&sz=64
 source:
   project: https://github.com/n24q02m/better-notion-mcp
+  commit: ab6bff6ea3f1650d3c7a017af2c756060ab8e6c3
 config:
   description: Configure the connection to Notion
   secrets:

--- a/servers/better-notion-mcp/server.yaml
+++ b/servers/better-notion-mcp/server.yaml
@@ -1,0 +1,21 @@
+name: better-notion-mcp
+image: n24q02m/better-notion-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - notion
+    - markdown
+about:
+  title: Better Notion MCP
+  description: Markdown-first MCP server for Notion API. 9 composite tools with 39 actions that consolidate Notion's 28+ REST API endpoints into action-based operations optimized for AI agents. Features auto-pagination, bulk operations, and ~77% token reduction via tiered documentation.
+  icon: https://www.google.com/s2/favicons?domain=notion.so&sz=64
+source:
+  project: https://github.com/n24q02m/better-notion-mcp
+config:
+  description: Configure the connection to Notion
+  secrets:
+    - name: better-notion-mcp.notion_token
+      env: NOTION_TOKEN
+      example: ntn_xxxxxxxxxxxxxxxxxxxx

--- a/servers/mnemo-mcp/server.yaml
+++ b/servers/mnemo-mcp/server.yaml
@@ -1,0 +1,21 @@
+name: mnemo-mcp
+image: n24q02m/mnemo-mcp
+type: server
+meta:
+  category: memory
+  tags:
+    - memory
+    - ai-memory
+    - search
+about:
+  title: Mnemo - Persistent AI Memory
+  description: Persistent AI memory with hybrid search (FTS5 full-text + sqlite-vec semantic) and cross-machine sync via rclone. Open, free, unlimited. Built-in Qwen3 embedding model requires no API keys. Proactive memory tool descriptions guide AI to save preferences, decisions, and facts automatically.
+  icon: https://raw.githubusercontent.com/n24q02m/mnemo-mcp/main/assets/icon.png
+source:
+  project: https://github.com/n24q02m/mnemo-mcp
+config:
+  description: Configure Mnemo MCP server (all optional - works with zero config)
+  secrets:
+    - name: mnemo-mcp.api_keys
+      env: API_KEYS
+      example: GOOGLE_API_KEY:AIza...

--- a/servers/mnemo-mcp/server.yaml
+++ b/servers/mnemo-mcp/server.yaml
@@ -1,5 +1,5 @@
 name: mnemo-mcp
-image: n24q02m/mnemo-mcp
+image: mcp/mnemo-mcp
 type: server
 meta:
   category: memory
@@ -13,6 +13,7 @@ about:
   icon: https://raw.githubusercontent.com/n24q02m/mnemo-mcp/main/assets/icon.png
 source:
   project: https://github.com/n24q02m/mnemo-mcp
+  commit: 2c2a25906ee5a90cf31face81564f009143b41e4
 config:
   description: Configure Mnemo MCP server (all optional - works with zero config)
   secrets:

--- a/servers/wet-mcp/server.yaml
+++ b/servers/wet-mcp/server.yaml
@@ -1,5 +1,5 @@
 name: wet-mcp
-image: n24q02m/wet-mcp
+image: mcp/wet-mcp
 type: server
 meta:
   category: search
@@ -13,6 +13,7 @@ about:
   icon: https://raw.githubusercontent.com/n24q02m/wet-mcp/main/assets/icon.png
 source:
   project: https://github.com/n24q02m/wet-mcp
+  commit: d3f6b73a1c9a29464b5adb8515e71b61629690fb
 config:
   description: Configure WET MCP server (all optional - works with zero config)
   secrets:

--- a/servers/wet-mcp/server.yaml
+++ b/servers/wet-mcp/server.yaml
@@ -1,0 +1,24 @@
+name: wet-mcp
+image: n24q02m/wet-mcp
+type: server
+meta:
+  category: search
+  tags:
+    - search
+    - web-scraping
+    - documentation
+about:
+  title: WET - Web Extended Toolkit
+  description: Open-source MCP server for web search (via embedded SearXNG), content extraction, academic research, and library documentation indexing with hybrid search. Features built-in Qwen3 embedding, anti-bot stealth mode, and rclone sync for indexed docs.
+  icon: https://raw.githubusercontent.com/n24q02m/wet-mcp/main/assets/icon.png
+source:
+  project: https://github.com/n24q02m/wet-mcp
+config:
+  description: Configure WET MCP server (all optional - works with zero config)
+  secrets:
+    - name: wet-mcp.api_keys
+      env: API_KEYS
+      example: GOOGLE_API_KEY:AIza...
+    - name: wet-mcp.github_token
+      env: GITHUB_TOKEN
+      example: ghp_xxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
## What does this PR do?

Add 5 MCP servers by [n24q02m](https://github.com/n24q02m), all published on npm/PyPI and Docker Hub:

- **better-notion-mcp**: Markdown-first Notion API (8 composite tools, 39+ actions)
- **wet-mcp**: Web search, content extraction, crawling, site mapping, library docs
- **mnemo-mcp**: Persistent AI memory with hybrid search + inline sync
- **better-email-mcp**: Email (IMAP/SMTP) for AI agents (3 composite tools, 14 actions)
- **better-godot-mcp**: Godot Engine 4.x (18 tools for scenes, scripts, shaders, etc.)

All servers are MIT-licensed, published on npm/PyPI, and have Docker images.

## MCP Server Information

| Server | Category | Docker Image | Source |
|--------|----------|-------------|--------|
| better-notion-mcp | productivity | `n24q02m/better-notion-mcp` | [GitHub](https://github.com/n24q02m/better-notion-mcp) |
| wet-mcp | search | `n24q02m/wet-mcp` | [GitHub](https://github.com/n24q02m/wet-mcp) |
| mnemo-mcp | memory | `n24q02m/mnemo-mcp` | [GitHub](https://github.com/n24q02m/mnemo-mcp) |
| better-email-mcp | communication | `n24q02m/better-email-mcp` | [GitHub](https://github.com/n24q02m/better-email-mcp) |
| better-godot-mcp | development | `n24q02m/better-godot-mcp` | [GitHub](https://github.com/n24q02m/better-godot-mcp) |

## Checklist

- [x] Each server has its own `server.yaml` in `servers/<name>/`
- [x] All Docker images are publicly available on Docker Hub
- [x] All servers follow the `server.yaml` schema
- [x] Source repos linked and MIT-licensed