### PR TITLE
Add Katana Manufacturing ERP MCP server

### DIFF
--- a/servers/katana-erp/server.yaml
+++ b/servers/katana-erp/server.yaml
@@ -1,0 +1,36 @@
+name: katana-erp
+image: mcp/katana-erp
+type: server
+
+meta:
+  category: productivity
+  tags:
+    - manufacturing
+    - erp
+    - inventory
+    - production
+    - orders
+
+about:
+  title: Katana Manufacturing ERP
+  description: >-
+    MCP server for Katana Manufacturing ERP — manage inventory, production,
+    purchase orders, sales orders, and manufacturing through AI assistants.
+    Features two-step confirmation for safe operations, automatic retries,
+    and 28 tools covering the full manufacturing workflow.
+  icon: https://www.google.com/s2/favicons?domain=katanamrp.com&sz=64
+
+source:
+  project: https://github.com/dougborg/katana-openapi-client
+  commit: 39e7c4e47c67772b10edb60c6d9ea8128444fa7a
+  directory: katana_mcp_server
+
+config:
+  description: |
+    Configure the Katana MCP server with your API credentials.
+    Get your API key from Katana: Settings → Integrations → API.
+  secrets:
+    - name: katana-erp.api_key
+      env: KATANA_API_KEY
+      example: your-api-key-here
+      description: Katana API key from account settings

--- a/servers/katana-erp/server.yaml
+++ b/servers/katana-erp/server.yaml
@@ -17,12 +17,13 @@ about:
     MCP server for Katana Manufacturing ERP — manage inventory, production,
     purchase orders, sales orders, and manufacturing through AI assistants.
     Features two-step confirmation for safe operations, automatic retries,
-    and 28 tools covering the full manufacturing workflow.
+    and 54 tools covering the full manufacturing workflow.
   icon: https://www.google.com/s2/favicons?domain=katanamrp.com&sz=64
 
 source:
   project: https://github.com/dougborg/katana-openapi-client
-  commit: 39e7c4e47c67772b10edb60c6d9ea8128444fa7a
+  branch: main
+  commit: 3a41c776e8bf60f53f85e2026aa1fcb5b28eb9ba
   directory: katana_mcp_server
 
 config:
@@ -34,3 +35,4 @@ config:
       env: KATANA_API_KEY
       example: your-api-key-here
       description: Katana API key from account settings
+      required: true

--- a/servers/katana-erp/tools.json
+++ b/servers/katana-erp/tools.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "add_manufacturing_order_recipe_row",
+    "description": "Add a new ingredient row to a manufacturing order's recipe."
+  },
+  {
+    "name": "batch_update_manufacturing_order_recipes",
+    "description": "Batch update recipe rows across one or more manufacturing orders."
+  },
+  {
+    "name": "check_inventory",
+    "description": "Check current stock levels for one or more SKUs or variant IDs."
+  },
+  {
+    "name": "create_item",
+    "description": "Create any item type (product, material, or service) in the Katana catalog."
+  },
+  {
+    "name": "create_manufacturing_order",
+    "description": "Create a manufacturing order to produce items."
+  },
+  {
+    "name": "create_material",
+    "description": "Create a raw material or component in the Katana catalog."
+  },
+  {
+    "name": "create_product",
+    "description": "Create a finished good product in the Katana catalog."
+  },
+  {
+    "name": "create_purchase_order",
+    "description": "Create a purchase order to buy items from a supplier."
+  },
+  {
+    "name": "create_sales_order",
+    "description": "Create a sales order for a customer purchase."
+  },
+  {
+    "name": "create_stock_adjustment",
+    "description": "Create a stock adjustment to correct inventory levels."
+  },
+  {
+    "name": "delete_item",
+    "description": "Permanently delete an item (product, material, or service) from Katana."
+  },
+  {
+    "name": "delete_manufacturing_order_recipe_row",
+    "description": "Delete an ingredient row from a manufacturing order's recipe."
+  },
+  {
+    "name": "fulfill_order",
+    "description": "Complete a manufacturing order (mark DONE) or fulfill a sales order (ship items)."
+  },
+  {
+    "name": "get_customer",
+    "description": "Get full details for a specific customer by ID."
+  },
+  {
+    "name": "get_inventory_movements",
+    "description": "Get inventory movement history for a SKU \u2014 shows every stock change with dates,"
+  },
+  {
+    "name": "get_item",
+    "description": "Get item details by ID and type (product, material, or service)."
+  },
+  {
+    "name": "get_manufacturing_order",
+    "description": "Look up manufacturing orders by order number or ID."
+  },
+  {
+    "name": "get_manufacturing_order_recipe",
+    "description": "List the ingredient (recipe) rows for a manufacturing order."
+  },
+  {
+    "name": "get_purchase_order",
+    "description": "Look up a purchase order by order number or ID."
+  },
+  {
+    "name": "get_sales_order",
+    "description": "Look up a sales order by number or ID with all line items."
+  },
+  {
+    "name": "get_variant_details",
+    "description": "Get comprehensive variant details by SKU(s) or variant ID(s)."
+  },
+  {
+    "name": "list_low_stock_items",
+    "description": "List items with stock levels below a threshold \u2014 useful for reorder planning."
+  },
+  {
+    "name": "list_sales_orders",
+    "description": "List sales orders with filters."
+  },
+  {
+    "name": "receive_purchase_order",
+    "description": "Receive delivered items from a purchase order and update inventory."
+  },
+  {
+    "name": "search_customers",
+    "description": "Search for customers by name or email."
+  },
+  {
+    "name": "search_items",
+    "description": "Search for items (products, materials, services) by name or SKU."
+  },
+  {
+    "name": "update_item",
+    "description": "Update an existing item's properties (product, material, or service)."
+  },
+  {
+    "name": "verify_order_document",
+    "description": "Verify a supplier document (invoice, packing slip) against a purchase order."
+  }
+]

