### PR TITLE
feat: add gitlab-extended MCP server

### DIFF
--- a/servers/gitlab-extended/server.yaml
+++ b/servers/gitlab-extended/server.yaml
@@ -1,0 +1,31 @@
+name: gitlab-extended
+image: mcp/gitlab-extended
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - gitlab
+    - developer-tools
+    - code-review
+about:
+  title: GitLab Extended
+  description: Token-efficient GitLab MCP server with 40 tools covering merge requests, issues, pipelines, repository browsing, and project management — with slimmed responses and diff truncation for lower token usage.
+  icon: https://www.google.com/s2/favicons?domain=gitlab.com&sz=64
+source:
+  project: https://github.com/PuvaanRaaj/gitlab-extended-mcp
+  commit: d70bf85fd5c3c845d91395f59dee4968c57f2532
+config:
+  description: Configure the connection to your GitLab instance
+  secrets:
+    - name: gitlab-extended.gitlab_token
+      env: GITLAB_TOKEN
+      example: glpat-xxxxxxxxxxxxxxxxxxxx
+  env:
+    - name: GITLAB_URL
+      example: https://gitlab.example.com
+      value: "{{gitlab-extended.gitlab_url}}"
+  parameters:
+    type: object
+    properties:
+      gitlab_url:
+        type: string


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gitlab-extended
**Repository URL:** https://github.com/PuvaanRaaj/gitlab-extended-mcp
**Brief Description:** Token-efficient GitLab MCP server with 40 tools covering merge requests, issues, pipelines, repository browsing, and project management. Responses are slimmed to essential fields only, diffs are truncated at 150 lines, and system notes are filtered — resulting in 40–60% fewer tokens compared to naive GitLab API proxies.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification via FastMCP
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile present (python:3.14-slim base)
- [x] **Documentation**: README with tool list, setup options, and token-efficiency comparison
- [x] **Security Contact**: GitHub issues on the repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gitlab-extended`
- [x] I have built the MCP Server using `task build -- --tools gitlab-extended`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)