### PR TITLE
Add iris-eval — MCP-native agent evaluation server

### DIFF
--- a/servers/iris-eval/server.yaml
+++ b/servers/iris-eval/server.yaml
@@ -1,0 +1,26 @@
+name: iris-eval
+image: ghcr.io/iris-eval/mcp-server
+type: server
+meta:
+  category: monitoring
+  tags:
+    - evaluation
+    - observability
+    - mcp
+    - agent-eval
+    - quality
+    - cost-tracking
+    - pii-detection
+about:
+  title: Iris — The Agent Eval Standard for MCP
+  description: >
+    MCP-native agent evaluation and observability server. Score output quality,
+    catch safety failures, enforce cost budgets — across every agent, every execution.
+    12 built-in eval rules, PII detection, hallucination markers, cost tracking.
+    Glama AAA rated. MIT licensed.
+  icon: https://www.google.com/s2/favicons?domain=iris-eval.com&sz=64
+source:
+  project: https://github.com/iris-eval/mcp-server
+  branch: main
+run:
+  type: stdio


### PR DESCRIPTION
## New MCP Server: iris-eval

### Server Info
- **Name:** iris-eval
- **Category:** monitoring
- **Description:** MCP-native agent evaluation and observability server. Score output quality, catch safety failures, enforce cost budgets. 12 built-in eval rules, PII detection, cost tracking.
- **Source:** https://github.com/iris-eval/mcp-server
- **Docker Image:** ghcr.io/iris-eval/mcp-server (public, multi-arch)
- **License:** MIT
- **Glama Rating:** AAA (Security A, License A, Quality A)

### Checklist
- [x] Server has a Dockerfile
- [x] Docker image is published and public (ghcr.io)
- [x] Server entry follows server.yaml format
- [x] MIT licensed
- [x] Published to Official MCP Registry (io.github.iris-eval/mcp-server)
- [x] Listed on punkpeye/awesome-mcp-servers