--- a/servers/katana-erp/tools.json
+++ b/servers/katana-erp/tools.json
@@ -1,15 +1,19 @@
 [
   {
-    "name": "add_manufacturing_order_recipe_row",
-    "description": "Add a new ingredient row to a manufacturing order's recipe."
-  },
-  {
-    "name": "batch_update_manufacturing_order_recipes",
-    "description": "Batch update recipe rows across one or more manufacturing orders."
-  },
-  {
     "name": "check_inventory",
     "description": "Check current stock levels for one or more SKUs or variant IDs."
+  },
+  {
+    "name": "correct_manufacturing_order",
+    "description": "Edit a closed MO without losing its original close-state."
+  },
+  {
+    "name": "correct_purchase_order",
+    "description": "Edit a closed (RECEIVED / PARTIALLY_RECEIVED) PO without losing the original receipt metadata."
+  },
+  {
+    "name": "correct_sales_order",
+    "description": "Edit a closed (DELIVERED) SO without losing its picked_date and fulfillment metadata."
   },
   {
     "name": "create_item",
@@ -40,12 +44,32 @@
     "description": "Create a stock adjustment to correct inventory levels."
   },
   {
+    "name": "create_stock_transfer",
+    "description": "Create a stock transfer moving inventory between two locations."
+  },
+  {
     "name": "delete_item",
     "description": "Permanently delete an item (product, material, or service) from Katana."
   },
   {
-    "name": "delete_manufacturing_order_recipe_row",
-    "description": "Delete an ingredient row from a manufacturing order's recipe."
+    "name": "delete_manufacturing_order",
+    "description": "Delete a manufacturing order."
+  },
+  {
+    "name": "delete_purchase_order",
+    "description": "Delete a purchase order."
+  },
+  {
+    "name": "delete_sales_order",
+    "description": "Delete a sales order."
+  },
+  {
+    "name": "delete_stock_adjustment",
+    "description": "Delete a stock adjustment by ID."
+  },
+  {
+    "name": "delete_stock_transfer",
+    "description": "Delete a stock transfer."
   },
   {
     "name": "fulfill_order",
@@ -57,15 +81,15 @@
   },
   {
     "name": "get_inventory_movements",
-    "description": "Get inventory movement history for a SKU \u2014 shows every stock change with dates,"
+    "description": "Get inventory movement history for a SKU \u2014 every stock change with dates, quantities, valuation (value_per_unit, value_in_stock_after, average_cost_after), and what caused each movement (sales, purchases, manufacturing, adjustments)."
   },
   {
     "name": "get_item",
-    "description": "Get item details by ID and type (product, material, or service)."
+    "description": "Get exhaustive item details by ID and type (product, material, or service)."
   },
   {
     "name": "get_manufacturing_order",
-    "description": "Look up manufacturing orders by order number or ID."
+    "description": "Look up a manufacturing order by number or ID, compact-by-default."
   },
   {
     "name": "get_manufacturing_order_recipe",
@@ -73,27 +97,103 @@
   },
   {
     "name": "get_purchase_order",
-    "description": "Look up a purchase order by order number or ID."
+    "description": "Look up a purchase order by order number or ID \u2014 exhaustive detail."
   },
   {
     "name": "get_sales_order",
     "description": "Look up a sales order by number or ID with all line items."
   },
   {
+    "name": "get_supplier",
+    "description": "Get full details for a specific supplier by ID."
+  },
+  {
     "name": "get_variant_details",
     "description": "Get comprehensive variant details by SKU(s) or variant ID(s)."
+  },
+  {
+    "name": "inventory_velocity",
+    "description": "Velocity stats for one or more SKUs: units sold/consumed, avg-daily, days of cover."
+  },
+  {
+    "name": "list_additional_costs",
+    "description": "List or search the additional-cost catalog (freight, duties, handling fees, etc.)."
+  },
+  {
+    "name": "list_blocking_ingredients",
+    "description": "Roll up blocking-ingredient recipe rows across manufacturing orders."
+  },
+  {
+    "name": "list_locations",
+    "description": "List or search warehouses and facilities."
   },
   {
     "name": "list_low_stock_items",
     "description": "List items with stock levels below a threshold \u2014 useful for reorder planning."
   },
   {
+    "name": "list_manufacturing_orders",
+    "description": "List manufacturing orders with filters \u2014 pass `ids=[1,2,3]` to fetch a specific batch by ID (cache-backed)."
+  },
+  {
+    "name": "list_operators",
+    "description": "List or search manufacturing operators."
+  },
+  {
+    "name": "list_purchase_orders",
+    "description": "List purchase orders with filters \u2014 pass `ids=[1,2,3]` to fetch a specific batch by ID (cache-backed)."
+  },
+  {
     "name": "list_sales_orders",
-    "description": "List sales orders with filters."
+    "description": "List sales orders with filters \u2014 pass `ids=[1,2,3]` to fetch a specific batch by ID (cache-backed, indexed SQL)."
+  },
+  {
+    "name": "list_stock_adjustments",
+    "description": "List stock adjustments with filters \u2014 pass `ids=[1,2,3]` to fetch a specific batch by ID (cache-backed)."
+  },
+  {
+    "name": "list_stock_transfers",
+    "description": "List stock transfers with filters \u2014 returns multiple transfers for discovery or bulk review."
+  },
+  {
+    "name": "list_suppliers",
+    "description": "List or search suppliers."
+  },
+  {
+    "name": "list_tax_rates",
+    "description": "List or search configured tax rates."
+  },
+  {
+    "name": "modify_item",
+    "description": "Modify an item \u2014 unified surface across header + variant CRUD."
+  },
+  {
+    "name": "modify_manufacturing_order",
+    "description": "Modify a manufacturing order \u2014 unified surface across header, recipe rows (ingredients), operation rows (production steps), and production records (completion logs)."
+  },
+  {
+    "name": "modify_purchase_order",
+    "description": "Modify a purchase order \u2014 unified surface across header, rows, and additional costs."
+  },
+  {
+    "name": "modify_sales_order",
+    "description": "Modify a sales order \u2014 unified surface across header, rows, addresses, fulfillments, and shipping fees."
+  },
+  {
+    "name": "modify_stock_transfer",
+    "description": "Modify a stock transfer \u2014 unified surface across header body fields and status transition."
+  },
+  {
+    "name": "rebuild_cache",
+    "description": "Force-rebuild the local typed cache for one or more transactional entity types."
   },
   {
     "name": "receive_purchase_order",
     "description": "Receive delivered items from a purchase order and update inventory."
+  },
+  {
+    "name": "sales_summary",
+    "description": "Group DELIVERED sales in a window by time or dimension \u2014 returns one row per group."
   },
   {
     "name": "search_customers",
@@ -101,11 +201,15 @@
   },
   {
     "name": "search_items",
-    "description": "Search for items (products, materials, services) by name or SKU."
+    "description": "Search for items (products, materials, services) by name or SKU \u2014 returns multiple matching items."
   },
   {
-    "name": "update_item",
-    "description": "Update an existing item's properties (product, material, or service)."
+    "name": "top_selling_variants",
+    "description": "Top-selling product variants over a date window \u2014 returns multiple ranked rows."
+  },
+  {
+    "name": "update_stock_adjustment",
+    "description": "Update an existing stock adjustment's header fields."
   },
   {
     "name": "verify_order_document",


### PR DESCRIPTION
## MCP Server Information

**Server Name:** katana-erp
**Repository URL:** https://github.com/dougborg/katana-openapi-client
**Brief Description:** MCP server for Katana Manufacturing ERP — manage inventory, production, purchase orders, sales orders, and manufacturing through AI assistants.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification (via FastMCP)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile at `katana_mcp_server/Dockerfile`
- [x] **Documentation**: README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name katana-erp`
- [ ] I have built the MCP Server using `task build -- --tools katana-erp`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Details

- **28 tools** covering inventory, catalog, orders, manufacturing, and document verification
- **Two-step confirmation** pattern for all create/modify/delete operations (preview then execute)
- **Monorepo**: Dockerfile is in `katana_mcp_server/` subdirectory (using `source.directory`)
- **Transport**: Supports stdio (default CLI) and streamable-http (Docker default on port 8765)
- **Auth**: Requires `KATANA_API_KEY` environment variable
- **License**: MIT