### PR TITLE
Add Jitbit Helpdesk MCP server

### DIFF
--- a/servers/jitbit-helpdesk/server.yaml
+++ b/servers/jitbit-helpdesk/server.yaml
@@ -1,0 +1,35 @@
+name: jitbit-helpdesk
+image: mcp/jitbit-helpdesk
+type: server
+meta:
+  category: productivity
+  tags:
+    - helpdesk
+    - customer-support
+    - tickets
+    - jitbit
+about:
+  title: Jitbit Helpdesk
+  description: Search and read support tickets from Jitbit Helpdesk. Works with both SaaS and on-premise installations. Three read-only tools for searching, listing, and viewing tickets with full conversation threads.
+  icon: https://www.jitbit.com/uploads/icon.png
+source:
+  project: https://github.com/jitbit/jitbit-helpdesk-mcp
+  branch: master
+  commit: 63f26bc8feccca273a020edf99206907b559107c
+config:
+  description: Jitbit Helpdesk connection settings
+  secrets:
+    - name: jitbit.token
+      env: JITBIT_TOKEN
+      example: your-jwt-api-token
+  env:
+    - name: JITBIT_URL
+      example: https://yourcompany.jitbit.com
+      value: "{{jitbit.url}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+    required:
+      - url


### PR DESCRIPTION
## Summary

Adds [Jitbit Helpdesk](https://www.jitbit.com/helpdesk/) MCP server to the catalog.

- **npm**: `jitbit-helpdesk-mcp`
- **GitHub**: https://github.com/jitbit/jitbit-helpdesk-mcp
- **License**: MIT

Three read-only tools for AI assistants to search, list, and view support tickets with full conversation threads. Works with both SaaS and on-premise Jitbit installations.