### PR TITLE
feat: add dbt-mcp server

### DIFF
--- a/servers/dbt-mcp/readme.md
+++ b/servers/dbt-mcp/readme.md
@@ -1,0 +1,1 @@
+https://docs.getdbt.com/docs/dbt-ai/about-mcp

--- a/servers/dbt-mcp/server.yaml
+++ b/servers/dbt-mcp/server.yaml
@@ -1,0 +1,85 @@
+name: dbt-mcp
+image: mcp/dbt-mcp
+type: server
+meta:
+  category: analytics
+  tags:
+    - dbt
+    - data
+    - analytics
+    - semantic-layer
+    - data-warehouse
+about:
+  title: dbt
+  description: |
+    Connect AI assistants to the dbt platform for data exploration, metrics querying,
+    and project management. Access the Semantic Layer to query metrics, explore
+    model lineage, run jobs, and execute SQL against your data warehouse.
+  icon: https://avatars.githubusercontent.com/u/15813678?s=200&v=4
+source:
+  project: https://github.com/dbt-labs/dbt-mcp
+  branch: main
+  commit: f29178e9cef5184c7a4ffdc02825926362963058
+config:
+  description: Configure connection to the dbt platform
+  secrets:
+    - name: dbt-mcp.token
+      env: DBT_TOKEN
+      example: dbtc_xxxxxxxxxxxxxxxxxxxx
+  env:
+    - name: DBT_HOST
+      example: cloud.getdbt.com
+      value: "{{dbt-mcp.host}}"
+    - name: DBT_PROD_ENV_ID
+      example: "123456"
+      value: "{{dbt-mcp.prod_env_id}}"
+    - name: DBT_DEV_ENV_ID
+      example: "789012"
+      value: "{{dbt-mcp.dev_env_id}}"
+    - name: DBT_USER_ID
+      example: "12345"
+      value: "{{dbt-mcp.user_id}}"
+    # Enable toolsets - users opt-in to the features they need
+    - name: DBT_MCP_ENABLE_SEMANTIC_LAYER
+      value: "{{dbt-mcp.enable_semantic_layer}}"
+    - name: DBT_MCP_ENABLE_DISCOVERY
+      value: "{{dbt-mcp.enable_discovery}}"
+    - name: DBT_MCP_ENABLE_ADMIN_API
+      value: "{{dbt-mcp.enable_admin_api}}"
+    - name: DBT_MCP_ENABLE_SQL
+      value: "{{dbt-mcp.enable_sql}}"
+  parameters:
+    type: object
+    properties:
+      host:
+        type: string
+        description: dbt host (e.g., cloud.getdbt.com)
+        default: cloud.getdbt.com
+      prod_env_id:
+        type: string
+        description: Production environment ID from dbt
+      dev_env_id:
+        type: string
+        description: Development environment ID (required for execute_sql)
+      user_id:
+        type: string
+        description: Your dbt user ID (required for execute_sql)
+      enable_semantic_layer:
+        type: boolean
+        description: Enable Semantic Layer tools (query_metrics, list_metrics, etc.)
+        default: true
+      enable_discovery:
+        type: boolean
+        description: Enable Discovery tools (get_model_details, get_lineage, etc.)
+        default: true
+      enable_admin_api:
+        type: boolean
+        description: Enable Admin API tools (list_jobs, trigger_job_run, etc.)
+        default: true
+      enable_sql:
+        type: boolean
+        description: Enable SQL tools (text_to_sql, execute_sql)
+        default: false
+    required:
+      - host
+      - prod_env_id

