### PR TITLE
Add operant-mcp security testing server

### DIFF
--- a/servers/operant-mcp/server.yaml
+++ b/servers/operant-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: operant-mcp
+image: mcp/operant-mcp
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - pentesting
+    - penetration-testing
+    - vulnerability-assessment
+    - forensics
+about:
+  title: Operant MCP
+  description: Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
+  icon: https://www.google.com/s2/favicons?domain=operantlabs.com&sz=64
+source:
+  project: https://github.com/operantlabs/operant-mcp
+  commit: 448fa631788b39314c86ab4495e7115ba988377b

--- a/servers/operant-mcp/tools.json
+++ b/servers/operant-mcp/tools.json
@@ -1,0 +1,383 @@
+[
+  {
+    "name": "sqli_where_bypass",
+    "description": "Test OR-based WHERE clause bypass SQL injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "sqli_login_bypass",
+    "description": "Test login form SQL injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Login form URL"},
+      {"name": "username_field", "type": "string", "desc": "Username field name"},
+      {"name": "password_field", "type": "string", "desc": "Password field name"}
+    ]
+  },
+  {
+    "name": "sqli_union_extract",
+    "description": "UNION-based data extraction SQL injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Vulnerable parameter"}
+    ]
+  },
+  {
+    "name": "sqli_blind_boolean",
+    "description": "Boolean-based blind SQL injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Vulnerable parameter"}
+    ]
+  },
+  {
+    "name": "sqli_blind_time",
+    "description": "Time-based blind SQL injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Vulnerable parameter"}
+    ]
+  },
+  {
+    "name": "sqli_file_read",
+    "description": "Read files via LOAD_FILE() SQL injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "file_path", "type": "string", "desc": "File path to read"}
+    ]
+  },
+  {
+    "name": "xss_reflected_test",
+    "description": "Test reflected XSS with 10 payloads",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "xss_payload_generate",
+    "description": "Generate context-aware XSS payloads",
+    "arguments": [
+      {"name": "context", "type": "string", "desc": "Injection context (html, attr, js, url)"}
+    ]
+  },
+  {
+    "name": "cmdi_test",
+    "description": "Test OS command injection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "cmdi_blind_detect",
+    "description": "Blind command injection via sleep timing",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "path_traversal_test",
+    "description": "Test directory traversal with encoding variants",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "ssrf_test",
+    "description": "Test SSRF with localhost bypass variants",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "ssrf_cloud_metadata",
+    "description": "Test cloud metadata access via SSRF",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "pcap_overview",
+    "description": "Protocol hierarchy and endpoint stats from PCAP file",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "pcap_extract_credentials",
+    "description": "Extract FTP/HTTP/SMTP credentials from PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "pcap_dns_analysis",
+    "description": "DNS query analysis from PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "pcap_http_objects",
+    "description": "Export HTTP objects from PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "pcap_detect_scan",
+    "description": "Detect port scanning activity in PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "pcap_follow_stream",
+    "description": "Follow TCP/UDP streams in PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"},
+      {"name": "stream_index", "type": "number", "desc": "Stream index to follow"}
+    ]
+  },
+  {
+    "name": "pcap_tls_analysis",
+    "description": "TLS/SNI analysis from PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "pcap_llmnr_ntlm",
+    "description": "Detect LLMNR/NTLM attacks in PCAP",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to PCAP file"}
+    ]
+  },
+  {
+    "name": "recon_quick",
+    "description": "Quick recon (robots.txt, headers, common dirs)",
+    "arguments": [
+      {"name": "target", "type": "string", "desc": "Target URL or domain"}
+    ]
+  },
+  {
+    "name": "recon_dns",
+    "description": "Full DNS enumeration",
+    "arguments": [
+      {"name": "domain", "type": "string", "desc": "Target domain"}
+    ]
+  },
+  {
+    "name": "recon_vhost",
+    "description": "Virtual host discovery",
+    "arguments": [
+      {"name": "target", "type": "string", "desc": "Target IP or domain"},
+      {"name": "wordlist", "type": "string", "desc": "Wordlist for brute-force"}
+    ]
+  },
+  {
+    "name": "recon_tls_sans",
+    "description": "Extract SANs from TLS certificates",
+    "arguments": [
+      {"name": "host", "type": "string", "desc": "Target hostname"},
+      {"name": "port", "type": "number", "desc": "Target port (default 443)"}
+    ]
+  },
+  {
+    "name": "recon_directory_bruteforce",
+    "description": "Directory brute-force on web server",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "wordlist", "type": "string", "desc": "Wordlist path"}
+    ]
+  },
+  {
+    "name": "recon_git_secrets",
+    "description": "Search git repos for secrets",
+    "arguments": [
+      {"name": "repo_path", "type": "string", "desc": "Path to git repository"}
+    ]
+  },
+  {
+    "name": "recon_s3_bucket",
+    "description": "Test S3 bucket permissions",
+    "arguments": [
+      {"name": "bucket_name", "type": "string", "desc": "S3 bucket name"}
+    ]
+  },
+  {
+    "name": "volatility_linux",
+    "description": "Linux memory analysis using Volatility 2",
+    "arguments": [
+      {"name": "image_path", "type": "string", "desc": "Path to memory image"},
+      {"name": "profile", "type": "string", "desc": "Volatility profile"}
+    ]
+  },
+  {
+    "name": "volatility_windows",
+    "description": "Windows memory analysis using Volatility 3",
+    "arguments": [
+      {"name": "image_path", "type": "string", "desc": "Path to memory image"}
+    ]
+  },
+  {
+    "name": "memory_detect_rootkit",
+    "description": "Linux rootkit detection in memory image",
+    "arguments": [
+      {"name": "image_path", "type": "string", "desc": "Path to memory image"}
+    ]
+  },
+  {
+    "name": "maldoc_analyze",
+    "description": "Full OLE document analysis pipeline",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to document file"}
+    ]
+  },
+  {
+    "name": "maldoc_extract_macros",
+    "description": "Extract VBA macros from Office documents",
+    "arguments": [
+      {"name": "file_path", "type": "string", "desc": "Path to document file"}
+    ]
+  },
+  {
+    "name": "cloudtrail_analyze",
+    "description": "CloudTrail log analysis",
+    "arguments": [
+      {"name": "log_path", "type": "string", "desc": "Path to CloudTrail log file"}
+    ]
+  },
+  {
+    "name": "cloudtrail_find_anomalies",
+    "description": "Detect anomalous CloudTrail events",
+    "arguments": [
+      {"name": "log_path", "type": "string", "desc": "Path to CloudTrail log file"}
+    ]
+  },
+  {
+    "name": "auth_csrf_extract",
+    "description": "Extract CSRF tokens from web pages",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  },
+  {
+    "name": "auth_bruteforce",
+    "description": "Username enumeration and credential brute-force",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Login URL"},
+      {"name": "usernames", "type": "string", "desc": "Usernames to test (comma-separated)"},
+      {"name": "passwords", "type": "string", "desc": "Passwords to test (comma-separated)"}
+    ]
+  },
+  {
+    "name": "auth_cookie_tamper",
+    "description": "Test cookie tampering vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "cookie", "type": "string", "desc": "Cookie to tamper"}
+    ]
+  },
+  {
+    "name": "cors_test",
+    "description": "Test CORS misconfigurations",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  },
+  {
+    "name": "clickjacking_test",
+    "description": "Test for clickjacking vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  },
+  {
+    "name": "frame_buster_bypass",
+    "description": "Test frame buster bypass techniques",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  },
+  {
+    "name": "idor_test",
+    "description": "Test for Insecure Direct Object Reference vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter with object reference"}
+    ]
+  },
+  {
+    "name": "role_escalation_test",
+    "description": "Test for privilege escalation vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  },
+  {
+    "name": "graphql_introspect",
+    "description": "GraphQL schema introspection",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "GraphQL endpoint URL"}
+    ]
+  },
+  {
+    "name": "graphql_find_hidden",
+    "description": "Find hidden GraphQL fields and mutations",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "GraphQL endpoint URL"}
+    ]
+  },
+  {
+    "name": "nosqli_detect",
+    "description": "Detect NoSQL injection vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "nosqli_auth_bypass",
+    "description": "Test NoSQL authentication bypass",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Login URL"}
+    ]
+  },
+  {
+    "name": "deserialization_test",
+    "description": "Test for insecure deserialization vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"},
+      {"name": "parameter", "type": "string", "desc": "Parameter to test"}
+    ]
+  },
+  {
+    "name": "file_upload_test",
+    "description": "Test file upload security controls",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "File upload URL"}
+    ]
+  },
+  {
+    "name": "price_manipulation_test",
+    "description": "Test for price manipulation vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  },
+  {
+    "name": "coupon_abuse_test",
+    "description": "Test for coupon and discount abuse vulnerabilities",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "Target URL"}
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** operant-mcp
**Repository URL:** https://github.com/operantlabs/operant-mcp
**Brief Description:** Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile added to repo
- [x] **Documentation**: README with setup instructions at https://github.com/operantlabs/operant-mcp
- [x] **Security Contact**: GitHub issues on the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## About operant-mcp

operant-mcp provides 51 security testing tools across these categories:
- SQL Injection (6 tools)
- XSS (2 tools)
- Command Injection (2 tools)
- Path Traversal (1 tool)
- SSRF (2 tools)
- PCAP/Network Forensics (8 tools)
- Reconnaissance (7 tools)
- Memory Forensics (3 tools)
- Malware Analysis (2 tools)
- Cloud Security (2 tools)
- Authentication (3 tools)
- Clickjacking & CORS (3 tools)
- IDOR & Privilege Escalation (2 tools)
- GraphQL Security (2 tools)
- NoSQL Injection (2 tools)
- Deserialization & File Upload (2 tools)
- Business Logic (2 tools)

Available on npm: https://www.npmjs.com/package/operant-mcp