### PR TITLE
Add Code Pathfinder SAST MCP server

### DIFF
--- a/servers/code-pathfinder/readme.md
+++ b/servers/code-pathfinder/readme.md
@@ -1,0 +1,1 @@
+Docs: https://codepathfinder.dev/docs/mcp/docker-mcp

--- a/servers/code-pathfinder/server.yaml
+++ b/servers/code-pathfinder/server.yaml
@@ -1,0 +1,39 @@
+name: code-pathfinder
+image: mcp/code-pathfinder
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - sast
+    - code-analysis
+    - call-graph
+    - python
+    - java
+    - go
+    - docker
+about:
+  title: Code Pathfinder
+  description: SAST engine with MCP interface for code analysis. Builds call graphs, resolves types, tracks taint flows across Python, Java, Go, and Dockerfiles. Find symbols, trace callers/callees, analyze Docker configurations, and detect security vulnerabilities.
+  icon: https://codepathfinder.dev/assets/cpf-logo-200.png
+source:
+  project: https://github.com/shivasurya/code-pathfinder
+  dockerfile: Dockerfile.mcp
+  commit: 7c5187c55f5aec6315308505bd309c5d04a0e38e
+run:
+  volumes:
+    - "{{code-pathfinder.path|volume-target}}:/project"
+  allowHosts:
+    - assets.codepathfinder.dev
+    - us.i.posthog.com
+config:
+  description: Select the project directory to analyze. Code Pathfinder will index the codebase and expose call graph, symbol search, and security analysis tools.
+  parameters:
+    type: object
+    properties:
+      path:
+        type: string
+        description: Path to the project directory to analyze
+        default: /Users/demo/project
+    required:
+      - path

