### PR TITLE
Add Transloadit MCP Server

### DIFF
--- a/servers/transloadit-mcp-server/server.yaml
+++ b/servers/transloadit-mcp-server/server.yaml
@@ -20,7 +20,9 @@ source:
 run:
   allowHosts:
     - api2.transloadit.com:443
+    - api2-us-east-1.transloadit.com:443
     - api2-eu-west-1.transloadit.com:443
+    - api2-ap-southeast-1.transloadit.com:443
 config:
   description: Configure Transloadit API credentials
   secrets:


### PR DESCRIPTION
## Summary

- Adds [Transloadit MCP Server](https://transloadit.com/docs/sdks/mcp-server/) to the Docker MCP Catalog
- Process video, audio, images, and documents with 86+ cloud media processing robots
- Encode video to HLS, resize images, transcribe speech, OCR documents, and more

## Details

- **npm**: [@transloadit/mcp-server](https://www.npmjs.com/package/@transloadit/mcp-server)
- **GitHub**: [transloadit/node-sdk](https://github.com/transloadit/node-sdk/tree/main/packages/mcp-server)
- **License**: MIT
- **Dockerfile**: `packages/mcp-server/Dockerfile` (node:22-alpine, npm install)
- **Docker image**: Already published at `ghcr.io/transloadit/mcp-server:latest`
- **MCP Registry**: Listed as `io.github.transloadit/mcp-server` on registry.modelcontextprotocol.io
- **Glama**: AAA score at https://glama.ai/mcp/servers/transloadit/node-sdk
