### PR TITLE
Add Gildara MCP server

### DIFF
--- a/servers/gildara/server.yaml
+++ b/servers/gildara/server.yaml
@@ -1,0 +1,23 @@
+name: gildara
+image: mcp/gildara
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - developer-tools
+    - ai-agents
+    - prompts
+about:
+  title: Gildara
+  description: Connect your AI tools to your Gildara prompt vault. List, resolve, run, and create structured prompts with operating contracts, auto-repair, and variable substitution.
+  icon: https://www.google.com/s2/favicons?domain=gildara.io&sz=64
+source:
+  project: https://github.com/gildara-io/mcp-server
+  branch: main
+  commit: fcdf8448eaf490562d80b579a5725e84fb461fea
+config:
+  description: Configure the connection to your Gildara prompt vault
+  secrets:
+    - name: gildara.api_key
+      env: GILDARA_API_KEY
+      example: pvk_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4

--- a/servers/gildara/server.yaml
+++ b/servers/gildara/server.yaml
@@ -9,15 +9,9 @@ meta:
     - prompts
 about:
   title: Gildara
-  description: Connect your AI tools to your Gildara prompt vault. List, resolve, run, and create structured prompts with operating contracts, auto-repair, and variable substitution.
+  description: Operating contracts for AI agents. Store, search, resolve, and share structured prompts across Claude, Cursor, Windsurf, and other MCP clients.
   icon: https://www.google.com/s2/favicons?domain=gildara.io&sz=64
 source:
   project: https://github.com/gildara-io/mcp-server
   branch: main
-  commit: fcdf8448eaf490562d80b579a5725e84fb461fea
-config:
-  description: Configure the connection to your Gildara prompt vault
-  secrets:
-    - name: gildara.api_key
-      env: GILDARA_API_KEY
-      example: pvk_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+  commit: e9987c42f146248253b876145fb575b9a0347c57


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Gildara
**Repository URL:** https://github.com/gildara-io/mcp-server
**Brief Description:** Operating contracts for AI agents, with a zero-configuration stdio MCP server for storing, searching, resolving, and sharing structured prompts.

## Basic Requirements

- [x] **Open Source:** MIT license
- [x] **MCP Compliant:** Published as @gildara/mcp-server 0.8.0 and listed in the Official MCP Registry
- [x] **Active Development:** Canonical repository updated July 2026
- [x] **Docker Artifact:** Dockerfile present
- [x] **Documentation:** README includes stdio setup and tool reference
- [x] **Security Contact:** GitHub issue tracker

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] go run ./cmd/validate --name gildara passes locally
- [ ] Docker build validation is delegated to this repository's CI because Docker is unavailable on the submitter workstation
- [x] No credentials are required: version 0.8.0 auto-provisions a free agent account when GILDARA_API_KEY is unset

This update refreshes the pinned canonical source commit to the published 0.8.0 mirror and removes the obsolete required API-key configuration.