--- a/servers/code-pathfinder/tools.json
+++ b/servers/code-pathfinder/tools.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "get_index_info",
+    "description": "Get comprehensive statistics about the indexed codebase (Python, Go, Java). Use this FIRST to understand the project scope before making other queries.",
+    "arguments": []
+  },
+  {
+    "name": "find_symbol",
+    "description": "Search and filter symbols by name and/or type. Supports Python, Go, and Java. Supports partial matching. Results are paginated.",
+    "arguments": [
+      {"name": "name", "type": "string", "desc": "Symbol name to find. Optional. Can be: short name ('login'), partial name ('auth'), or FQN ('myapp.auth.login')"},
+      {"name": "type", "type": "string", "desc": "Filter by single symbol type. Optional. One of: function_definition, method, constructor, property, special_method, class_definition, interface, enum, dataclass, module_variable, constant, class_field, parameter"},
+      {"name": "types", "type": "array", "desc": "Filter by multiple symbol types. Optional. Array of type strings. Alternative to 'type' parameter"},
+      {"name": "module", "type": "string", "desc": "Filter by module. Optional. Matches symbols whose FQN starts with the module path (e.g., 'core.settings', 'data_manager.models'). Works with all symbol types"},
+      {"name": "limit", "type": "integer", "desc": "Max results to return (default: 50, max: 500)"},
+      {"name": "cursor", "type": "string", "desc": "Pagination cursor from previous response"}
+    ]
+  },
+  {
+    "name": "find_module",
+    "description": "Search for Python modules by name. Returns module information including file path and symbol counts.",
+    "arguments": [
+      {"name": "name", "type": "string", "desc": "Module name to find. Can be FQN ('myapp.auth') or short name ('auth')"}
+    ]
+  },
+  {
+    "name": "list_modules",
+    "description": "List all Python modules in the indexed project. Returns comprehensive module information.",
+    "arguments": []
+  },
+  {
+    "name": "get_callers",
+    "description": "Find all functions that CALL a given function (reverse call graph / incoming edges). Answer: \"Who uses this function?\" Results are paginated.",
+    "arguments": [
+      {"name": "function", "type": "string", "desc": "Function to find callers for. Use short name ('login') or FQN ('myapp.auth.login')"},
+      {"name": "limit", "type": "integer", "desc": "Max results to return (default: 50, max: 500)"},
+      {"name": "cursor", "type": "string", "desc": "Pagination cursor from previous response"}
+    ]
+  },
+  {
+    "name": "get_callees",
+    "description": "Find all functions CALLED BY a given function (forward call graph / outgoing edges). Answer: \"What does this function depend on?\" Results are paginated.",
+    "arguments": [
+      {"name": "function", "type": "string", "desc": "Function to find callees for. Use short name ('process') or FQN ('myapp.payment.process')"},
+      {"name": "limit", "type": "integer", "desc": "Max results to return (default: 50, max: 500)"},
+      {"name": "cursor", "type": "string", "desc": "Pagination cursor from previous response"}
+    ]
+  },
+  {
+    "name": "get_call_details",
+    "description": "Get detailed information about a SPECIFIC call from one function to another. Most detailed view of a single call site.",
+    "arguments": [
+      {"name": "caller", "type": "string", "desc": "The function making the call (short name or FQN)"},
+      {"name": "callee", "type": "string", "desc": "The function being called (short name, will match partially)"}
+    ]
+  },
+  {
+    "name": "resolve_import",
+    "description": "Resolve a Python import path to its actual file location in the project.",
+    "arguments": [
+      {"name": "import", "type": "string", "desc": "Import path to resolve. Can be FQN ('myapp.auth.users') or short name ('users')"}
+    ]
+  },
+  {
+    "name": "find_dockerfile_instructions",
+    "description": "Search Dockerfile instructions with semantic filtering. Supports instruction-specific filters (has_digest for FROM, user for USER, port for EXPOSE).",
+    "arguments": [
+      {"name": "instruction_type", "type": "string", "desc": "Filter by instruction type (FROM, RUN, USER, EXPOSE, COPY, ADD, WORKDIR, etc.)"},
+      {"name": "file_path", "type": "string", "desc": "Filter by Dockerfile path (supports partial matching)"},
+      {"name": "base_image", "type": "string", "desc": "Filter FROM instructions by base image name (e.g., 'python', 'alpine')"},
+      {"name": "port", "type": "integer", "desc": "Filter EXPOSE instructions by port number"},
+      {"name": "has_digest", "type": "boolean", "desc": "Filter FROM instructions by digest pinning (true=pinned, false=unpinned)"},
+      {"name": "user", "type": "string", "desc": "Filter USER instructions by username"},
+      {"name": "limit", "type": "integer", "desc": "Maximum results to return (default: 100)"}
+    ]
+  },
+  {
+    "name": "find_compose_services",
+    "description": "Search docker-compose services with filtering. Supports configuration filters (has_privileged, has_volume, exposes_port).",
+    "arguments": [
+      {"name": "service_name", "type": "string", "desc": "Filter by service name (supports partial matching)"},
+      {"name": "file_path", "type": "string", "desc": "Filter by docker-compose.yml path"},
+      {"name": "has_privileged", "type": "boolean", "desc": "Filter by privileged mode (true=privileged containers only)"},
+      {"name": "exposes_port", "type": "integer", "desc": "Filter services exposing specific port"},
+      {"name": "has_volume", "type": "string", "desc": "Filter services with specific volume path (e.g., '/var/run/docker.sock')"},
+      {"name": "limit", "type": "integer", "desc": "Maximum results to return (default: 100)"}
+    ]
+  },
+  {
+    "name": "get_dockerfile_details",
+    "description": "Get complete breakdown of a Dockerfile with all instructions and multi-stage analysis.",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to Dockerfile (required)"}
+    ]
+  },
+  {
+    "name": "get_docker_dependencies",
+    "description": "Retrieves dependency information for Docker entities (compose services or Dockerfile stages).",
+    "arguments": [
+      {"name": "type", "type": "string", "desc": "Entity type: \"compose\" for docker-compose services or \"dockerfile\" for Dockerfile stages"},
+      {"name": "name", "type": "string", "desc": "Entity name: service name (for compose) or stage name/alias (for dockerfile)"},
+      {"name": "file_path", "type": "string", "desc": "Optional: Filter to specific file path"},
+      {"name": "direction", "type": "string", "desc": "Traversal direction: \"upstream\", \"downstream\", or \"both\" (default: \"both\")"},
+      {"name": "max_depth", "type": "integer", "desc": "Maximum traversal depth (default: 10)"}
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** code-pathfinder
**Repository URL:** https://github.com/shivasurya/code-pathfinder
**Brief Description:** Open-source SAST engine with MCP interface. Builds call graphs, resolves types, and tracks taint flows across Python, Java, Go, and Dockerfiles. 12 MCP tools for symbol search, call graph traversal, import resolution, and Docker configuration analysis.

## About Code Pathfinder

[Code Pathfinder](https://codepathfinder.dev) is an open-source static application security testing (SAST) engine that indexes codebases into a queryable call graph. It parses source files using tree-sitter, builds a 5-pass call graph with bidirectional type inference, and exposes 12 MCP tools over stdio for AI coding assistants.

- **Website:** https://codepathfinder.dev
- **Docker MCP Docs:** https://codepathfinder.dev/docs/mcp/docker-mcp
- **Tools Reference:** https://codepathfinder.dev/docs/mcp/tools-reference
- **GitHub:** https://github.com/shivasurya/code-pathfinder
- **License:** Apache-2.0
- **MCP Registry:** https://registry.modelcontextprotocol.io/?q=pathfinder

### 12 MCP Tools

| Tool | Description |
|------|-------------|
| `get_index_info` | Codebase statistics — symbols, modules, call edges, files |
| `find_symbol` | Search functions, classes, methods by name/type/module |
| `find_module` | Search Python modules by name |
| `list_modules` | List all Python modules in the project |
| `get_callers` | Reverse call graph — who calls this function? |
| `get_callees` | Forward call graph — what does this function call? |
| `get_call_details` | Detailed call site info between two functions |
| `resolve_import` | Resolve Python import paths to file locations |
| `find_dockerfile_instructions` | Search Dockerfile instructions with semantic filters |
| `find_compose_services` | Search docker-compose services with config filters |
| `get_dockerfile_details` | Full Dockerfile breakdown with multi-stage analysis |
| `get_docker_dependencies` | Dependency graph for compose services and Dockerfile stages |

### Configuration

- **Volume mount:** User's project directory mounted at `/project`
- **Network:** `allowHosts` for `assets.codepathfinder.dev` (type registry CDN) and `us.i.posthog.com` (anonymous analytics)
- **Custom Dockerfile:** `Dockerfile.mcp` (separate from main `Dockerfile` used for scan/CI)
- **No secrets required**
- **Non-root container** (runs as `pathfinder` user, pinned Debian base with digest)

## Validation

```
$ task validate -- --name code-pathfinder
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid
```

```
$ task build -- --tools code-pathfinder
12 tools found.
✅ Image built as mcp/code-pathfinder
```

## Testing

Tested end-to-end with [label-studio](https://github.com/HumanSignal/label-studio) — a real-world Django project with 1,678 functions, 263 modules, 13 Dockerfiles, and 10 docker-compose services.

**How to reproduce:**

```bash
# 1. Build the image from the pinned commit
task build -- --tools code-pathfinder

# 2. Clone a test project
git clone https://github.com/HumanSignal/label-studio.git /tmp/label-studio

# 3. Send JSON-RPC over stdio
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
  | docker run -i --rm -v /tmp/label-studio:/project mcp/code-pathfinder:latest
```

**Server logs (stderr):**

```
Starting MCP server...
MCP server ready (indexing in background)...
Building index in background...
Client: docker-mcp-test 1.0
[initialize] completed (600.567µs)
Loaded stdlib manifest from CDN: 211 modules available
Loaded third-party manifest: 208 packages available
Index built in 21.35s — 1,678 functions, 1,634 call edges, 263 modules
Indexing complete - server ready!
Tool call: find_symbol — completed (216ms)
Tool call: find_dockerfile_instructions — completed (405ms)
```

**JSON-RPC response (stdout):**

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "protocolVersion": "2024-11-05",
    "serverInfo": {
      "name": "dev.codepathfinder/pathfinder",
      "version": "2.0.1"
    },
    "capabilities": {"tools": {}}
  }
}
```

**find_symbol(type=class_definition, limit=5)** — found 638 classes:

```
label_studio.data_export.serializers.ExportCreateSerializer (line 222)
label_studio.io_storages.s3.models.S3ImportStorage (line 269)
label_studio.organizations.serializers.OrganizationMemberListSerializer (line 69)
label_studio.jwt_auth.models.JWTSettings (line 14)
```

**find_dockerfile_instructions(type=FROM)** — found 13 FROM instructions across 6 Dockerfiles:

```
Dockerfile.cloudrun:1  → FROM heartexlabs/label-studio:latest
Dockerfile:19          → FROM node:${NODE_VERSION}-alpine AS frontend-builder
Dockerfile:128         → FROM python:${PYTHON_VERSION}-alpine AS production
Dockerfile.development:26 → FROM python:${PYTHON_VERSION}-slim AS venv-builder
```

## Basic Requirements

- [x] **Open Source**: Apache-2.0 license
- [x] **MCP Compliant**: Implements MCP protocol (JSON-RPC 2.0 over stdio)
- [x] **Active Development**: 626+ merged PRs, regular releases
- [x] **Docker Artifact**: `Dockerfile.mcp` at repo root
- [x] **Documentation**: https://codepathfinder.dev/docs/mcp/docker-mcp
- [x] **Security Contact**: GitHub security advisories enabled

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I have tested the MCP Server using `task validate -- --name code-pathfinder` (all 11 checks passed)
- [x] I have built the MCP Server using `task build -- --tools code-pathfinder` (12 tools found)
- [x] No credentials required — server analyzes local mounted project directory