### PR TITLE
 feat: Add CrashStory MCP - Colorado crash data & attorney search

### DIFF
--- a/servers/crashstory/server.yaml
+++ b/servers/crashstory/server.yaml
@@ -1,0 +1,17 @@
+name: crashstory
+type: remote
+meta:
+  category: data
+  tags:
+    - colorado
+    - crash-data
+    - legal
+    - attorney
+    - remote
+about:
+  title: CrashStory
+  description: Search 594K+ Colorado car accident records by location, date, and severity. Compare 600+ personal injury attorneys with AI-analyzed review intelligence from 25K+ client reviews. Free, public, read-only.
+  icon: https://www.google.com/s2/favicons?domain=crashstory.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://crashstory-mcp-production.up.railway.app/mcp


### PR DESCRIPTION

  Adds CrashStory MCP as a remote server to the registry.

  CrashStory provides free, public, read-only access to Colorado traffic
  accident data and personal injury attorney intelligence.

  ## Server Details

  - **Type:** Remote (Streamable HTTP, stateless)
  - **Endpoint:** https://crashstory-mcp-production.up.railway.app/mcp
  - **Auth:** None required
  - **License:** MIT

  ## Tools (15)

  | Category | Tools |
  |---|---|
  | Crash Data | `search_crashes`, `get_crash_details`, `get_nearby_crashes` |
  | Attorney Search | `search_attorneys`, `get_attorney_profile`, `find_nearby_attorneys`,      
  `compare_attorneys` |
  | Reviews | `get_attorney_reviews`, `get_review_intelligence`, `compare_review_intelligence`, 
  `search_attorney_reviews`, `get_review_analytics` |
  | Leaderboards | `get_attorney_leaderboard`, `get_city_review_leaderboard` |
  | Metadata | `list_attorney_cities` |

  ## Data Coverage

  - 594K+ Colorado crash records
  - 600+ personal injury attorneys
  - 25K+ client reviews with AI analysis

  Closes #1536