### PR TITLE
Add global-chat MCP server

### DIFF
--- a/servers/global-chat/server.yaml
+++ b/servers/global-chat/server.yaml
@@ -1,0 +1,36 @@
+name: global-chat
+image: mcp/global-chat
+type: server
+meta:
+  category: productivity
+  tags:
+    - ai-agents
+    - agent-discovery
+    - mcp
+    - a2a
+    - agents-txt
+    - x402
+    - directory
+    - search
+about:
+  title: Global Chat
+  description: Cross-protocol AI agent discovery. Search 18K+ MCP servers and A2A agents across 6+ registries, validate agents.txt files, and browse the agent marketplace from one MCP server.
+  icon: https://avatars.githubusercontent.com/u/20568599?v=4
+source:
+  project: https://github.com/pumanitro/global-chat
+  branch: master
+  commit: 65f4742fee8ce810bc3275b85d8fe68cc5278cd3
+  directory: mcp-server
+config:
+  description: Configure the Global Chat MCP Server
+  env:
+    - name: GLOBAL_CHAT_BASE_URL
+      example: https://global-chat.io
+      value: "{{global-chat.base_url}}"
+  parameters:
+    type: object
+    properties:
+      base_url:
+        type: string
+        description: Base URL for the Global Chat API. Defaults to https://global-chat.io.
+        default: https://global-chat.io

--- a/servers/global-chat/tools.json
+++ b/servers/global-chat/tools.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "validate_agents_txt",
+    "description": "Validate agents.txt for agent discovery — checks an agents.txt file (by URL or raw content) against the agents.txt spec used for MCP and A2A agent discovery.",
+    "arguments": [
+      {"name": "url", "type": "string", "desc": "URL of an agents.txt file to fetch and validate"},
+      {"name": "content", "type": "string", "desc": "Raw agents.txt content to validate inline"}
+    ]
+  },
+  {
+    "name": "list_agents",
+    "description": "List agents in the global-chat agent directory — browse all AI agents registered on global-chat.io, with optional type filter (defi, social, data, infra, trading, governance).",
+    "arguments": [
+      {"name": "type", "type": "string", "desc": "Optional agent type filter"}
+    ]
+  },
+  {
+    "name": "search_agents",
+    "description": "Search agents in the global-chat agent directory — find AI agents by name, description, or capability across the agent marketplace.",
+    "arguments": [
+      {"name": "query", "type": "string", "desc": "Free-text search query"}
+    ]
+  },
+  {
+    "name": "list_a2a_agents",
+    "description": "List A2A agents (Agent-to-Agent protocol) from the global-chat A2A directory — returns every crawled Agent Card with capabilities, skills, and provider info.",
+    "arguments": []
+  },
+  {
+    "name": "search_a2a_agents",
+    "description": "Search A2A agents (Agent-to-Agent protocol) by name, provider, description, or domain — cross-protocol agent-card discovery via /.well-known/agent.json.",
+    "arguments": [
+      {"name": "query", "type": "string", "desc": "Free-text search query"}
+    ]
+  },
+  {
+    "name": "get_a2a_agent_details",
+    "description": "Get A2A agent details by slug — fetches the full Agent Card profile (capabilities, skills, provider, source domain) for a specific A2A agent.",
+    "arguments": [
+      {"name": "slug", "type": "string", "desc": "Agent slug identifier"}
+    ]
+  },
+  {
+    "name": "register_agent",
+    "description": "Register an AI agent in the global-chat agent directory — adds a new agent to the agent marketplace for discovery by other autonomous agents and x402 counterparties.",
+    "arguments": [
+      {"name": "name", "type": "string", "desc": "Agent name"},
+      {"name": "description", "type": "string", "desc": "Agent description"},
+      {"name": "url", "type": "string", "desc": "Agent base URL"}
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Adds **global-chat** — a cross-protocol AI agent discovery MCP server — to the Docker MCP Registry.

Global Chat aggregates agents across MCP, A2A, and agents.txt protocols into a single discovery layer. From this MCP server an agent (or user) can search 18K+ MCP servers across 6+ registries, validate agents.txt files, browse the A2A agent directory, inspect Agent Cards, and register new agents — without leaving their MCP client.

- Repository: https://github.com/pumanitro/global-chat
- Homepage: https://global-chat.io
- Source subdirectory: `mcp-server/` (Dockerfile lives there)
- License: MIT
- Category: productivity

## Tools exposed

1. `search_agents` — full-text search across the global-chat agent directory
2. `list_agents` — list agents with optional type filter (defi, social, data, infra, trading, governance)
3. `validate_agents_txt` — validate an agents.txt file by URL or raw content
4. `list_a2a_agents` — list all crawled A2A Agent Cards
5. `search_a2a_agents` — search A2A agents by name / provider / domain
6. `get_a2a_agent_details` — fetch a single A2A Agent Card by slug
7. `register_agent` — register a new agent in the global-chat marketplace

A `tools.json` file is included next to `server.yaml` so `task build -- --tools global-chat` can enumerate tools without actually starting the server.

## Checklist

- [x] MIT-licensed (permissive, Docker-compatible)
- [x] Dockerfile at `mcp-server/Dockerfile` — multi-stage Node 22 alpine build, non-root `mcp` user, healthcheck, OCI labels
- [x] `server.yaml` follows the schema used by existing entries (e.g. apify-mcp-server, astra-db)
- [x] `source.directory: mcp-server` points the build context at the subfolder
- [x] `source.commit` pinned to a specific commit SHA
- [x] `tools.json` included to avoid common CI build failures
- [x] No secrets required to run; single optional env var `GLOBAL_CHAT_BASE_URL` defaults to `https://global-chat.io`

Happy to iterate on category, description length, or icon selection if anything needs to change.