### PR TITLE
Add Engram Memory

### DIFF
--- a/servers/engram-memory/readme.md
+++ b/servers/engram-memory/readme.md
@@ -1,0 +1,53 @@
+# Engram Memory
+
+Persistent memory for AI agents. Engram gives any MCP client a brain that survives across sessions: it stores facts, preferences, decisions, and corrections, then retrieves them semantically when relevant.
+
+## What it does
+
+Engram exposes six tools to MCP clients:
+
+- `memory_store` — store a memory with semantic embedding
+- `memory_search` — three-tier recall (hot cache → hash index → vector search)
+- `memory_recall` — context injection for system prompts
+- `memory_forget` — remove a memory from all tiers
+- `memory_consolidate` — merge near-duplicates
+- `memory_connect` — discover cross-category connections
+
+## Architecture
+
+A single container bundles three components, supervised by s6-overlay:
+
+1. **Qdrant** — vector database (port 6333)
+2. **FastEmbed** — ONNX-based embedding service, native ARM64 + x86_64 (port 11435)
+3. **MCP HTTP server** — three-tier recall engine exposing memory tools (port 8585)
+
+The recall engine implements:
+
+- **Tier 1**: Hot-tier cache with ACT-R cognitive activation (sub-millisecond)
+- **Tier 2**: Multi-head LSH hash index for O(1) candidate retrieval
+- **Tier 3**: Hybrid Qdrant search (dense vectors + BM25 sparse with RRF fusion)
+- **Graph layer**: Kuzu-backed entity tracking with spreading activation
+- **Consolidation**: Janitor (deduplication) and Librarian (cross-category linking)
+
+Memories persist in `/data` (mount a volume).
+
+## Performance
+
+On Apple Silicon (M-series, ARM64) with 100 memories:
+
+| Metric               | Cold      | Warm   |
+| -------------------- | --------- | ------ |
+| Search latency       | ~190 ms   | ~24 ms |
+| Store latency        | ~42 ms    | —      |
+| Embedding throughput | 60+ emb/s | —      |
+| Top-3 accuracy       | 97%       | —      |
+
+The cold path runs the full three-tier pipeline (hash candidates → hybrid search → graph expansion). The warm path returns from the hot tier in roughly the time it takes to embed the query.
+
+## Source
+
+[github.com/EngramMemory/engram-memory-community](https://github.com/EngramMemory/engram-memory-community)
+
+## License
+
+MIT

--- a/servers/engram-memory/server.yaml
+++ b/servers/engram-memory/server.yaml
@@ -1,0 +1,39 @@
+name: engram-memory
+image: engrammemory/engram-memory
+type: server
+meta:
+  category: ai
+  tags:
+    - memory
+    - ai
+    - knowledge-graph
+    - vector-search
+    - embeddings
+about:
+  title: Engram Memory
+  description: Persistent memory for AI agents with three-tier recall (hot cache, hash index, vector search). Single container bundles vector database, ONNX embeddings, and the MCP server. Includes ACT-R cognitive cache, multi-head LSH, BM25 hybrid search, and a Kuzu graph layer for entity tracking.
+  icon: https://raw.githubusercontent.com/EngramMemory/engram-memory-community/main/assets/logo.svg
+source:
+  project: https://github.com/EngramMemory/engram-memory-community
+  commit: df71cdb28205e50f26d8e9d785d1dbdce9170bf9
+  dockerfile: docker/all-in-one/Dockerfile
+config:
+  description: Engram Memory bundles Qdrant, FastEmbed, and the MCP server in a single container. Mount a volume at /data to persist memories across restarts.
+  env:
+    - name: COLLECTION_NAME
+      example: agent-memory
+      value: "{{engram-memory.collection_name}}"
+    - name: MODEL_NAME
+      example: nomic-ai/nomic-embed-text-v1.5
+      value: "{{engram-memory.model_name}}"
+  parameters:
+    type: object
+    properties:
+      collection_name:
+        type: string
+        default: agent-memory
+        description: Qdrant collection name for storing memories
+      model_name:
+        type: string
+        default: nomic-ai/nomic-embed-text-v1.5
+        description: FastEmbed model identifier

--- a/servers/engram-memory/server.yaml
+++ b/servers/engram-memory/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://raw.githubusercontent.com/EngramMemory/engram-memory-community/main/assets/logo.svg
 source:
   project: https://github.com/EngramMemory/engram-memory-community
-  commit: df71cdb28205e50f26d8e9d785d1dbdce9170bf9
+  commit: b344f4aa0aa0115556b7caa85679d08ca7eed1f9
   dockerfile: docker/all-in-one/Dockerfile
 config:
   description: Engram Memory bundles Qdrant, FastEmbed, and the MCP server in a single container. Mount a volume at /data to persist memories across restarts.

--- a/servers/engram-memory/tools.json
+++ b/servers/engram-memory/tools.json
@@ -1,0 +1,125 @@
+[
+  {
+    "name": "memory_store",
+    "description": "Store a memory with semantic embedding (indexed into hot-tier cache and hash index)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Text content to store"
+        },
+        "category": {
+          "type": "string",
+          "enum": ["preference", "fact", "decision", "entity", "other"],
+          "default": "other",
+          "description": "Memory category"
+        },
+        "importance": {
+          "type": "number",
+          "default": 0.5,
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Importance score (0-1)"
+        }
+      },
+      "required": ["text"]
+    }
+  },
+  {
+    "name": "memory_search",
+    "description": "Search memories using three-tier recall: hot cache (sub-ms), hash index (O(1)), and vector search",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Natural language search query"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 10,
+          "description": "Max results"
+        },
+        "category": {
+          "type": "string",
+          "enum": ["preference", "fact", "decision", "entity", "other"],
+          "description": "Filter by category"
+        }
+      },
+      "required": ["query"]
+    }
+  },
+  {
+    "name": "memory_recall",
+    "description": "Recall relevant memories for context injection (higher threshold, designed for auto-recall)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "Context to recall memories for"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 5,
+          "description": "Max memories to recall"
+        }
+      },
+      "required": ["context"]
+    }
+  },
+  {
+    "name": "memory_forget",
+    "description": "Delete a memory from all tiers (hot cache, hash index, and vector store)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "memory_id": {
+          "type": "string",
+          "description": "UUID of memory to delete"
+        },
+        "query": {
+          "type": "string",
+          "description": "Search query to find and delete the best match"
+        }
+      }
+    }
+  },
+  {
+    "name": "memory_consolidate",
+    "description": "Find and merge near-duplicate memories (Community: fixed 0.95 threshold)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "type": "number",
+          "default": 0.95,
+          "description": "Similarity threshold for deduplication"
+        }
+      }
+    }
+  },
+  {
+    "name": "memory_connect",
+    "description": "Discover cross-category connections for a memory (Community: max 3 per call)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "memory_id": {
+          "type": "string",
+          "description": "UUID of memory to connect"
+        },
+        "query": {
+          "type": "string",
+          "description": "Search to find the memory first"
+        },
+        "max_connections": {
+          "type": "integer",
+          "default": 3,
+          "description": "Max connections to discover"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Adds [Engram Memory](https://github.com/EngramMemory/engram-memory-community) — a persistent memory system for AI agents with a three-tier recall engine (hot cache → hash index → vector search), bundled as a single container.

## What it does

Engram exposes 6 MCP tools for memory operations:

- `memory_store` — store text with semantic embedding
- `memory_search` — three-tier recall search
- `memory_recall` — context injection for system prompts
- `memory_forget` — delete from all tiers
- `memory_consolidate` — merge near-duplicate memories
- `memory_connect` — discover cross-category connections

## Architecture

A single container bundles three services supervised by s6-overlay, with all state persisted to a `/data` volume:

1. **Qdrant** — vector database (port 6333)
2. **FastEmbed 0.7.4** — ONNX-based embedding service, native ARM64 + x86_64 (port 11435)
3. **MCP HTTP server** — three-tier recall engine (port 8585)

The recall engine implements:
- **Tier 1**: Hot-tier cache with ACT-R cognitive activation (sub-millisecond)
- **Tier 2**: Multi-head LSH hash index for O(1) candidate retrieval
- **Tier 3**: Hybrid Qdrant search (dense vectors + BM25 sparse with RRF fusion)
- **Graph layer**: Kuzu-backed entity tracking with spreading activation
- **Consolidation**: Janitor (deduplication) and Librarian (cross-category linking)

## Verification

- Image is published at `engrammemory/engram-memory:latest` (also tagged `:v1.0.0` and `:df71cdb`)
- Built and tested on Apple Silicon (linux/arm64) and linux/amd64
- Single `docker run -d -p 6333:6333 -p 11435:11435 -p 8585:8585 -v engram_data:/data engrammemory/engram-memory:latest` is sufficient to start
- All 6 MCP tools verified responding via the bundled HTTP server
- Performance on 100-memory corpus: ~190ms cold search, ~24ms warm, 97% top-3 accuracy

## License

MIT