### PR TITLE
Add Recursive AI support agent platform (3 remote servers)

### DIFF
--- a/servers/recursive-support-alan/readme.md
+++ b/servers/recursive-support-alan/readme.md
@@ -1,0 +1,1 @@
+Docs: https://codereclaimers.com

--- a/servers/recursive-support-alan/server.yaml
+++ b/servers/recursive-support-alan/server.yaml
@@ -1,0 +1,18 @@
+name: recursive-support-alan
+type: remote
+meta:
+  category: productivity
+  tags:
+    - consulting
+    - ai-agent
+    - knowledge-base
+    - remote
+about:
+  title: CodeReclaimers Capability Oracle
+  description: Query skills, project history, and availability for CodeReclaimers LLC consulting.
+  icon: https://alan.recursive.support/static/logo.png
+source:
+  project: https://recursive.support
+remote:
+  transport_type: streamable-http
+  url: https://alan.recursive.support/mcp

--- a/servers/recursive-support-alan/tools.json
+++ b/servers/recursive-support-alan/tools.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "query_capabilities",
+    "description": "Query the knowledge base of Alan McIntyre, an independent consultant specializing in computational geometry, scientific C++/Python/Julia computing, and neuroevolution.",
+    "arguments": [
+      {
+        "name": "question",
+        "type": "string",
+        "description": "Question about skills, project history, or availability",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "get_availability",
+    "description": "Returns current availability status for Alan McIntyre (CodeReclaimers LLC).",
+    "arguments": []
+  },
+  {
+    "name": "get_capability_manifest",
+    "description": "Returns the full structured capability manifest including domains, engagement types, project list, and endpoint URLs.",
+    "arguments": []
+  }
+]

--- a/servers/recursive-support-dezignworks/readme.md
+++ b/servers/recursive-support-dezignworks/readme.md
@@ -1,0 +1,1 @@
+Docs: https://dezignworks.com

--- a/servers/recursive-support-dezignworks/server.yaml
+++ b/servers/recursive-support-dezignworks/server.yaml
@@ -1,0 +1,19 @@
+name: recursive-support-dezignworks
+type: remote
+meta:
+  category: productivity
+  tags:
+    - cad
+    - reverse-engineering
+    - ai-agent
+    - knowledge-base
+    - remote
+about:
+  title: DezignWorks Product Oracle
+  description: Query DezignWorks reverse engineering software — features, compatibility, and pricing.
+  icon: https://dezignworks.recursive.support/static/logo.png
+source:
+  project: https://dezignworks.com
+remote:
+  transport_type: streamable-http
+  url: https://dezignworks.recursive.support/mcp

--- a/servers/recursive-support-dezignworks/tools.json
+++ b/servers/recursive-support-dezignworks/tools.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "query_product",
+    "description": "Query the DezignWorks knowledge base for information about reverse engineering software that integrates with SolidWorks and Autodesk Inventor.",
+    "arguments": [
+      {
+        "name": "question",
+        "type": "string",
+        "description": "Question about DezignWorks features, compatibility, workflows, or troubleshooting",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "recommend_product",
+    "description": "Recommend the right DezignWorks product tier based on equipment and needs. Three tiers: Probing ($6,995), Mesh Modeler ($8,995), Unlimited ($12,995).",
+    "arguments": [
+      {
+        "name": "question",
+        "type": "string",
+        "description": "Description of hardware and workflow to match to a product tier",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "get_product_info",
+    "description": "Returns structured product information including tiers, pricing, supported CAD platforms, and core capabilities.",
+    "arguments": []
+  },
+  {
+    "name": "get_supported_hardware",
+    "description": "Returns the list of supported measurement devices, file formats, and system requirements.",
+    "arguments": []
+  }
+]

--- a/servers/recursive-support/readme.md
+++ b/servers/recursive-support/readme.md
@@ -1,0 +1,1 @@
+Docs: https://recursive.support

--- a/servers/recursive-support/server.yaml
+++ b/servers/recursive-support/server.yaml
@@ -1,0 +1,18 @@
+name: recursive-support
+type: remote
+meta:
+  category: productivity
+  tags:
+    - customer-support
+    - ai-agent
+    - knowledge-base
+    - remote
+about:
+  title: Recursive Support Oracle
+  description: AI support agent platform for small businesses. Query pricing, features, and live examples.
+  icon: https://recursive.support/static/logo.png
+source:
+  project: https://recursive.support
+remote:
+  transport_type: streamable-http
+  url: https://recursive.support/mcp

--- a/servers/recursive-support/tools.json
+++ b/servers/recursive-support/tools.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "query_product",
+    "description": "Query the Recursive knowledge base for information about the AI support agent platform — features, pricing, how it works, live examples, getting started, or technical details.",
+    "arguments": [
+      {
+        "name": "question",
+        "type": "string",
+        "description": "Question about the Recursive platform",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "get_pricing",
+    "description": "Returns structured pricing data for Recursive support agent plans. Three tiers: Basic ($49/mo), Pro ($99/mo), Premium ($299/mo).",
+    "arguments": []
+  },
+  {
+    "name": "get_platform_capabilities",
+    "description": "Returns structured information about Recursive platform features, AI model details, supported integrations, and what is included at every tier.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## Summary

Adds three remote MCP servers from the [Recursive](https://recursive.support) AI support agent platform:

| Server | Endpoint | Description |
|--------|----------|-------------|
| `recursive-support` | https://recursive.support/mcp | Platform product oracle — pricing, features, examples |
| `recursive-support-alan` | https://alan.recursive.support/mcp | Consulting capability oracle for CodeReclaimers LLC |
| `recursive-support-dezignworks` | https://dezignworks.recursive.support/mcp | Product oracle for DezignWorks reverse engineering software |

## Details

- **Transport:** Streamable HTTP (all three)
- **Auth:** None required (public endpoints)
- **Dynamic tools:** Tool definitions provided in `tools.json` for each server
- **Also published on** the official MCP Registry at `registry.modelcontextprotocol.io` as `support.recursive/*`

All three endpoints are live and responding to MCP JSON-RPC requests.