### PR TITLE
Add Outscraper MCP server

### DIFF
--- a/servers/outscraper/server.yaml
+++ b/servers/outscraper/server.yaml
@@ -1,0 +1,39 @@
+name: outscraper
+image: mcp/outscraper
+type: server
+meta:
+  category: search
+  tags:
+    - outscraper
+    - search
+    - business-data
+    - google-maps
+    - enrichment
+    - lead-generation
+    - company-enrichment
+    - reviews
+    - web-scraping
+about:
+  title: Outscraper
+  description: Official Outscraper MCP server for business discovery, Google Maps intelligence, company enrichment, review analysis, contact data, search, and structured web extraction.
+  icon: https://www.google.com/s2/favicons?domain=outscraper.com&sz=64
+source:
+  project: https://github.com/outscraper/outscraper-mcp-server
+  commit: c90c56610f4715815fee305be37c345e169a0a76
+config:
+  description: Configure the connection to Outscraper.
+  secrets:
+    - name: outscraper.api_key
+      env: OUTSCRAPER_API_KEY
+      example: YOUR_OUTSCRAPER_API_KEY
+      description: Create an API key in the Outscraper dashboard to authenticate MCP tool calls.
+  env:
+    - name: OUTSCRAPER_API_BASE_URL
+      example: https://api.outscraper.com
+      value: "{{outscraper.url}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        default: https://api.outscraper.com


### PR DESCRIPTION
## MCP Server Information

**Server Name:** `outscraper`  
**Repository URL:** `https://github.com/outscraper/outscraper-mcp-server`  
**Brief Description:** Official Outscraper MCP server for business discovery, Google Maps intelligence, company enrichment, review analysis, contact data, search, and structured web extraction.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: `SECURITY.md` in the source repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name outscraper`
- [x] I have built the MCP Server using `task build -- --tools outscraper`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

- This submission uses the Docker-built path with `image: mcp/outscraper`.
- The server can start and enumerate tools without a preconfigured API key, which helps registry validation.
- Authentication is still required for live Outscraper API calls through `OUTSCRAPER_API_KEY`.
- If Docker reviewers require end-to-end live verification, a test Outscraper API key can be shared through the review form.
