### PR TITLE
Add validation tests for title and commit pinning

### DIFF
--- a/cmd/validate/main_test.go
+++ b/cmd/validate/main_test.go
@@ -112,6 +112,86 @@ func Test_isNameValid(t *testing.T) {
 	}
 }
 
+func Test_isTitleValid(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantError bool
+	}{
+		{
+			name: "valid single-word title",
+			args: args{
+				name: "atlassian",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid multi-word title",
+			args: args{
+				name: "astra-db",
+			},
+			wantError: false,
+		},
+		{
+			name: "title contains MCP",
+			args: args{
+				name: "bad-server",
+			},
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTitleValid(tt.args.name); (got != nil) != tt.wantError {
+				t.Errorf("isTitleValid() = %v, want error=%v", got, tt.wantError)
+			}
+		})
+	}
+}
+
+func Test_isCommitPinnedIfNecessary(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantError bool
+	}{
+		{
+			name: "local server with pinned commit",
+			args: args{
+				name: "atlassian",
+			},
+			wantError: false,
+		},
+		{
+			name: "remote server skips commit check",
+			args: args{
+				name: "notion-remote",
+			},
+			wantError: false,
+		},
+		{
+			name: "local server missing commit",
+			args: args{
+				name: "bad-server",
+			},
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCommitPinnedIfNecessary(tt.args.name); (got != nil) != tt.wantError {
+				t.Errorf("isCommitPinnedIfNecessary() = %v, want error=%v", got, tt.wantError)
+			}
+		})
+	}
+}
+
 func Test_areSecretsValid(t *testing.T) {
 	type args struct {
 		name string

--- a/servers/bad-server/server.yaml
+++ b/servers/bad-server/server.yaml
@@ -1,0 +1,17 @@
+name: bad-server
+image: mcp/bad-server
+type: server
+meta:
+  category: devops
+  tags:
+    - test
+about:
+  title: Bad MCP
+  description: Test fixture for validation testing
+source:
+  project: https://github.com/example/bad-server
+config:
+  secrets:
+    - name: invalidsecretwithoutdot
+      env: INVALID_SECRET
+      example: test


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit tests for two validation functions in the MCP server validation tool:

1. **`Test_isTitleValid`**: Tests validation of server titles, including:
   - Valid single-word titles
   - Valid multi-word titles with hyphens
   - Rejection of titles containing "MCP"

2. **`Test_isCommitPinnedIfNecessary`**: Tests validation of commit pinning requirements, including:
   - Local servers with pinned commits (valid)
   - Remote servers that skip commit checks (valid)
   - Local servers missing commits (invalid)

## Changes

- Added 86 lines of test coverage in `cmd/validate/main_test.go`
- Added test fixture `servers/bad-server/server.yaml` to support validation testing scenarios

## Test Plan

The new unit tests provide direct coverage of the validation logic. All tests follow the existing test patterns in the codebase and use realistic test fixtures to verify both valid and invalid server configurations.

https://claude.ai/code/session_01Dh6rzoMGbxQHAo7TGZmxog