### PR TITLE
Add Strale (remote MCP server)

### DIFF
--- a/servers/strale/readme.md
+++ b/servers/strale/readme.md
@@ -1,0 +1,32 @@
+Strale is trust and quality infrastructure for AI agents. 250+ verified data capabilities — IBAN validation, company registry lookups across 27 countries, sanctions and PEP screening, web scraping, lead enrichment, Web3 risk analysis — each continuously tested and assigned a dual-profile quality score. Every execution returns structured JSON with data provenance and an audit trail.
+
+## What you can do
+
+- **Validate financial identifiers** — IBAN, VAT, SWIFT/BIC, LEI, EORI
+- **Look up companies** — registry data from 27 countries (SE, NO, DK, FI, UK, DE, FR, NL, US, AU, and more)
+- **Screen for compliance risk** — sanctions lists, PEP databases, adverse media, beneficial ownership
+- **Extract structured data** — invoices, PDFs, web pages, metadata
+- **Assess domain reputation** — WHOIS, DNS, SSL, security headers, tech stack
+- **Web3 intelligence** — wallet risk scoring, token safety, DeFi protocol data, ENS resolution
+
+## Authentication
+
+1. Sign up at [strale.dev/signup](https://strale.dev/signup) — free €2.00 trial credits, no card required
+2. Set your API key as `STRALE_API_KEY`
+
+## Free tier
+
+These tools work without an API key:
+
+- `strale_search` — browse all 250+ capabilities
+- `strale_getting_started` — see free capabilities with examples
+- `strale_trust_profile` — check quality scores
+- `strale_execute` with free slugs: `email-validate`, `iban-validate`, `dns-lookup`, `url-to-markdown`, `json-repair`
+
+## Quick start
+
+1. Call `strale_search` with query "IBAN" to find validation capabilities
+2. Call `strale_execute` with slug `iban-validate` and inputs `{"iban": "DE89370400440532013000"}`
+3. Call `strale_trust_profile` with slug `iban-validate` to check the quality score
+
+Docs: [strale.dev/docs](https://strale.dev/docs)

--- a/servers/strale/readme.md
+++ b/servers/strale/readme.md
@@ -1,4 +1,4 @@
-Strale is trust and quality infrastructure for AI agents. 250+ verified data capabilities — IBAN validation, company registry lookups across 27 countries, sanctions and PEP screening, web scraping, lead enrichment, Web3 risk analysis — each continuously tested and assigned a dual-profile quality score. Every execution returns structured JSON with data provenance and an audit trail.
+Strale exposes a catalog of data capabilities for AI agents — IBAN/VAT/LEI validation, company registry lookups across 27 countries, sanctions and PEP screening, web extraction, document parsing, and Web3 wallet/token intelligence. Every execution returns structured JSON with provenance.
 
 ## What you can do
 
@@ -18,7 +18,7 @@ Strale is trust and quality infrastructure for AI agents. 250+ verified data cap
 
 These tools work without an API key:
 
-- `strale_search` — browse all 250+ capabilities
+- `strale_search` — browse the full capability catalog
 - `strale_getting_started` — see free capabilities with examples
 - `strale_trust_profile` — check quality scores
 - `strale_execute` with free slugs: `email-validate`, `iban-validate`, `dns-lookup`, `url-to-markdown`, `json-repair`

--- a/servers/strale/server.yaml
+++ b/servers/strale/server.yaml
@@ -1,0 +1,34 @@
+name: strale
+type: remote
+meta:
+  category: data-analytics
+  tags:
+    - compliance
+    - validation
+    - company-data
+    - web3
+    - remote
+about:
+  title: Strale
+  description: >-
+    Trust and quality infrastructure for AI agents. 250+ quality-scored
+    capabilities for IBAN validation, company registry lookups across 27
+    countries, sanctions and PEP screening, web scraping, lead enrichment,
+    and Web3 risk analysis — each with dual-profile quality scores and full
+    audit trails. Free tier available for email validation, IBAN validation,
+    DNS lookup, URL-to-markdown, and JSON repair — no API key needed.
+  icon: https://strale.dev/strale.jpg
+remote:
+  transport_type: streamable-http
+  url: https://api.strale.io/mcp
+  headers:
+    Authorization: "Bearer ${STRALE_API_KEY}"
+config:
+  description: >-
+    Get a free API key at https://strale.dev/signup (includes €2.00 trial
+    credits). Some tools (strale_search, strale_getting_started,
+    strale_trust_profile) work without a key.
+  secrets:
+    - name: strale.api_key
+      env: STRALE_API_KEY
+      example: <STRALE_API_KEY>

--- a/servers/strale/server.yaml
+++ b/servers/strale/server.yaml
@@ -11,12 +11,11 @@ meta:
 about:
   title: Strale
   description: >-
-    Trust and quality infrastructure for AI agents. 250+ quality-scored
-    capabilities for IBAN validation, company registry lookups across 27
-    countries, sanctions and PEP screening, web scraping, lead enrichment,
-    and Web3 risk analysis — each with dual-profile quality scores and full
-    audit trails. Free tier available for email validation, IBAN validation,
-    DNS lookup, URL-to-markdown, and JSON repair — no API key needed.
+    Catalog of data capabilities for AI agents: IBAN/VAT/LEI validation,
+    company registry lookups across 27 countries, sanctions and PEP
+    screening, web extraction, document parsing, and Web3 wallet/token
+    intelligence. Free tier covers email-validate, iban-validate,
+    dns-lookup, url-to-markdown, and json-repair without an API key.
   icon: https://strale.dev/strale.jpg
 remote:
   transport_type: streamable-http

--- a/servers/strale/tools.json
+++ b/servers/strale/tools.json
@@ -1,0 +1,91 @@
+[
+  {
+    "name": "strale_ping",
+    "description": "Health check. Returns server status, tool count, capability count, and response time."
+  },
+  {
+    "name": "strale_getting_started",
+    "description": "Returns 5 free capabilities you can use immediately without an API key (email-validate, dns-lookup, json-repair, url-to-markdown, iban-validate) plus setup steps for full access."
+  },
+  {
+    "name": "strale_search",
+    "description": "Search 250+ capabilities and bundled solutions by keyword or category. Covers compliance, validation, company registries, domain intelligence, Web3, and more. Free — no API key needed.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Search keyword (e.g., 'sanctions', 'IBAN', 'company data', 'web3')"
+      },
+      {
+        "name": "category",
+        "type": "string",
+        "desc": "Filter by category: compliance, validation, data-extraction, developer-tools, web3, security",
+        "optional": true
+      },
+      {
+        "name": "offset",
+        "type": "number",
+        "desc": "Number of results to skip for pagination",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "strale_execute",
+    "description": "Run any of 250+ capabilities by slug. Validate IBANs, look up companies in 27 countries, screen against sanctions lists, extract data from URLs, check VAT numbers, assess wallet risk, and more. Returns structured JSON with quality score and data provenance. Free capabilities work without an API key.",
+    "arguments": [
+      {
+        "name": "slug",
+        "type": "string",
+        "desc": "Capability slug from strale_search results (e.g., 'iban-validate', 'swedish-company-data')"
+      },
+      {
+        "name": "inputs",
+        "type": "object",
+        "desc": "Input parameters matching the capability's required fields"
+      },
+      {
+        "name": "max_price_cents",
+        "type": "number",
+        "desc": "Maximum price in EUR cents. Default: 200 (€2.00). Execution fails if capability costs more.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "strale_balance",
+    "description": "Check current wallet balance in EUR. Requires an API key."
+  },
+  {
+    "name": "strale_methodology",
+    "description": "Get Strale's quality and trust methodology. Explains the dual-profile scoring model (Quality Profile + Reliability Profile), the SQS matrix, execution guidance, test infrastructure, and current limitations."
+  },
+  {
+    "name": "strale_trust_profile",
+    "description": "Check if a capability is reliable before calling it. Returns SQS quality score (0-100), Quality grade, Reliability grade, execution guidance, 30-day test history, known limitations, and cost envelope.",
+    "arguments": [
+      {
+        "name": "slug",
+        "type": "string",
+        "desc": "Capability or solution slug (e.g., 'iban-validate', 'kyb-essentials-se')"
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Whether this is a 'capability' or a 'solution'. Default: 'capability'.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "strale_transaction",
+    "description": "Retrieve a past execution record by transaction ID. Returns inputs, outputs, latency, price, data provenance, and success/failure status. Free-tier transactions are accessible without an API key.",
+    "arguments": [
+      {
+        "name": "transaction_id",
+        "type": "string",
+        "desc": "Transaction ID returned from a strale_execute call"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds Strale as a remote MCP server (Streamable HTTP).

- **Type:** Remote (externally hosted)
- **Transport:** streamable-http
- **URL:** https://api.strale.io/mcp
- **Auth:** Bearer token (API key)

Strale exposes a catalog of data capabilities for AI agents — IBAN/VAT/LEI validation, company registry lookups across 27 countries, sanctions and PEP screening, web extraction, document parsing, and Web3 wallet/token intelligence. Every execution returns structured JSON with provenance.

Free tier: five capabilities work without an API key (`email-validate`, `iban-validate`, `dns-lookup`, `url-to-markdown`, `json-repair`).

Three files added under `servers/strale/`: `server.yaml`, `tools.json`, `readme.md`.