### PR TITLE
Add CKAN MCP Server

### DIFF
--- a/servers/ckan-mcp-server/server.yaml
+++ b/servers/ckan-mcp-server/server.yaml
@@ -8,7 +8,7 @@ meta:
     - open-data
     - ckan
 about:
-  title: CKAN
+  title: CKAN Portals
   description: Connect to any CKAN open data portal and search datasets, explore organizations, query tabular data via DataStore, and read metadata. Works with dati.gov.it, data.gov, open.canada.ca, data.gov.uk, and thousands of public portals worldwide.
   icon: https://raw.githubusercontent.com/ondata/ckan-mcp-server/main/icon.png
 source:


### PR DESCRIPTION
## Description

Adds the CKAN MCP Server to the Docker MCP Registry.

## What it does

Connects Claude and other AI assistants to any CKAN-based open data portal. Provides tools for:
- Advanced dataset search with Solr syntax
- DataStore queries for tabular data analysis
- Organization and group exploration
- Complete metadata access

Works with dati.gov.it, data.gov, open.canada.ca, data.gov.uk, and thousands of public CKAN portals worldwide.

## Links

- Repository: https://github.com/ondata/ckan-mcp-server
- License: MIT
