### PR TITLE
Shorten duckduckgo description to fix Docker Hub truncation

### DIFF
--- a/servers/duckduckgo/server.yaml
+++ b/servers/duckduckgo/server.yaml
@@ -9,7 +9,7 @@ meta:
 about:
   title: Private Web Search
   icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
-  description: "Community-maintained MCP server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo."
+  description: "Community-maintained server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo."
 source:
   project: https://github.com/nickclyde/duckduckgo-mcp-server
   commit: 72140a7136a52d51ec9fdccdd7ff504959d0a5cf


### PR DESCRIPTION
## Summary
- Removed "MCP" from the duckduckgo server description to shorten it
- Previously showed as: `Community-maintained MCP server for DuckDuckGo search. Not published by or affiliated with DuckDu...`
- Now fits within Docker Hub's character limit: `Community-maintained server for DuckDuckGo search. Not published by or affiliated with DuckDuckGo.`