### PR TITLE
Add findata-mcp, feedback-synthesis-mcp, and mcp-billing-gateway

### DIFF
--- a/servers/feedback-synthesis-mcp/readme.md
+++ b/servers/feedback-synthesis-mcp/readme.md
@@ -1,0 +1,20 @@
+# Feedback Synthesis MCP
+
+Customer feedback aggregation and synthesis MCP server. Analyzes feedback from GitHub Issues, Hacker News discussions, and App Store reviews to surface actionable insights.
+
+## Tools
+
+| Tool | Description | Cost |
+|------|-------------|------|
+| `synthesize_feedback` | Full feedback synthesis with themes and sentiment | $0.05/call |
+| `get_pain_points` | Ranked list of user pain points | $0.02/call |
+| `search_feedback` | Search feedback by keyword/topic | $0.01/call |
+| `get_sentiment_trends` | Sentiment trends over time | $0.03/call |
+
+## Authentication
+
+This server uses the [x402 payment protocol](https://x402.org) for pay-per-use access. No API key or subscription is required — each tool call is priced individually and settled via Base network USDC micropayments.
+
+## Source
+
+https://github.com/sapph1re/feedback-synthesis-mcp

--- a/servers/feedback-synthesis-mcp/server.yaml
+++ b/servers/feedback-synthesis-mcp/server.yaml
@@ -1,0 +1,23 @@
+name: feedback-synthesis-mcp
+type: remote
+
+dynamic:
+  tools: false
+
+meta:
+  category: data
+  tags:
+    - feedback
+    - sentiment-analysis
+    - product-research
+    - user-research
+    - x402
+
+about:
+  title: Feedback Synthesis MCP
+  description: Customer feedback synthesis MCP server. Aggregates and analyzes feedback from GitHub Issues, Hacker News, and App Store reviews. Surfaces pain points, sentiment trends, and actionable insights via x402 micropayments.
+  icon: https://www.google.com/s2/favicons?domain=feedback-synthesis-mcp-production.up.railway.app&sz=64
+
+remote:
+  transport_type: streamable-http
+  url: https://feedback-synthesis-mcp-production.up.railway.app/mcp

--- a/servers/feedback-synthesis-mcp/tools.json
+++ b/servers/feedback-synthesis-mcp/tools.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "synthesize_feedback",
+    "description": "Synthesize customer feedback from multiple sources (GitHub Issues, Hacker News, App Store) into a structured summary with themes, sentiment, and key quotes",
+    "arguments": [
+      {
+        "name": "product",
+        "description": "Product or company name to research",
+        "required": true
+      },
+      {
+        "name": "sources",
+        "description": "Sources to include: github, hackernews, appstore (comma-separated, default: all)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "get_pain_points",
+    "description": "Extract and rank the top user pain points for a product from aggregated feedback data",
+    "arguments": [
+      {
+        "name": "product",
+        "description": "Product or company name",
+        "required": true
+      },
+      {
+        "name": "limit",
+        "description": "Maximum number of pain points to return (default: 10)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "search_feedback",
+    "description": "Search aggregated feedback for specific topics or keywords",
+    "arguments": [
+      {
+        "name": "product",
+        "description": "Product or company name",
+        "required": true
+      },
+      {
+        "name": "query",
+        "description": "Search query or topic",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "get_sentiment_trends",
+    "description": "Get sentiment trends over time for a product, showing how user sentiment has changed",
+    "arguments": [
+      {
+        "name": "product",
+        "description": "Product or company name",
+        "required": true
+      },
+      {
+        "name": "period",
+        "description": "Time period: 7d, 30d, 90d (default: 30d)",
+        "required": false
+      }
+    ]
+  }
+]

--- a/servers/findata-mcp/readme.md
+++ b/servers/findata-mcp/readme.md
@@ -1,0 +1,22 @@
+# FinData MCP
+
+Financial data MCP server providing real-time market data via x402 micropayments.
+
+## Tools
+
+| Tool | Description | Cost |
+|------|-------------|------|
+| `stock_quote` | Real-time stock price, volume, market cap | $0.001/call |
+| `company_fundamentals` | P/E, EPS, revenue, margins | $0.002/call |
+| `economic_indicator` | GDP, CPI, unemployment, Fed rate | $0.001/call |
+| `sec_filing` | Recent 10-K, 10-Q, 8-K filings | $0.002/call |
+| `crypto_price` | Crypto price, 24h change, market cap | $0.001/call |
+
+## Authentication
+
+This server uses the [x402 payment protocol](https://x402.org) for pay-per-use access. No API key or subscription is required — each tool call is priced individually and settled via Base network USDC micropayments.
+
+## Source
+
+- Thin client: https://pypi.org/project/findata-mcp/
+- GitHub: https://github.com/sapph1re/findata-mcp

--- a/servers/findata-mcp/server.yaml
+++ b/servers/findata-mcp/server.yaml
@@ -1,0 +1,24 @@
+name: findata-mcp
+type: remote
+
+dynamic:
+  tools: false
+
+meta:
+  category: finance
+  tags:
+    - finance
+    - stocks
+    - crypto
+    - economic-data
+    - sec-filings
+    - x402
+
+about:
+  title: FinData MCP
+  description: Financial data MCP server providing real-time stock quotes, company fundamentals, economic indicators, SEC filings, and crypto prices via x402 micropayments. Pay per call — no subscription required.
+  icon: https://www.google.com/s2/favicons?domain=findata-mcp-production-1cd3.up.railway.app&sz=64
+
+remote:
+  transport_type: streamable-http
+  url: https://findata-mcp-production-1cd3.up.railway.app/mcp

--- a/servers/findata-mcp/tools.json
+++ b/servers/findata-mcp/tools.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "stock_quote",
+    "description": "Get real-time stock quote including price, change, volume, and market cap for a given ticker symbol",
+    "arguments": [
+      {
+        "name": "symbol",
+        "description": "Stock ticker symbol (e.g. AAPL, MSFT, TSLA)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "company_fundamentals",
+    "description": "Get company fundamental data including P/E ratio, EPS, revenue, profit margins, and balance sheet highlights",
+    "arguments": [
+      {
+        "name": "symbol",
+        "description": "Stock ticker symbol",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "economic_indicator",
+    "description": "Fetch macroeconomic indicators such as GDP, CPI, unemployment rate, and Federal Funds Rate from FRED",
+    "arguments": [
+      {
+        "name": "indicator",
+        "description": "Indicator name (e.g. GDP, CPI, UNEMPLOYMENT, FED_RATE)",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "sec_filing",
+    "description": "Retrieve recent SEC filings for a company (10-K, 10-Q, 8-K) with filing dates and document links",
+    "arguments": [
+      {
+        "name": "symbol",
+        "description": "Stock ticker symbol",
+        "required": true
+      },
+      {
+        "name": "filing_type",
+        "description": "Filing type: 10-K, 10-Q, or 8-K",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "crypto_price",
+    "description": "Get current cryptocurrency price, 24h change, volume, and market cap",
+    "arguments": [
+      {
+        "name": "symbol",
+        "description": "Cryptocurrency symbol (e.g. BTC, ETH, SOL)",
+        "required": true
+      }
+    ]
+  }
+]

--- a/servers/mcp-billing-gateway/readme.md
+++ b/servers/mcp-billing-gateway/readme.md
@@ -1,0 +1,20 @@
+# MCP Billing Gateway
+
+Billing infrastructure for MCP server operators. Add monetization to any MCP server without building payment infrastructure from scratch.
+
+## What it does
+
+Register your MCP server with the billing gateway to get:
+- **Billing proxy**: A managed endpoint that handles payment verification before forwarding to your server
+- **Pricing plans**: Per-call, flat-rate, or Stripe subscription billing models
+- **Revenue tracking**: Usage analytics, revenue dashboards, and Stripe Connect payouts
+- **x402 support**: Native x402 micropayment verification for agent-to-agent billing
+
+## Authentication
+
+Obtain an operator API key by calling `register_operator` with no auth header (free signup), then use the returned key as `Authorization: Bearer <key>` for all subsequent calls.
+
+## Source
+
+- SDK: https://github.com/sapph1re/mcp-billing-gateway-sdk
+- Docs: https://mcp-billing-gateway-production.up.railway.app/docs

--- a/servers/mcp-billing-gateway/server.yaml
+++ b/servers/mcp-billing-gateway/server.yaml
@@ -1,0 +1,32 @@
+name: mcp-billing-gateway
+type: remote
+
+dynamic:
+  tools: false
+
+meta:
+  category: developer-tools
+  tags:
+    - billing
+    - monetization
+    - payments
+    - stripe
+    - x402
+    - mcp-infrastructure
+
+about:
+  title: MCP Billing Gateway
+  description: Billing infrastructure for MCP server operators. Register your MCP server, configure pricing plans (Stripe subscriptions or x402 micropayments), track usage analytics, and manage revenue — all via MCP tools.
+  icon: https://www.google.com/s2/favicons?domain=mcp-billing-gateway-production.up.railway.app&sz=64
+
+remote:
+  transport_type: streamable-http
+  url: https://mcp-billing-gateway-production.up.railway.app/mcp/
+  headers:
+    Authorization: "Bearer ${BILLING_GATEWAY_API_KEY}"
+
+config:
+  secrets:
+    - name: billing_gateway.api_key
+      env: BILLING_GATEWAY_API_KEY
+      example: bgw_your_operator_api_key

--- a/servers/mcp-billing-gateway/tools.json
+++ b/servers/mcp-billing-gateway/tools.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "register_operator",
+    "description": "Register a new operator account with Stripe Connect onboarding to receive payouts",
+    "arguments": [
+      {
+        "name": "email",
+        "description": "Operator email address",
+        "required": true
+      },
+      {
+        "name": "name",
+        "description": "Operator or company name",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "get_operator_profile",
+    "description": "Get current operator profile and Stripe Connect onboarding status",
+    "arguments": []
+  },
+  {
+    "name": "register_server",
+    "description": "Register a new MCP server for billing management",
+    "arguments": [
+      {
+        "name": "name",
+        "description": "Server display name",
+        "required": true
+      },
+      {
+        "name": "upstream_url",
+        "description": "URL of the upstream MCP server to proxy",
+        "required": true
+      },
+      {
+        "name": "proxy_slug",
+        "description": "URL slug for the billing proxy endpoint",
+        "required": true
+      },
+      {
+        "name": "auth_mode",
+        "description": "Authentication mode: api_key or x402",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "list_servers",
+    "description": "List all MCP servers registered by the operator",
+    "arguments": []
+  },
+  {
+    "name": "get_server",
+    "description": "Get server details including pricing plans and configuration",
+    "arguments": [
+      {
+        "name": "api_key",
+        "description": "Server API key",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "create_pricing_plan",
+    "description": "Create a pricing plan for a server (flat rate, per-call, or subscription)",
+    "arguments": [
+      {
+        "name": "server_id",
+        "description": "Server ID",
+        "required": true
+      },
+      {
+        "name": "name",
+        "description": "Plan name",
+        "required": true
+      },
+      {
+        "name": "billing_model",
+        "description": "Billing model: per_call, flat_rate, or subscription",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "get_usage_analytics",
+    "description": "Get usage analytics for a server including call counts, revenue, and top callers",
+    "arguments": [
+      {
+        "name": "api_key",
+        "description": "Server API key",
+        "required": true
+      },
+      {
+        "name": "period",
+        "description": "Time period: 7d, 30d (default: 30d)",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "get_revenue_summary",
+    "description": "Get revenue summary and payout history for the operator account",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## Summary

Adding three production remote MCP servers using streamable-http transport:

### findata-mcp
Financial data MCP server with 5 tools covering stocks, crypto, SEC filings, and economic indicators. Uses x402 micropayments for pay-per-use access (no subscription required).

- **URL**: https://findata-mcp-production-1cd3.up.railway.app/mcp
- **Transport**: streamable-http
- **Auth**: x402 micropayments (Base network USDC)
- **PyPI thin client**: https://pypi.org/project/findata-mcp/
- **Source**: https://github.com/sapph1re/findata-mcp

### feedback-synthesis-mcp
Customer feedback aggregation and synthesis server. Pulls from GitHub Issues, Hacker News, and App Store reviews to surface pain points and sentiment trends.

- **URL**: https://feedback-synthesis-mcp-production.up.railway.app/mcp
- **Transport**: streamable-http
- **Auth**: x402 micropayments (Base network USDC)
- **Source**: https://github.com/sapph1re/feedback-synthesis-mcp

### mcp-billing-gateway
Billing infrastructure for MCP server operators. Register any MCP server, configure Stripe or x402 pricing plans, track usage analytics, and manage revenue without building payment infrastructure from scratch.

- **URL**: https://mcp-billing-gateway-production.up.railway.app/mcp/
- **Transport**: streamable-http
- **Auth**: Bearer API key (obtained via `register_operator` tool — free signup)
- **SDK**: https://github.com/sapph1re/mcp-billing-gateway-sdk

## Testing

All three servers are live on Railway (mainnet) and have passed full E2E and black-box testing. Health endpoints return 200.

```bash
curl https://findata-mcp-production-1cd3.up.railway.app/health
curl https://feedback-synthesis-mcp-production.up.railway.app/health
curl https://mcp-billing-gateway-production.up.railway.app/health
```