### PR TITLE
fix: harden auto-merge workflow (expression injection + race condition)

### DIFF
--- a/.github/pin-upgrade-auto-merge-helper-scripts/wait-for-checks.sh
+++ b/.github/pin-upgrade-auto-merge-helper-scripts/wait-for-checks.sh
@@ -4,6 +4,12 @@ set -e
 pr_number="$1"
 repository="$2"
 
+# Required check prefixes that must exist and pass before auto-merge.
+# The security review check is posted by a private repo after a dispatch delay
+# (typically 60-90s). Without this gate, the script could see "all checks green"
+# before the security review check is even created.
+REQUIRED_CHECK_PREFIXES=("security-review/")
+
 # Get all check runs for the PR's head SHA
 head_sha=$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid')
 
@@ -20,6 +26,18 @@ if [ "$total_checks" -eq 0 ]; then
   echo "skip=true" >> "$GITHUB_OUTPUT"
   exit 0
 fi
+
+# Verify all required checks exist
+for prefix in "${REQUIRED_CHECK_PREFIXES[@]}"; do
+  match=$(echo "$check_runs" | jq -r --arg p "$prefix" '[.[] | select(.name | startswith($p))] | length')
+  if [ "$match" -eq 0 ]; then
+    echo "Required check with prefix '$prefix' has not been created yet."
+    echo "Will retry when it appears."
+    echo "skip=true" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+  echo "Required check prefix '$prefix' found ($match match(es))"
+done
 
 # Check if any checks failed
 failed_checks=$(echo "$check_runs" | jq -r '.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null) | .name')

--- a/.github/workflows/auto-merge-pins.yaml
+++ b/.github/workflows/auto-merge-pins.yaml
@@ -61,57 +61,68 @@ jobs:
       - name: Validate PR is from bot and ready for merge
         id: validate
         if: steps.pr.outputs.skip != 'true'
+        env:
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          PR_STATE: ${{ steps.pr.outputs.state }}
+          PR_IS_DRAFT: ${{ steps.pr.outputs.is_draft }}
+          PR_LABELS: ${{ steps.pr.outputs.labels }}
         run: |
           .github/pin-upgrade-auto-merge-helper-scripts/validate-pr.sh \
-            "${{ steps.pr.outputs.author }}" \
-            "${{ steps.pr.outputs.state }}" \
-            "${{ steps.pr.outputs.is_draft }}" \
-            "${{ steps.pr.outputs.labels }}"
+            "$PR_AUTHOR" \
+            "$PR_STATE" \
+            "$PR_IS_DRAFT" \
+            "$PR_LABELS"
 
       - name: Extract server name from changed files
         id: extract
         if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
-        run: .github/pin-upgrade-auto-merge-helper-scripts/extract-server.sh "${{ steps.pr.outputs.pr_number }}"
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: .github/pin-upgrade-auto-merge-helper-scripts/extract-server.sh "$PR_NUMBER"
 
       - name: Wait for all checks to pass
         id: checks
         if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          REPO: ${{ github.repository }}
         run: |
           .github/pin-upgrade-auto-merge-helper-scripts/wait-for-checks.sh \
-            "${{ steps.pr.outputs.pr_number }}" \
-            "${{ github.repository }}"
+            "$PR_NUMBER" \
+            "$REPO"
 
       - name: Comment on PR before merging
         if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          SERVER: ${{ steps.extract.outputs.server }}
         run: |
           .github/pin-upgrade-auto-merge-helper-scripts/comment-pr.sh \
             success \
-            "${{ steps.pr.outputs.pr_number }}" \
-            "${{ steps.extract.outputs.server }}"
+            "$PR_NUMBER" \
+            "$SERVER"
 
       - name: Merge PR
         if: steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true' && steps.extract.outputs.skip != 'true' && steps.checks.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
-        run: .github/pin-upgrade-auto-merge-helper-scripts/merge-pr.sh "${{ steps.pr.outputs.pr_number }}"
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: .github/pin-upgrade-auto-merge-helper-scripts/merge-pr.sh "$PR_NUMBER"
 
       - name: Handle merge failure
         if: failure() && steps.pr.outputs.skip != 'true' && steps.validate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.docker-mcp-registry-bot-auth.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          pr_number="${{ steps.pr.outputs.pr_number }}"
-
-          if [ -n "$pr_number" ]; then
+          if [ -n "$PR_NUMBER" ]; then
             .github/pin-upgrade-auto-merge-helper-scripts/comment-pr.sh \
               failure \
-              "$pr_number" \
+              "$PR_NUMBER" \
               "" \
-              "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "$WORKFLOW_URL"
           fi


### PR DESCRIPTION
## Summary

Security hardening for the auto-merge-pins workflow, addressing feedback from Mark's review:

- **Expression injection fix**: Move all `${{ }}` interpolations from `run:` blocks to `env:` blocks. The `labels` output was the riskiest since label names are user-controllable. The `get-pr-details.sh` step already followed this pattern — now all steps are consistent.
- **Race condition fix**: `wait-for-checks.sh` now requires a `security-review/` check to exist before proceeding. Previously, if CI + CodeQL completed before the security review check was created (~60-90s dispatch delay), the script would see "all checks green" and merge without the review. If the required check never gets created, the PR won't auto-merge (safer failure mode).

## Test plan

- [ ] Verify on a pin upgrade PR that the workflow waits for the security-review check before merging
- [ ] Verify that if security-review check doesn't exist yet, the workflow sets `skip=true` and waits for re-trigger
- [ ] Verify expression injection fix doesn't change behavior (env vars pass through identically to inline interpolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)