### PR TITLE
Add Help Scout MCP Server

### DIFF
--- a/servers/helpscout-mcp-server/server.yaml
+++ b/servers/helpscout-mcp-server/server.yaml
@@ -1,0 +1,44 @@
+name: helpscout-mcp-server
+image: mcp/helpscout-mcp-server
+type: server
+meta:
+  category: customer-support
+  tags:
+    - customer-support
+    - helpscout
+    - help-scout
+    - support-tickets
+    - crm
+    - mcp
+about:
+  title: Help Scout
+  description: Search and retrieve Help Scout conversations, customers, organizations, and threads. 17 read-only tools with PII protection, caching, and rate limit handling.
+  icon: https://www.google.com/s2/favicons?domain=helpscout.com&sz=64
+source:
+  project: https://github.com/drewburchfield/help-scout-mcp-server
+  commit: 47649ff2b3dcbbff2e4619f9cf701f946737bc94
+config:
+  description: Connect to your Help Scout account
+  secrets:
+    - name: helpscout-mcp-server.client_id
+      env: HELPSCOUT_APP_ID
+      example: <HELPSCOUT_APP_ID>
+    - name: helpscout-mcp-server.client_secret
+      env: HELPSCOUT_APP_SECRET
+      example: <HELPSCOUT_APP_SECRET>
+  env:
+    - name: REDACT_MESSAGE_CONTENT
+      example: "false"
+      value: "{{helpscout-mcp-server.redact_message_content}}"
+    - name: HELPSCOUT_DEFAULT_INBOX_ID
+      example: ""
+      value: "{{helpscout-mcp-server.default_inbox_id}}"
+  parameters:
+    type: object
+    properties:
+      redact_message_content:
+        type: string
+        default: "false"
+      default_inbox_id:
+        type: string
+        default: ""

--- a/servers/helpscout-mcp-server/tools.json
+++ b/servers/helpscout-mcp-server/tools.json
@@ -1,0 +1,19 @@
+[
+  {"name": "searchInboxes", "description": "List or search inboxes by name"},
+  {"name": "listAllInboxes", "description": "List all inboxes with IDs"},
+  {"name": "searchConversations", "description": "List conversations by status, date range, inbox, or tags"},
+  {"name": "comprehensiveConversationSearch", "description": "Search conversation content by keywords across all statuses"},
+  {"name": "advancedConversationSearch", "description": "Filter conversations by email domain, customer email, or multiple tags"},
+  {"name": "structuredConversationFilter", "description": "Lookup conversation by ticket number, assignee, customer ID, or folder"},
+  {"name": "getConversationSummary", "description": "Get conversation summary with first customer message and latest staff reply"},
+  {"name": "getThreads", "description": "Retrieve full message history for a conversation"},
+  {"name": "getServerTime", "description": "Get current server timestamp for time-relative searches"},
+  {"name": "listCustomers", "description": "Browse or search customers by name, query, or modification date"},
+  {"name": "searchCustomersByEmail", "description": "Search customers by email address using the v3 API"},
+  {"name": "getCustomer", "description": "Get a customer profile by ID with contact details and address"},
+  {"name": "getCustomerContacts", "description": "Get all contact channels for a customer: emails, phones, chats, social profiles, websites, address"},
+  {"name": "listOrganizations", "description": "List all organizations with sorting options"},
+  {"name": "getOrganization", "description": "Get an organization by ID with optional customer and conversation counts"},
+  {"name": "getOrganizationMembers", "description": "Get all customers belonging to an organization"},
+  {"name": "getOrganizationConversations", "description": "Get all conversations associated with an organization"}
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** helpscout-mcp-server
**Repository URL:** https://github.com/drewburchfield/help-scout-mcp-server
**Brief Description:** Search and retrieve Help Scout conversations, customers, organizations, and threads. 17 read-only tools with PII protection, caching, and rate limit handling.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name helpscout-mcp-server`
- [x] I have built the MCP Server using `task build -- --tools helpscout-mcp-server`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

- `tools.json` is provided because the server requires OAuth2 credentials to start and list tools
- Test credentials will be shared via the Google Form