### PR TITLE
Add engram: persistent knowledge base MCP server

### DIFF
--- a/servers/engram/server.yaml
+++ b/servers/engram/server.yaml
@@ -1,0 +1,21 @@
+name: engram
+image: cylian/engram
+type: server
+meta:
+  category: knowledge
+  tags:
+    - knowledge-base
+    - search
+    - markdown
+    - xapian
+    - graph
+    - memory
+about:
+  title: Engram
+  description: "Persistent knowledge base with full-text search and typed graph relations. Markdown files as source of truth, Xapian index as rebuildable cache. 7 tools: remember (upsert), recall, search, forget, list, tags, rebuild."
+  icon: https://engram-kb.org/favicon.svg
+source:
+  project: https://github.com/cylian-org/engram
+  branch: main
+  commit: 5ada8f0
+  directory: .

--- a/servers/engram/tools.json
+++ b/servers/engram/tools.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "remember",
+    "description": "Store or update a knowledge base entry (upsert). Detects duplicates by title similarity. Content may contain kb://uuid#type links for graph relations."
+  },
+  {
+    "name": "recall",
+    "description": "Read the full content of an entry with its graph relations (outgoing links and incoming backlinks)."
+  },
+  {
+    "name": "search",
+    "description": "Full-text search with Xapian French stemming, wildcards, spelling correction, and optional tag filtering."
+  },
+  {
+    "name": "forget",
+    "description": "Delete a knowledge base entry (file and search index)."
+  },
+  {
+    "name": "list",
+    "description": "List entries sorted by title, with optional tag filter (AND logic)."
+  },
+  {
+    "name": "tags",
+    "description": "List all tags with entry counts."
+  },
+  {
+    "name": "rebuild",
+    "description": "Rebuild the Xapian search index from Markdown files."
+  }
+]


### PR DESCRIPTION
## New Server: Engram

Persistent knowledge base MCP server with full-text search and typed graph relations.

### Tools (7)

- **remember**: Store or update knowledge (upsert with duplicate detection)
- **recall**: Read an entry with graph relations (outgoing + backlinks)
- **search**: Full-text search with French stemming and tag filtering
- **forget**: Remove an entry
- **list**: Browse entries by tag
- **tags**: List all tags with counts
- **rebuild**: Rebuild search index from files

### Links

- Source: https://github.com/cylian-org/engram
- Docker Hub: https://hub.docker.com/r/cylian/engram
- Website: https://engram-kb.org
- License: MIT