### PR TITLE
Add MCP Billing Gateway - turnkey billing infrastructure for MCP server operators

### DIFF
--- a/servers/mcp-billing-gateway/readme.md
+++ b/servers/mcp-billing-gateway/readme.md
@@ -1,0 +1,1 @@
+https://github.com/sapph1re/mcp-billing-gateway-sdk

--- a/servers/mcp-billing-gateway/server.yaml
+++ b/servers/mcp-billing-gateway/server.yaml
@@ -1,0 +1,19 @@
+name: mcp-billing-gateway
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: payments
+  tags:
+    - payments
+    - billing
+    - mcp
+    - saas
+    - remote
+about:
+  title: MCP Billing Gateway
+  description: Turnkey billing infrastructure for MCP server operators. Register servers, create pricing plans, track usage, manage Stripe Connect payouts, and verify x402 micropayments — without building your own payment stack.
+  icon: https://www.google.com/s2/favicons?domain=mcp-billing-gateway-production.up.railway.app&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://mcp-billing-gateway-production.up.railway.app/mcp/

--- a/servers/mcp-billing-gateway/server.yaml
+++ b/servers/mcp-billing-gateway/server.yaml
@@ -3,10 +3,10 @@ type: remote
 dynamic:
   tools: true
 meta:
-  category: payments
+  category: developer-tools
   tags:
-    - payments
     - billing
+    - payments
     - mcp
     - saas
     - remote

--- a/servers/mcp-billing-gateway/tools.json
+++ b/servers/mcp-billing-gateway/tools.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "register_operator",
+    "description": "Register a new operator account with Stripe Connect onboarding",
+    "arguments": []
+  },
+  {
+    "name": "get_operator_info",
+    "description": "Get current operator profile and status",
+    "arguments": []
+  },
+  {
+    "name": "list_servers",
+    "description": "List all MCP servers registered by the operator",
+    "arguments": []
+  },
+  {
+    "name": "create_server",
+    "description": "Register a new MCP server for billing",
+    "arguments": []
+  },
+  {
+    "name": "get_server",
+    "description": "Get server details including pricing plans",
+    "arguments": []
+  },
+  {
+    "name": "update_server",
+    "description": "Update server settings",
+    "arguments": []
+  },
+  {
+    "name": "create_plan",
+    "description": "Create a pricing plan for a server",
+    "arguments": []
+  },
+  {
+    "name": "list_plans",
+    "description": "List pricing plans for a server",
+    "arguments": []
+  },
+  {
+    "name": "get_usage",
+    "description": "Get usage analytics for a server (calls, revenue, top callers)",
+    "arguments": []
+  },
+  {
+    "name": "get_revenue",
+    "description": "Get revenue summary and payout history",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## Summary

Adding [MCP Billing Gateway](https://github.com/sapph1re/mcp-billing-gateway-sdk) as a remote MCP server.

**What it does:** Turnkey billing infrastructure for MCP server operators. Register servers, create pricing plans, track usage, manage Stripe Connect payouts, and verify x402 micropayments — without building your own payment stack.

**Server type:** Remote (Streamable HTTP)  
**URL:** https://mcp-billing-gateway-production.up.railway.app/mcp/  
**Auth:** None required at protocol level (operators authenticate via Stripe Connect during registration)

**Tools:**
- `register_operator` — Register a new operator account with Stripe Connect onboarding
- `create_server` — Register a new MCP server for billing
- `create_plan` — Create a pricing plan for a server
- `get_usage` — Get usage analytics (calls, revenue, top callers)
- `get_revenue` — Get revenue summary and payout history
- And more (see tools.json)

**License:** MIT (public SDK repo: https://github.com/sapph1re/mcp-billing-gateway-sdk)

Note: Validation steps (task validate/build) require Go + Task which aren't available in my CI environment; the server.yaml follows the remote/dappier-remote template pattern and should pass automated CI.