### PR TITLE
Add Redmine MCP server

### DIFF
--- a/servers/redmine/readme.md
+++ b/servers/redmine/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/Shaqal7/claude-redmine-mcp#readme

--- a/servers/redmine/server.yaml
+++ b/servers/redmine/server.yaml
@@ -1,0 +1,40 @@
+name: redmine
+image: mcp/redmine
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - project-management
+    - issue-tracking
+    - redmine
+about:
+  title: Redmine
+  description: Issue-focused Redmine integration over MCP. List, search, and inspect issues with normalized context. Add notes, update statuses, and reassign issues with validation. Scoped to allowed projects only.
+  icon: https://www.google.com/s2/favicons?domain=redmine.org&sz=64
+source:
+  project: https://github.com/Shaqal7/claude-redmine-mcp
+  branch: main
+  commit: 4ec2ddd6955fbb37373730279831573383a075a3
+config:
+  description: Configure the connection to your Redmine instance
+  secrets:
+    - name: redmine.api_key
+      env: REDMINE_API_KEY
+      example: your-redmine-api-key
+  env:
+    - name: REDMINE_BASE_URL
+      example: https://redmine.example.com
+      value: "{{redmine.url}}"
+    - name: REDMINE_ALLOWED_PROJECTS
+      example: project1,project2
+      value: "{{redmine.projects}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        description: Full base URL of your Redmine instance, including subpath if any
+      projects:
+        type: string
+        description: Comma-separated project identifiers (slugs) or numeric IDs

--- a/servers/redmine/tools.json
+++ b/servers/redmine/tools.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "list_issues",
+    "description": "List issues for one allowed Redmine project with optional filtering by status, assignee, and sort order."
+  },
+  {
+    "name": "search_issues",
+    "description": "Full-text search across issue subjects and descriptions in allowed projects."
+  },
+  {
+    "name": "get_issue",
+    "description": "Fetch normalized detail for a single issue including journals, relations, custom fields, and allowed statuses."
+  },
+  {
+    "name": "add_issue_note",
+    "description": "Append a note or comment to an existing issue."
+  },
+  {
+    "name": "update_issue_status",
+    "description": "Change issue status with validation against allowed transitions."
+  },
+  {
+    "name": "assign_issue",
+    "description": "Reassign an issue to a project member with fuzzy name matching."
+  }
+]


### PR DESCRIPTION
## Summary

- Adds a new **Redmine** MCP server to the registry
- Issue-focused integration: list, search, get issues, add notes, update statuses, reassign — all with validation
- Scoped to allowed projects only (configurable via `REDMINE_ALLOWED_PROJECTS`)
- Returns normalized issue context instead of raw Redmine payloads
- MIT licensed, Dockerfile included in source repo

## Server details

| Field | Value |
|-------|-------|
| Source | https://github.com/Shaqal7/claude-redmine-mcp |
| License | MIT |
| Transport | stdio |
| Category | productivity |
| Tools | `list_issues`, `search_issues`, `get_issue`, `add_issue_note`, `update_issue_status`, `assign_issue` |

## Configuration

- **Secret:** `REDMINE_API_KEY` — Redmine personal API key
- **Env:** `REDMINE_BASE_URL` — full Redmine instance URL
- **Env:** `REDMINE_ALLOWED_PROJECTS` — comma-separated project identifiers

## Test plan

- [x] Docker image builds successfully (`docker build -t redmine-mcp .`)
- [x] Server starts and exposes 6 tools over stdio
- [ ] CI checks pass