### PR TITLE
Add Robtex network intelligence MCP server

### DIFF
--- a/servers/robtex/readme.md
+++ b/servers/robtex/readme.md
@@ -1,0 +1,12 @@
+Robtex provides 55+ network intelligence and security tools via MCP. All tools are read-only and require no authentication.
+
+**Categories:**
+- **DNS**: Forward/reverse lookups (A, AAAA, MX, NS, TXT, CNAME, SOA, PTR), passive DNS, historic reverse lookups
+- **IP**: Geolocation, network/ASN mapping, reputation checks against 100+ blocklists, threat intelligence
+- **BGP/AS**: AS info, WHOIS, prefix announcements
+- **Domain**: Reputation scoring (Majestic, Tranco, CrUX, Umbrella, Cloudflare Radar), blocklist checks, shared hosting/NS/MX discovery
+- **Bitcoin**: Transaction details, address balances, block data, UTXO tracking, blockchain statistics
+- **Lightning Network**: Node lookups, channel info, peer recommendations, alias search
+- **Utilities**: MAC vendor lookup, hostname parsing, email verification
+
+Docs: https://www.robtex.com/en/mcp-server

--- a/servers/robtex/server.yaml
+++ b/servers/robtex/server.yaml
@@ -1,0 +1,24 @@
+name: robtex
+type: remote
+meta:
+  category: security
+  tags:
+    - security
+    - dns
+    - network
+    - ip
+    - whois
+    - bgp
+    - bitcoin
+    - lightning-network
+    - threat-intelligence
+    - remote
+about:
+  title: Robtex
+  description: Network intelligence and security tools — DNS lookups, reverse DNS, IP geolocation, BGP routing, WHOIS, domain reputation, threat intel, Bitcoin blockchain, and Lightning Network analysis. 55+ read-only tools, no auth required.
+  icon: https://www.robtex.com/favicon.ico
+remote:
+  transport_type: streamable-http
+  url: https://robtex.com/mcp
+source:
+  project: https://www.robtex.com

--- a/servers/robtex/tools.json
+++ b/servers/robtex/tools.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "lookup_dns",
+    "description": "Lookup DNS records (A, AAAA, MX, NS, TXT, CNAME, SOA) for a hostname with domain reputation info",
+    "arguments": [{"name": "hostname", "type": "string", "description": "Hostname to look up", "required": true}]
+  },
+  {
+    "name": "reverse_lookup_ip",
+    "description": "Find hostnames pointing to a specific IP address",
+    "arguments": [{"name": "ip", "type": "string", "description": "IP address", "required": true}, {"name": "limit", "type": "number", "description": "Max results", "required": false}, {"name": "offset", "type": "number", "description": "Pagination offset", "required": false}]
+  },
+  {
+    "name": "ip_reputation",
+    "description": "Check IP against 100+ real-time blocklists (DNSBLs) with threat categories and AS info",
+    "arguments": [{"name": "ip", "type": "string", "description": "IP address to check", "required": true}]
+  },
+  {
+    "name": "ip_geolocation",
+    "description": "Get geographic location for an IP: country, city, region, coordinates, timezone",
+    "arguments": [{"name": "ip", "type": "string", "description": "IP address", "required": true}]
+  },
+  {
+    "name": "ip_network",
+    "description": "Get BGP route, AS number, AS name, and route description for an IP",
+    "arguments": [{"name": "ip", "type": "string", "description": "IP address", "required": true}]
+  },
+  {
+    "name": "ip_threat_intel",
+    "description": "Combined threat intelligence: DNSBL, IPsum, FireHOL, bad ASN, Tor exit status",
+    "arguments": [{"name": "ip", "type": "string", "description": "IP address", "required": true}]
+  },
+  {
+    "name": "domain_reputation",
+    "description": "Domain reputation: Majestic, Tranco ranks, blocklist status, HSTS preload, disposable email",
+    "arguments": [{"name": "hostname", "type": "string", "description": "Domain name", "required": true}]
+  },
+  {
+    "name": "domain_ranking",
+    "description": "Domain popularity from 5 sources: Majestic, Tranco, Cloudflare Radar, Umbrella, CrUX",
+    "arguments": [{"name": "hostname", "type": "string", "description": "Domain name", "required": true}]
+  },
+  {
+    "name": "lookup_bitcoin_transaction",
+    "description": "Full Bitcoin transaction details: inputs, outputs, fee, SegWit flag, Lightning correlation",
+    "arguments": [{"name": "txid", "type": "string", "description": "Transaction ID", "required": true}]
+  },
+  {
+    "name": "lookup_bitcoin_address",
+    "description": "Bitcoin address balance, tx counts, type, first/last seen, ransomware flags",
+    "arguments": [{"name": "address", "type": "string", "description": "Bitcoin address", "required": true}]
+  },
+  {
+    "name": "lookup_lightning_node",
+    "description": "Lightning Network node details by public key: alias, peers, channels, centrality",
+    "arguments": [{"name": "pubkey", "type": "string", "description": "Node public key", "required": true}]
+  },
+  {
+    "name": "as_info",
+    "description": "AS number info: name, organization, country, description",
+    "arguments": [{"name": "asn", "type": "string", "description": "AS number (e.g. 15169)", "required": true}]
+  },
+  {
+    "name": "pdns_forward",
+    "description": "Passive DNS records for a domain (A, AAAA, MX, NS, CNAME)",
+    "arguments": [{"name": "domain", "type": "string", "description": "Domain name", "required": true}]
+  },
+  {
+    "name": "check_email",
+    "description": "Verify email address via SMTP: MX check, RCPT TO test, catch-all detection, TLS support",
+    "arguments": [{"name": "email", "type": "string", "description": "Email address", "required": true}]
+  }
+]


### PR DESCRIPTION
## Summary

Adds **Robtex** as a remote MCP server providing 55+ read-only network intelligence and security tools.

**Endpoint:** `https://robtex.com/mcp` (streamable-http)  
**Auth:** None required  
**Category:** Security  

### Tools include:
- **DNS**: Forward/reverse lookups (A, AAAA, MX, NS, TXT, CNAME, SOA, PTR), passive DNS, historic reverse lookups
- **IP**: Geolocation, network/ASN mapping, reputation checks against 100+ blocklists, threat intelligence
- **BGP/AS**: AS info, WHOIS, prefix announcements
- **Domain**: Reputation scoring (Majestic, Tranco, CrUX, Umbrella, Cloudflare Radar), blocklist checks, shared hosting/NS/MX discovery
- **Bitcoin**: Transaction details, address balances, block data, UTXO tracking, blockchain statistics
- **Lightning Network**: Node lookups, channel info, peer recommendations, alias search
- **Utilities**: MAC vendor lookup, hostname parsing, email verification

### Files
- `servers/robtex/server.yaml` — Remote server config (streamable-http, no OAuth)
- `servers/robtex/tools.json` — Representative tool listing (14 of 55+ tools)
- `servers/robtex/readme.md` — Documentation link

### Testing
\`\`\`bash
# Verify endpoint responds
curl -X POST https://robtex.com/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
\`\`\`

Docs: https://www.robtex.com/en/mcp-server