### PR TITLE
feat: add courtlistener-citations — legal citation hallucination detection

### DIFF
--- a/servers/courtlistener-citations/readme.md
+++ b/servers/courtlistener-citations/readme.md
@@ -1,0 +1,1 @@
+For full documentation, see the [CourtListener Citations MCP repository](https://github.com/john-walkoe/courtlistener_citations_mcp).

--- a/servers/courtlistener-citations/server.yaml
+++ b/servers/courtlistener-citations/server.yaml
@@ -21,7 +21,7 @@ about:
   icon: https://www.courtlistener.com/favicon.ico
 source:
   project: https://github.com/john-walkoe/courtlistener_citations_mcp
-  commit: f05167e684cc39b166574d4f36e7e489447b4157
+  commit: 099952ad3dfdcf82769c60ae9b09b6bf386ace95
 config:
   description: >
     Requires a free CourtListener API token.

--- a/servers/courtlistener-citations/server.yaml
+++ b/servers/courtlistener-citations/server.yaml
@@ -1,0 +1,32 @@
+name: courtlistener-citations
+image: mcp/courtlistener-citations
+type: server
+meta:
+  category: legal
+  tags:
+    - legal
+    - citations
+    - research
+    - hallucination-detection
+    - law
+about:
+  title: CourtListener Citation Validation
+  description: >
+    Validates legal citations against CourtListener's 9M+ court opinion database.
+    Detects AI-hallucinated citations in legal briefs — including citations that
+    resolve to a completely different case than claimed (name mismatch), citations
+    not found in the database, and ambiguous reporter strings. Returns color-coded
+    results with direct links to each case on CourtListener. Built for lawyers,
+    legal researchers, and anyone reviewing AI-generated legal documents.
+  icon: https://www.courtlistener.com/favicon.ico
+source:
+  project: https://github.com/john-walkoe/courtlistener_citations_mcp
+  commit: 1804159b74cb7522d6a9db3bf9a2b8bff480248
+config:
+  description: >
+    Requires a free CourtListener API token.
+    Get one at: https://www.courtlistener.com/sign-in/
+  secrets:
+    - name: courtlistener-citations.api_token
+      env: COURTLISTENER_API_TOKEN
+      example: your_40_character_hex_token_here

--- a/servers/courtlistener-citations/server.yaml
+++ b/servers/courtlistener-citations/server.yaml
@@ -21,7 +21,7 @@ about:
   icon: https://www.courtlistener.com/favicon.ico
 source:
   project: https://github.com/john-walkoe/courtlistener_citations_mcp
-  commit: ebd4fd1bfc7ae409ac42ed120f1cd1cfc242e93e
+  commit: f05167e684cc39b166574d4f36e7e489447b4157
 config:
   description: >
     Requires a free CourtListener API token.

--- a/servers/courtlistener-citations/server.yaml
+++ b/servers/courtlistener-citations/server.yaml
@@ -21,7 +21,7 @@ about:
   icon: https://www.courtlistener.com/favicon.ico
 source:
   project: https://github.com/john-walkoe/courtlistener_citations_mcp
-  commit: 1804159b74cb7522d6a9db3bf9a2b8bff480248
+  commit: ebd4fd1bfc7ae409ac42ed120f1cd1cfc242e93e
 config:
   description: >
     Requires a free CourtListener API token.

--- a/servers/courtlistener-citations/tools.json
+++ b/servers/courtlistener-citations/tools.json
@@ -1,0 +1,109 @@
+[
+  {
+    "name": "courtlistener_validate_citations",
+    "description": "Extract and validate all legal citations from document text against the CourtListener database. Returns status per citation: 200 (found), 300 (ambiguous), 404 (not found — potential hallucination), plus name-mismatch detection for citations that resolve to a different case than claimed.",
+    "arguments": [
+      {
+        "name": "text",
+        "type": "string",
+        "desc": "Full document text containing legal citations to validate"
+      }
+    ]
+  },
+  {
+    "name": "courtlistener_extract_citations",
+    "description": "Extract ALL legal citation types from document text using eyecite (runs locally, no API key required). Returns case citations, statutory citations, law journal citations, id. and supra back-references. Use before validate_citations to get a complete citation inventory.",
+    "arguments": [
+      {
+        "name": "text",
+        "type": "string",
+        "desc": "Document text to extract citations from"
+      }
+    ]
+  },
+  {
+    "name": "courtlistener_search_cases",
+    "description": "Search for cases by name, court, date, or full-text query. Use as fallback when validate_citations returns 404 for a citation.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Full-text search query (optional)"
+      },
+      {
+        "name": "case_name",
+        "type": "string",
+        "desc": "Case name to search for, e.g. 'Alice Corp v CLS Bank' (optional)"
+      },
+      {
+        "name": "court",
+        "type": "string",
+        "desc": "Court identifier, e.g. 'scotus', 'ca1', 'cafc', 'dcd' (optional)"
+      },
+      {
+        "name": "citation",
+        "type": "string",
+        "desc": "Citation string to filter by (optional)"
+      }
+    ]
+  },
+  {
+    "name": "courtlistener_lookup_citation",
+    "description": "Look up a case directly by its reporter citation string (e.g. '573 U.S. 208'). Use as last resort after validate_citations and search_cases both fail.",
+    "arguments": [
+      {
+        "name": "citation",
+        "type": "string",
+        "desc": "Legal citation string, e.g. '573 U.S. 208' or '134 S. Ct. 2347'"
+      }
+    ]
+  },
+  {
+    "name": "courtlistener_get_cluster",
+    "description": "Get detailed information about a specific opinion cluster (a court decision) by its CourtListener cluster ID. Returns case name, court, date filed, parallel citations, citation count, judges, and a direct URL.",
+    "arguments": [
+      {
+        "name": "cluster_id",
+        "type": "integer",
+        "desc": "CourtListener cluster ID from opinion URLs, e.g. /opinion/2679558/"
+      },
+      {
+        "name": "include_opinions",
+        "type": "boolean",
+        "desc": "Include full opinion text excerpts (default: false)"
+      }
+    ]
+  },
+  {
+    "name": "courtlistener_search_clusters",
+    "description": "Search opinion clusters with filters for case name, court, docket number, judge, or citation. A cluster groups all opinions (majority, dissent, concurrence) from a single court decision.",
+    "arguments": [
+      {
+        "name": "case_name",
+        "type": "string",
+        "desc": "Case name to search (optional)"
+      },
+      {
+        "name": "court",
+        "type": "string",
+        "desc": "Court identifier, e.g. 'scotus', 'cafc' (optional)"
+      },
+      {
+        "name": "citation",
+        "type": "string",
+        "desc": "Citation to search (optional)"
+      }
+    ]
+  },
+  {
+    "name": "courtlistener_citations_get_guidance",
+    "description": "Get contextual guidance for using the CourtListener citation validation tools. Available sections: overview, workflow, response_format, hallucination_patterns, edge_cases, risk_assessment, limitations.",
+    "arguments": [
+      {
+        "name": "section",
+        "type": "string",
+        "desc": "Guidance section name (default: overview)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** courtlistener-citations

**Repository URL:** https://github.com/john-walkoe/courtlistener_citations_mcp

**Brief Description:** Validates legal citations against CourtListener's 9M+ court opinion database. Detects AI-hallucinated citations in legal briefs — including fabricated cases, citations that resolve to the wrong case (name mismatch), and ambiguous reporters. Returns color-coded results with direct CourtListener links via an interactive MCP App panel.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name courtlistener-citations`
- [x] I have built the MCP Server using `task build -- --tools courtlistener-citations`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
