### PR TITLE
update pin for clickhouse

### DIFF
--- a/servers/clickhouse/server.yaml
+++ b/servers/clickhouse/server.yaml
@@ -12,7 +12,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/54801242?v=4
 source:
   project: https://github.com/ClickHouse/mcp-clickhouse
-  commit: 21e6cb2b0758150e8fd0627b699fbfd78e31837b
+  commit: 3a72467c825da2615b59fefb9d40694d3b517f92
 config:
   description: Configure the connection to ClickHouse
   secrets:


### PR DESCRIPTION
v0.3.0 of mcp-clickhouse has been released on GitHub (notes [here](https://github.com/ClickHouse/mcp-clickhouse/releases/tag/v0.3.0)) and on [PyPI](https://pypi.org/project/mcp-clickhouse/).

Also, I noticed mcp-registry-bot seems to do this work automatically. Would would we need to do to get our GH releases tied to a mcp/clickhouse pin update task automatically?