### PR TITLE
add workspace-qdrant-mcp server

### DIFF
--- a/servers/workspace-qdrant-mcp/server.yaml
+++ b/servers/workspace-qdrant-mcp/server.yaml
@@ -1,0 +1,32 @@
+name: workspace-qdrant-mcp
+image: mcp/workspace-qdrant-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - memory
+    - search
+    - qdrant
+    - vector-database
+    - semantic-search
+about:
+  title: workspace-qdrant-mcp
+  description: Project-scoped semantic workspace memory for AI coding assistants. Auto-indexes code and docs into Qdrant with hybrid search (dense + sparse + RRF) and tree-sitter semantic chunking. Alpha — testers and feedback welcome.
+  icon: https://avatars.githubusercontent.com/u/214433?v=4
+source:
+  project: https://github.com/ChrisGVE/workspace-qdrant-mcp
+config:
+  description: Configure connection to Qdrant vector database
+  env:
+    - name: QDRANT_URL
+      example: http://host.docker.internal:6333
+      value: '{{workspace-qdrant-mcp.qdrant_url}}'
+  secrets:
+    - name: workspace-qdrant-mcp.qdrant_api_key
+      env: QDRANT_API_KEY
+      example: your-qdrant-cloud-api-key
+  parameters:
+    type: object
+    properties:
+      qdrant_url:
+        type: string


### PR DESCRIPTION
## Description

Adds `workspace-qdrant-mcp` — a project-scoped semantic workspace memory MCP server for AI coding assistants.

**What it does:**
- Watches project files and auto-indexes code + docs into Qdrant
- Tree-sitter semantic chunking (by function/class/method)
- Hybrid search: dense (FastEmbed) + sparse (BM25) + RRF fusion
- 6 MCP tools: store, search, retrieve, grep, list, rules

**Status:** Alpha — actively seeking testers and feedback.

**GitHub:** https://github.com/ChrisGVE/workspace-qdrant-mcp

## Configuration

- `QDRANT_URL` — URL of Qdrant instance (default: `http://host.docker.internal:6333`)
- `QDRANT_API_KEY` — API key for Qdrant Cloud (optional, for cloud deployments)

## Notes

The Docker image builds from the `Dockerfile` at the repo root. The MCP server communicates via stdio transport and connects to an external Qdrant instance.