### PR TITLE
Add git executable resolution utility for cross-platform support

### DIFF
--- a/cmd/ci/helpers.go
+++ b/cmd/ci/helpers.go
@@ -32,6 +32,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/docker/mcp-registry/internal/gitutil"
 	"github.com/docker/mcp-registry/pkg/servers"
 )
 
@@ -132,7 +133,11 @@ func gitDiff(workspace, base, head, mode string) ([]string, error) {
 
 // runGitCommand executes git with the given arguments inside the directory.
 func runGitCommand(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+	gitPath, err := gitutil.Executable()
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command(gitPath, args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/security-reviewer/main.go
+++ b/cmd/security-reviewer/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/mcp-registry/internal/gitutil"
 	"github.com/spf13/cobra"
 )
 
@@ -28,8 +29,6 @@ const (
 	repositoryDirName = "repository"
 	// dockerExecutable identifies the docker CLI binary invoked by the tool.
 	dockerExecutable = "docker"
-	// gitExecutable identifies the git CLI binary used to manage repositories.
-	gitExecutable = "git"
 	// projectPrefix is applied to compose project names to make them unique yet readable.
 	projectPrefix = "security-reviewer"
 	// agentService is the compose service name running the security reviewer container.
@@ -272,6 +271,11 @@ func sanitizeName(text string) string {
 
 // prepareRepository clones the repository and materializes commits for review.
 func prepareRepository(ctx context.Context, opts options, repositoryDir string) error {
+	gitPath, err := gitutil.Executable()
+	if err != nil {
+		return err
+	}
+
 	parentDir := filepath.Dir(repositoryDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		return fmt.Errorf("create repository parent directory: %w", err)
@@ -280,19 +284,19 @@ func prepareRepository(ctx context.Context, opts options, repositoryDir string) 
 		return fmt.Errorf("reset repository directory: %w", err)
 	}
 
-	if err := runCommand(ctx, "", gitExecutable, "clone", opts.Repository, repositoryDir); err != nil {
+	if err := runCommand(ctx, "", gitPath, "clone", opts.Repository, repositoryDir); err != nil {
 		return fmt.Errorf("clone repository: %w", err)
 	}
 
-	if err := ensureCommit(ctx, repositoryDir, opts.HeadSHA); err != nil {
+	if err := ensureCommit(ctx, gitPath, repositoryDir, opts.HeadSHA); err != nil {
 		return err
 	}
-	if err := runCommand(ctx, repositoryDir, gitExecutable, "checkout", "--detach", opts.HeadSHA); err != nil {
+	if err := runCommand(ctx, repositoryDir, gitPath, "checkout", "--detach", opts.HeadSHA); err != nil {
 		return fmt.Errorf("checkout head commit: %w", err)
 	}
 
 	if opts.BaseSHA != "" {
-		if err := ensureCommit(ctx, repositoryDir, opts.BaseSHA); err != nil {
+		if err := ensureCommit(ctx, gitPath, repositoryDir, opts.BaseSHA); err != nil {
 			return err
 		}
 	}
@@ -301,17 +305,17 @@ func prepareRepository(ctx context.Context, opts options, repositoryDir string) 
 }
 
 // ensureCommit verifies that a commit exists locally, fetching if needed.
-func ensureCommit(ctx context.Context, repoDir, sha string) error {
+func ensureCommit(ctx context.Context, gitPath, repoDir, sha string) error {
 	if sha == "" {
 		return nil
 	}
-	if err := runCommand(ctx, repoDir, gitExecutable, "rev-parse", "--verify", sha); err == nil {
+	if err := runCommand(ctx, repoDir, gitPath, "rev-parse", "--verify", sha); err == nil {
 		return nil
 	}
-	if err := runCommand(ctx, repoDir, gitExecutable, "fetch", "origin", sha); err != nil {
+	if err := runCommand(ctx, repoDir, gitPath, "fetch", "origin", sha); err != nil {
 		return fmt.Errorf("fetch commit %s: %w", sha, err)
 	}
-	if err := runCommand(ctx, repoDir, gitExecutable, "rev-parse", "--verify", sha); err != nil {
+	if err := runCommand(ctx, repoDir, gitPath, "rev-parse", "--verify", sha); err != nil {
 		return fmt.Errorf("verify commit %s: %w", sha, err)
 	}
 	return nil

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -1,0 +1,92 @@
+/*
+Copyright © 2025 Docker, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package gitutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+var (
+	resolvedGit     string
+	resolvedGitOnce sync.Once
+	resolvedGitErr  error
+)
+
+// Executable returns the path to the git binary. On Windows it probes common
+// Git for Windows install locations and honours the CLAUDE_CODE_GIT_BASH_PATH
+// environment variable when git is not directly available in PATH.
+// The result is cached after the first successful lookup.
+func Executable() (string, error) {
+	resolvedGitOnce.Do(func() {
+		resolvedGit, resolvedGitErr = findGit()
+	})
+	return resolvedGit, resolvedGitErr
+}
+
+func findGit() (string, error) {
+	if p, err := exec.LookPath("git"); err == nil {
+		return p, nil
+	}
+
+	if runtime.GOOS != "windows" {
+		return "", fmt.Errorf("git executable not found in PATH")
+	}
+
+	// On Windows, git may be installed but not on PATH. Try common locations.
+	var candidates []string
+
+	// Derive git.exe from CLAUDE_CODE_GIT_BASH_PATH when available.
+	// The variable typically points to bash.exe inside a Git for Windows
+	// installation (e.g. C:\Program Files\Git\bin\bash.exe). Walk up to
+	// the installation root and check for cmd\git.exe.
+	if bashPath := os.Getenv("CLAUDE_CODE_GIT_BASH_PATH"); bashPath != "" {
+		dir := filepath.Dir(bashPath)
+		for dir != filepath.Dir(dir) {
+			candidates = append(candidates, filepath.Join(dir, "cmd", "git.exe"))
+			dir = filepath.Dir(dir)
+		}
+	}
+
+	for _, env := range []string{"ProgramFiles", "ProgramFiles(x86)", "LocalAppData"} {
+		if base := os.Getenv(env); base != "" {
+			candidates = append(candidates, filepath.Join(base, "Git", "cmd", "git.exe"))
+		}
+	}
+
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"git is required but was not found in PATH or common install locations; " +
+			"install Git for Windows (https://git-scm.com/download/win) or set " +
+			"CLAUDE_CODE_GIT_BASH_PATH to the bash.exe in your Git for Windows installation",
+	)
+}


### PR DESCRIPTION
## Description

This PR introduces a new `gitutil` package that provides cross-platform git executable resolution, with special handling for Windows environments. The utility is then integrated into the security-reviewer and CI helper tools to use this centralized resolution logic.

## Changes

### New Package: `internal/gitutil`
- Added `Executable()` function that returns the path to the git binary
- Implements intelligent git discovery:
  - First attempts standard `PATH` lookup via `exec.LookPath`
  - On Windows, probes common Git for Windows installation locations
  - Honors `CLAUDE_CODE_GIT_BASH_PATH` environment variable to derive git.exe location from bash.exe
  - Checks standard Windows installation directories: `ProgramFiles`, `ProgramFiles(x86)`, and `LocalAppData`
- Caches the result after first successful lookup using `sync.Once`
- Provides helpful error messages with installation guidance

### Updated: `cmd/security-reviewer/main.go`
- Replaced hardcoded `gitExecutable = "git"` constant with dynamic resolution via `gitutil.Executable()`
- Updated `prepareRepository()` to obtain git path and pass it to git operations
- Updated `ensureCommit()` signature to accept git path parameter
- All git command invocations now use the resolved path

### Updated: `cmd/ci/helpers.go`
- Updated `runGitCommand()` to use `gitutil.Executable()` instead of hardcoded "git"

## Motivation

This change improves cross-platform compatibility, particularly for Windows users who may have Git installed in non-standard locations or not in their PATH. The centralized utility prevents code duplication and provides consistent git discovery behavior across the codebase.

## Test Plan

Existing functionality is preserved - the changes are backward compatible. The git executable resolution will be tested through existing integration tests that exercise the security-reviewer and CI helper commands.

https://claude.ai/code/session_01UWmvbebmx8ZmXDUXNfs5EM