--- a/servers/dbt-mcp/tools.json
+++ b/servers/dbt-mcp/tools.json
@@ -1,0 +1,150 @@
+[
+  {
+    "description": "List all metrics available in the Semantic Layer",
+    "name": "list_metrics"
+  },
+  {
+    "description": "List all saved queries in the Semantic Layer",
+    "name": "list_saved_queries"
+  },
+  {
+    "description": "Get dimensions for a specific metric",
+    "name": "get_dimensions"
+  },
+  {
+    "description": "Get entities for a specific metric",
+    "name": "get_entities"
+  },
+  {
+    "description": "Query metrics from the Semantic Layer with dimensions and filters",
+    "name": "query_metrics"
+  },
+  {
+    "description": "Get the compiled SQL for a metrics query",
+    "name": "get_metrics_compiled_sql"
+  },
+  {
+    "description": "Get all mart models in the dbt project",
+    "name": "get_mart_models"
+  },
+  {
+    "description": "Get all models in the dbt project",
+    "name": "get_all_models"
+  },
+  {
+    "description": "Get detailed information about a specific model",
+    "name": "get_model_details"
+  },
+  {
+    "description": "Get parent models (upstream dependencies) for a model",
+    "name": "get_model_parents"
+  },
+  {
+    "description": "Get child models (downstream dependencies) for a model",
+    "name": "get_model_children"
+  },
+  {
+    "description": "Get health status and test results for a model",
+    "name": "get_model_health"
+  },
+  {
+    "description": "Get the full lineage graph for a model",
+    "name": "get_lineage"
+  },
+  {
+    "description": "Get all sources defined in the dbt project",
+    "name": "get_all_sources"
+  },
+  {
+    "description": "Get detailed information about a specific source",
+    "name": "get_source_details"
+  },
+  {
+    "description": "Get all exposures defined in the dbt project",
+    "name": "get_exposures"
+  },
+  {
+    "description": "Get detailed information about a specific exposure",
+    "name": "get_exposure_details"
+  },
+  {
+    "description": "Get models related to a specific model",
+    "name": "get_related_models"
+  },
+  {
+    "description": "Get detailed information about a specific macro",
+    "name": "get_macro_details"
+  },
+  {
+    "description": "Get detailed information about a specific seed",
+    "name": "get_seed_details"
+  },
+  {
+    "description": "Get detailed information about a semantic model",
+    "name": "get_semantic_model_details"
+  },
+  {
+    "description": "Get detailed information about a specific snapshot",
+    "name": "get_snapshot_details"
+  },
+  {
+    "description": "Get detailed information about a specific test",
+    "name": "get_test_details"
+  },
+  {
+    "description": "Convert natural language to SQL using the Semantic Layer",
+    "name": "text_to_sql"
+  },
+  {
+    "description": "Execute SQL queries against your data warehouse",
+    "name": "execute_sql"
+  },
+  {
+    "description": "List all jobs in the dbt project",
+    "name": "list_jobs"
+  },
+  {
+    "description": "Get detailed information about a specific job",
+    "name": "get_job_details"
+  },
+  {
+    "description": "Get detailed information about the dbt project",
+    "name": "get_project_details"
+  },
+  {
+    "description": "Trigger a job run",
+    "name": "trigger_job_run"
+  },
+  {
+    "description": "List job runs for a specific job",
+    "name": "list_jobs_runs"
+  },
+  {
+    "description": "Get detailed information about a specific job run",
+    "name": "get_job_run_details"
+  },
+  {
+    "description": "Cancel a running job",
+    "name": "cancel_job_run"
+  },
+  {
+    "description": "Retry a failed job run",
+    "name": "retry_job_run"
+  },
+  {
+    "description": "List artifacts from a job run",
+    "name": "list_job_run_artifacts"
+  },
+  {
+    "description": "Get a specific artifact from a job run",
+    "name": "get_job_run_artifact"
+  },
+  {
+    "description": "Get error details from a failed job run",
+    "name": "get_job_run_error"
+  },
+  {
+    "description": "Get the version of the dbt MCP server",
+    "name": "get_mcp_server_version"
+  }
+]


### PR DESCRIPTION
## Summary

- Adds the [dbt-mcp](https://github.com/dbt-labs/dbt-mcp) server to the registry
- Connects AI assistants to the dbt platform for data exploration, metrics querying, and project management
- Local server using the Dockerfile at the root of the repository

## Server details

- **Category:** analytics
- **Image:** `mcp/dbt-mcp`
- **Source:** https://github.com/dbt-labs/dbt-mcp @ `v1.10.0`

## Configuration

The server requires a dbt Cloud access token (`DBT_TOKEN`) and supports optional env vars for environment IDs. Toolsets (Semantic Layer, Discovery, Admin API, SQL) can be individually enabled/disabled via env vars.