### PR TITLE
Add TezTun MCP server

### DIFF
--- a/servers/teztun/server.yaml
+++ b/servers/teztun/server.yaml
@@ -1,0 +1,30 @@
+name: teztun
+image: asadullokhn/teztun
+type: server
+meta:
+  category: devops
+  tags:
+    - tunnel
+    - ngrok-alternative
+    - devops
+    - networking
+about:
+  title: TezTun
+  description: "Manage TezTun tunnels, subdomains, and service tokens. TezTun is a self-hosted ngrok alternative that exposes local services through teztun.uz with HTTPS and optional custom domains."
+  icon: https://avatars.githubusercontent.com/u/87550552?s=200&v=4
+source:
+  project: https://github.com/asadullokhn/teztun-mcp
+  commit: e674465193fca7dac9bfa773b2ba87621d8e53fc
+run:
+  command:
+    - mcp
+  allowHosts:
+    - app.teztun.uz:443
+    - teztun.uz:443
+config:
+  description: Configure your TezTun service token
+  secrets:
+    - name: teztun.token
+      env: TEZTUN_TOKEN
+      example: tzt_your-token-here
+      description: A TezTun service token (starts with `tzt_`). Mint one at [app.teztun.uz/tokens](https://app.teztun.uz/tokens).


### PR DESCRIPTION
## MCP Server Information

**Server Name:** teztun
**Repository URL:** https://github.com/asadullokhn/teztun-mcp
**Brief Description:** TezTun is a self-hosted ngrok alternative. This MCP server lets AI clients manage tunnels, subdomains, and service tokens through the TezTun API at app.teztun.uz.

## Basic Requirements

- [x] **Open Source**: MIT (see [LICENSE](https://github.com/asadullokhn/teztun-mcp/blob/main/LICENSE))
- [x] **MCP Compliant**: Implements the MCP stdio transport; already listed on the official MCP Registry as \`io.github.asadullokhn/teztun\`
- [x] **Active Development**: Maintained alongside the TezTun service at teztun.uz
- [x] **Docker Artifact**: Self-built image \`asadullokhn/teztun\` on Docker Hub (296 pulls, multi-arch amd64/arm64)
- [x] **Documentation**: README in launcher repo + https://teztun.uz/docs/mcp-server
- [x] **Security Contact**: support@teztun.uz

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using \`task validate -- --name teztun\` (all 12 checks pass)
- [ ] I have built the MCP Server using \`task build -- --tools teztun\` — skipped per CONTRIBUTING.md: *\"Not needed if providing your own image\"* (self-built path)
- [ ] Test credentials — will share via the form once the PR is acknowledged (tokens are minted per-user at app.teztun.uz/tokens)

## Notes

- Self-built image — signatures/provenance/SBOM come from my own CI (GitHub Actions → Docker Hub).
- Already published to the official MCP Registry at \`registry.modelcontextprotocol.io\` under \`io.github.asadullokhn/teztun\`.
- Run command \`mcp\` overrides the container CMD so \`teztun mcp\` starts the stdio transport.