### PR TITLE
feat: add ALTER Identity remote MCP server

### DIFF
--- a/servers/alter-identity/readme.md
+++ b/servers/alter-identity/readme.md
@@ -1,0 +1,29 @@
+## ALTER Identity MCP Server
+
+Identity infrastructure for the AI economy — the science of being known.
+
+ALTER delivers verified human identity to any MCP client via a 33-trait psychometric engine. It provides belonging probability, full trait vectors, attunement depth scores, and privacy-gated inference — built on psychometric science (BRAVING Trust Inventory, Bayesian adaptive assessment).
+
+### What it does
+
+- **Psychometric assessment** — 33 traits across 5 categories, Bayesian adaptive delivery
+- **Belonging probability** — composite fit score: `0.40 × authenticity + 0.35 × acceptance + 0.25 × complementarity`
+- **Trait vectors** — full 33-dimension identity field, privacy-gated by consent tier
+- **Attunement depth** — measures how well an agent knows a person over time (replaces streaks)
+- **Identity verification** — verify ~handle ownership via DNS TXT + MCP discovery
+
+### Tools (free tier — 16 tools)
+
+`get_profile`, `get_trait_snapshot`, `get_full_trait_vector`, `compute_belonging`, `assess_traits`, `verify_identity`, `get_identity_trust_score`, `get_engagement_level`, `get_match_recommendations`, `list_archetypes`, `get_competencies`, `search_identities`, `query_matches`, `get_side_quest_graph`, `get_privacy_budget`, `recommend_tool`
+
+### Access
+
+- **Free tier:** 16 tools · 10 req/min · 100 req/day — no API key required
+- **Premium:** x402 micropayment-gated tools and higher rate limits
+- **API key:** set `ALTER_API_KEY` for authenticated premium access
+
+### Docs
+
+- Source / SDK: https://github.com/true-alter/alter-identity
+- MCP namespace: `com.truealter/identity` v0.3.1
+- DNS discovery: `_alter.truealter.com` TXT

--- a/servers/alter-identity/server.yaml
+++ b/servers/alter-identity/server.yaml
@@ -1,0 +1,22 @@
+name: alter-identity
+type: remote
+meta:
+  category: security
+  tags:
+    - identity
+    - psychometrics
+    - assessment
+    - remote
+about:
+  title: ALTER Identity
+  description: Identity infrastructure for the AI economy. 33-trait psychometric engine delivering verified human identity via MCP — belonging probability, trait vectors, attunement depth, and privacy-gated inference.
+  icon: https://truealter.com/favicon.ico
+remote:
+  transport_type: streamable-http
+  url: https://mcp.truealter.com/api/v1/mcp
+config:
+  secrets:
+    - name: alter.api_key
+      env: ALTER_API_KEY
+      example: <YOUR_API_KEY>
+      description: Optional API key for premium tier. Free tier (16 tools, 10 req/min, 100 req/day) works without authentication.


### PR DESCRIPTION
## Summary

ALTER Identity is a **remote streamable-HTTP MCP server** providing psychometric identity infrastructure for the AI economy.

### Server details

| Field | Value |
|---|---|
| Name | `alter-identity` |
| Type | remote |
| Transport | `streamable-http` |
| URL | `https://mcp.truealter.com/api/v1/mcp` |
| Category | security (identity management) |
| License | Apache-2.0 |
| Source | https://github.com/true-alter/alter-identity |

### What it does

- **33-trait psychometric assessment** — Bayesian adaptive delivery across 5 trait categories
- **Belonging probability** — composite fit score for human-role matching
- **Trait vectors** — full 33-dimension identity field, privacy-gated by consent tier
- **Attunement depth** — measures how well an agent knows a person over time
- **Identity verification** — verify ~handle ownership via DNS TXT + MCP discovery

### Access model

- **Free tier:** 16 tools · 10 req/min · 100 req/day — no API key required (works without `ALTER_API_KEY`)
- **Premium:** x402 micropayment-gated tools and higher rate limits
- Optional: set `ALTER_API_KEY` for premium authenticated access

### Registry status

- Official MCP Registry: `com.truealter/identity` v0.3.1 (DNS-verified, `_alter.truealter.com` TXT)
- Smithery: listed as `blake/alter-identity`
- npm: `@truealter/sdk` v0.2.2

### Testing

The free tier requires no credentials — Docker MCP Toolkit can connect directly to `https://mcp.truealter.com/api/v1/mcp` and list tools without any API key.