### PR TITLE
Convert Neon entry to remote MCP server

### DIFF
--- a/servers/neon/server.yaml
+++ b/servers/neon/server.yaml
@@ -10,7 +10,7 @@ meta:
     - postgres
     - remote
 about:
-  title: Neon
+  title: Neon Postgres
   description: Manage Neon Postgres databases using natural language with the Neon MCP Server
   icon: https://neon.com/brand/neon-logomark-dark-color.svg
 remote:


### PR DESCRIPTION
## Summary
- convert existing `servers/neon` from a local Docker-built server entry to a remote MCP server entry
- point Neon to the hosted endpoint `https://mcp.neon.tech/mcp` (Streamable HTTP)
- configure API key authentication via `Authorization: Bearer ${NEON_API_KEY}`
- use official Neon brand logomark icon from `https://neon.com/brand`

## Test plan
- [x] `go run ./cmd/validate --name neon`
- [x] verify `servers/neon/server.yaml` includes `type: remote`, remote URL, and API key header
- [x] verify icon URL resolves as SVG and passes validator checks