### PR TITLE
Add HemmaBo Federation MCP Server

### DIFF
--- a/servers/hemmabo-federation/server.yaml
+++ b/servers/hemmabo-federation/server.yaml
@@ -1,0 +1,32 @@
+name: hemmabo-federation
+image: ghcr.io/hemmabo-se/hemmabo-mcp-server:latest
+type: server
+meta:
+  category: travel
+  tags:
+    - travel
+    - vacation-rental
+    - booking
+    - property-management
+    - pricing
+about:
+  title: HemmaBo Federation MCP Server
+  description: >
+    AI-native vacation rental infrastructure for independent hosts. Search
+    properties, check real-time availability, get canonical pricing quotes
+    (public, federation, and gap-night rates), and create direct bookings.
+    Supports seasonal pricing, guest-count staircase tiers, weekly/biweekly
+    package discounts, and host-controlled federation discounts. Each property
+    is its own node — all data is live from the source of truth.
+  icon: https://hemmabo-mcp-server.vercel.app/icon.png
+source:
+  project: https://github.com/HemmaBo-se/hemmabo-mcp-server
+config:
+  description: Configure the connection to HemmaBo's property database
+  secrets:
+    - name: hemmabo-federation.supabase_url
+      env: SUPABASE_URL
+      example: https://your-project.supabase.co
+    - name: hemmabo-federation.supabase_service_role_key
+      env: SUPABASE_SERVICE_ROLE_KEY
+      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...

--- a/servers/hemmabo-federation/tools.json
+++ b/servers/hemmabo-federation/tools.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "search_properties",
+    "description": "Search vacation rental properties by location and travel dates. Returns only available properties with live pricing (public + federation rates).",
+    "arguments": [
+      { "name": "region", "type": "string", "desc": "Region or destination (e.g. 'Skåne', 'Toscana')" },
+      { "name": "country", "type": "string", "desc": "Country (e.g. 'Sweden')" },
+      { "name": "guests", "type": "integer", "desc": "Number of guests" },
+      { "name": "checkIn", "type": "string", "desc": "Check-in date (YYYY-MM-DD)" },
+      { "name": "checkOut", "type": "string", "desc": "Check-out date (YYYY-MM-DD)" }
+    ]
+  },
+  {
+    "name": "check_availability",
+    "description": "Check whether a property is available for the requested date range. Verifies blocked dates, bookings, and active locks.",
+    "arguments": [
+      { "name": "propertyId", "type": "string", "desc": "Property UUID" },
+      { "name": "checkIn", "type": "string", "desc": "Check-in date (YYYY-MM-DD)" },
+      { "name": "checkOut", "type": "string", "desc": "Check-out date (YYYY-MM-DD)" }
+    ]
+  },
+  {
+    "name": "get_canonical_quote",
+    "description": "Get detailed pricing: publicTotal, federationTotal, gapTotal. Per-night breakdown, season info, package pricing. All integers in local currency.",
+    "arguments": [
+      { "name": "propertyId", "type": "string", "desc": "Property UUID" },
+      { "name": "checkIn", "type": "string", "desc": "Check-in date (YYYY-MM-DD)" },
+      { "name": "checkOut", "type": "string", "desc": "Check-out date (YYYY-MM-DD)" },
+      { "name": "guests", "type": "integer", "desc": "Number of guests" }
+    ]
+  },
+  {
+    "name": "create_booking",
+    "description": "Create a direct booking. Validates availability, calculates federation price, and creates a pending booking record requiring host approval.",
+    "arguments": [
+      { "name": "propertyId", "type": "string", "desc": "Property UUID" },
+      { "name": "checkIn", "type": "string", "desc": "Check-in date (YYYY-MM-DD)" },
+      { "name": "checkOut", "type": "string", "desc": "Check-out date (YYYY-MM-DD)" },
+      { "name": "guests", "type": "integer", "desc": "Number of guests" },
+      { "name": "guestName", "type": "string", "desc": "Guest full name" },
+      { "name": "guestEmail", "type": "string", "desc": "Guest email" },
+      { "name": "guestPhone", "type": "string", "desc": "Guest phone (optional)" }
+    ]
+  }
+]


### PR DESCRIPTION
AI-native vacation rental infrastructure for independent hosts. Search properties, check availability, get pricing quotes, and create direct bookings via MCP. Supports seasonal pricing, guest-count staircase tiers, and host-controlled federation discounts.

License: MIT
Source: https://github.com/HemmaBo-se/hemmabo-mcp-server

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: ""
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [ ] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [ ] **MCP Compliant**: Implements MCP API specification
- [ ] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: Dockerfile
- [ ] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [ ] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
