### PR TITLE
Add ClawMachine MCP server for WAGMIOS Docker management

### DIFF
--- a/servers/clawmachine/server.yaml
+++ b/servers/clawmachine/server.yaml
@@ -1,0 +1,37 @@
+name: clawmachine
+image: itzmizzle/clawmachine:latest
+type: server
+meta:
+  category: devops
+  tags:
+    - docker
+    - containers
+    - devops
+    - wagmios
+    - homelab
+about:
+  title: ClawMachine
+  description: MCP server for WAGMIOS — manage Docker containers, images, and marketplace apps via natural language. Provides 18 scoped tools for container lifecycle, image management, and marketplace operations through the WAGMIOS REST API.
+  icon: https://avatars.githubusercontent.com/u/212703782?s=200&v=4
+source:
+  project: https://github.com/mentholmike/clawmachine
+  commit: dfd6d3c9a1e0a169c2b30ac4a384f4ca07374338
+config:
+  description: Configure the WAGMIOS API connection
+  secrets:
+    - name: clawmachine.api_key
+      env: WAGMIOS_API_KEY
+      example: <YOUR_WAGMIOS_API_KEY>
+  env:
+    - name: WAGMIOS_API_URL
+      example: http://localhost:5179
+      value: '{{clawmachine.wagmios_api_url}}'
+  parameters:
+    type: object
+    properties:
+      wagmios_api_url:
+        type: string
+        description: URL of your WAGMIOS backend API (e.g. http://localhost:5179)
+        default: http://localhost:5179
+    required:
+      - wagmios_api_url

--- a/servers/clawmachine/tools.json
+++ b/servers/clawmachine/tools.json
@@ -1,0 +1,219 @@
+[
+  {
+    "name": "browse_marketplace",
+    "description": "Browse all available apps in the WAGMIOS marketplace (34+ self-hosted apps)",
+    "arguments": []
+  },
+  {
+    "name": "check_scopes",
+    "description": "Check the current API key's status, label, and granted scopes",
+    "arguments": []
+  },
+  {
+    "name": "container_config",
+    "description": "Get the full configuration of a container (environment, volumes, ports, etc.)",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Container ID or name"
+      }
+    ]
+  },
+  {
+    "name": "container_logs",
+    "description": "Get log output from a container",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Container ID or name"
+      },
+      {
+        "name": "tail",
+        "type": "number",
+        "desc": "Number of lines to return from the end (default 100)"
+      }
+    ]
+  },
+  {
+    "name": "create_container",
+    "description": "Create a new Docker container",
+    "arguments": [
+      {
+        "name": "env",
+        "type": "object",
+        "desc": "Environment variables as key-value pairs"
+      },
+      {
+        "name": "image",
+        "type": "string",
+        "desc": "Docker image (e.g. nginx:alpine)"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Container name"
+      },
+      {
+        "name": "ports",
+        "type": "object",
+        "desc": "Port mappings (array of {private, public, protocol})"
+      },
+      {
+        "name": "volumes",
+        "type": "object",
+        "desc": "Volume mounts (array of {host, container})"
+      }
+    ]
+  },
+  {
+    "name": "delete_container",
+    "description": "Delete a container permanently. This is irreversible — confirm with the user before calling.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Container ID or name to delete"
+      }
+    ]
+  },
+  {
+    "name": "delete_image",
+    "description": "Delete a Docker image. This is irreversible — confirm with the user before calling.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Image ID to delete"
+      }
+    ]
+  },
+  {
+    "name": "get_marketplace_app",
+    "description": "Get details for a specific marketplace app",
+    "arguments": [
+      {
+        "name": "app_id",
+        "type": "string",
+        "desc": "App ID (e.g. jellyfin, nginx, ollama)"
+      }
+    ]
+  },
+  {
+    "name": "install_app",
+    "description": "Download and install a marketplace app (does not start it). Use start_app to start after installing.",
+    "arguments": [
+      {
+        "name": "app_id",
+        "type": "string",
+        "desc": "App ID to install (e.g. jellyfin, nginx, ollama)"
+      },
+      {
+        "name": "container_name",
+        "type": "string",
+        "desc": "Custom container name (optional)"
+      },
+      {
+        "name": "custom_name",
+        "type": "string",
+        "desc": "Custom app name (optional)"
+      },
+      {
+        "name": "environment",
+        "type": "object",
+        "desc": "Custom environment variables as key-value pairs (optional)"
+      }
+    ]
+  },
+  {
+    "name": "list_containers",
+    "description": "List all Docker containers (running and stopped)",
+    "arguments": []
+  },
+  {
+    "name": "list_images",
+    "description": "List all Docker images on the host",
+    "arguments": []
+  },
+  {
+    "name": "list_installed_apps",
+    "description": "List all apps installed via the WAGMIOS marketplace",
+    "arguments": []
+  },
+  {
+    "name": "pull_image",
+    "description": "Pull a Docker image from a registry",
+    "arguments": [
+      {
+        "name": "image",
+        "type": "string",
+        "desc": "Image name (e.g. nginx:alpine)"
+      }
+    ]
+  },
+  {
+    "name": "restart_container",
+    "description": "Restart a container",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Container ID or name"
+      }
+    ]
+  },
+  {
+    "name": "start_app",
+    "description": "Start an installed marketplace app (pulls image and runs docker compose up)",
+    "arguments": [
+      {
+        "name": "app_id",
+        "type": "string",
+        "desc": "App ID (e.g. jellyfin)"
+      },
+      {
+        "name": "compose_path",
+        "type": "string",
+        "desc": "Compose file path returned by install_app"
+      },
+      {
+        "name": "container_name",
+        "type": "string",
+        "desc": "Container name used during install"
+      }
+    ]
+  },
+  {
+    "name": "start_container",
+    "description": "Start a stopped container",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Container ID or name"
+      }
+    ]
+  },
+  {
+    "name": "stop_container",
+    "description": "Stop a running container",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Container ID or name"
+      }
+    ]
+  },
+  {
+    "name": "system_info",
+    "description": "Get Docker version, API version, and system information from the WAGMIOS host",
+    "arguments": []
+  },
+  {
+    "name": "system_metrics",
+    "description": "Get CPU, memory, disk usage, and container counts from the WAGMIOS host",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## ClawMachine — MCP Server for WAGMIOS

ClawMachine provides 18 scoped MCP tools for managing Docker containers, images, and marketplace apps through the [WAGMIOS](https://github.com/mentholmike/wagmios) REST API.

### Features
- **Container lifecycle**: list, logs, config, start, stop, restart, create, delete
- **Image management**: list, pull, delete
- **Marketplace**: browse 34+ self-hosted apps, install, start
- **System info**: Docker version, API version, system metrics
- **Scope-gated tools**: tools only register if the API key has the required scope (containers:read, containers:write, containers:delete, images:read, images:write, marketplace:read, marketplace:write)
- **Multi-instance mode**: manage multiple WAGMIOS hosts from a single MCP server with per-host scope validation

### Details
- **Image**: `itzmizzle/clawmachine:latest` (multi-arch: linux/amd64, linux/arm64)
- **License**: MIT
- **Transport**: stdio (default) and SSE
- **MCP Protocol**: 2024-11-05
- **Source**: https://github.com/mentholmike/clawmachine

### Configuration
- `WAGMIOS_API_KEY` (secret): API key from your WAGMIOS instance
- `WAGMIOS_API_URL` (env): URL of your WAGMIOS backend (default: http://localhost:5179)

### Testing
ClawMachine has been tested end-to-end against a live WAGMIOS instance and has undergone 3 rounds of adversarial code review.

Test credentials can be provided via the [shared credentials form](https://forms.gle/6Lw3nsvu2d6nFg8e6).