### PR TITLE
feat: add search-docs MCP server

### DIFF
--- a/servers/search-docs/server.yaml
+++ b/servers/search-docs/server.yaml
@@ -29,9 +29,8 @@ source:
   commit: e77a9fdd1db6958d2380a131908da68ab62b57b4
 run:
   volumes:
-    - "{{search-docs.project_path|volume-target}}:/projects/current"
-  env:
-    EMBEDDING_URL: "{{search-docs.embedding_url}}"
+    - "{{search-docs.project_path}}:/workspace:ro"
+    - "{{search-docs.project_path}}/.search-docs:/workspace/.search-docs"
 config:
   description: Configure project directory to index and optional external Embedding server URL
   parameters:

--- a/servers/search-docs/server.yaml
+++ b/servers/search-docs/server.yaml
@@ -26,6 +26,10 @@ about:
     The project directory is mounted read-only for document scanning.
     Index data is persisted in the .search-docs subdirectory (read-write).
 
+    If no external Embedding server is specified, the built-in server auto-detects
+    in order: Docker compose service, host-side server (host.docker.internal:24281),
+    then falls back to spawning a local instance.
+
     Designed for AI coding assistants to search and retrieve project documentation efficiently.
   icon: https://avatars.githubusercontent.com/u/57501900?s=200&v=4
 source:
@@ -35,10 +39,13 @@ run:
   volumes:
     - "{{search-docs.project_path}}:/workspace:ro"
     - "{{search-docs.project_path}}/.search-docs:/workspace/.search-docs"
+  env:
+    EMBEDDING_URL: "{{search-docs.embedding_url}}"
 config:
   description: |
     Project directory to index. Documents (*.md) are read from this directory.
     Index data is stored in .search-docs/ subdirectory within the project.
+    Embedding URL is optional — auto-detection covers most setups.
   parameters:
     type: object
     properties:
@@ -46,5 +53,9 @@ config:
         type: string
         description: Project directory containing Markdown documents to search
         default: /Users/demo/my-project
+      embedding_url:
+        type: string
+        description: "Embedding server URL (optional, auto-detected if not set). Example: http://host.docker.internal:24282"
+        default: ""
     required:
       - project_path

--- a/servers/search-docs/server.yaml
+++ b/servers/search-docs/server.yaml
@@ -9,18 +9,22 @@ meta:
     - vector-search
     - local-files
     - markdown
+    - japanese
 about:
   title: search-docs
   description: |
     Local document vector search system for project documentation.
 
     Features:
-    • Vector search over local Markdown documents using Ruri Embedding model
+    • Vector search over local Markdown documents using Ruri Embedding model (optimized for Japanese)
     • Automatic document indexing and background re-indexing
     • Section-based splitting (H1-H4 headings, token-based)
     • Document outline and full content retrieval
     • Multi-project support with related project linking
     • Built-in Embedding server (ONNX Runtime, CPU-optimized)
+
+    The project directory is mounted read-only for document scanning.
+    Index data is persisted in the .search-docs subdirectory (read-write).
 
     Designed for AI coding assistants to search and retrieve project documentation efficiently.
   icon: https://avatars.githubusercontent.com/u/57501900?s=200&v=4
@@ -32,17 +36,15 @@ run:
     - "{{search-docs.project_path}}:/workspace:ro"
     - "{{search-docs.project_path}}/.search-docs:/workspace/.search-docs"
 config:
-  description: Configure project directory to index and optional external Embedding server URL
+  description: |
+    Project directory to index. Documents (*.md) are read from this directory.
+    Index data is stored in .search-docs/ subdirectory within the project.
   parameters:
     type: object
     properties:
       project_path:
         type: string
-        description: Project directory containing documents to search
+        description: Project directory containing Markdown documents to search
         default: /Users/demo/my-project
-      embedding_url:
-        type: string
-        description: External Embedding server URL (optional, uses built-in server if not set)
-        default: ""
     required:
       - project_path

--- a/servers/search-docs/server.yaml
+++ b/servers/search-docs/server.yaml
@@ -1,0 +1,49 @@
+name: search-docs
+image: mcp/search-docs
+type: server
+meta:
+  category: search
+  tags:
+    - search
+    - documents
+    - vector-search
+    - local-files
+    - markdown
+about:
+  title: search-docs
+  description: |
+    Local document vector search system for project documentation.
+
+    Features:
+    • Vector search over local Markdown documents using Ruri Embedding model
+    • Automatic document indexing and background re-indexing
+    • Section-based splitting (H1-H4 headings, token-based)
+    • Document outline and full content retrieval
+    • Multi-project support with related project linking
+    • Built-in Embedding server (ONNX Runtime, CPU-optimized)
+
+    Designed for AI coding assistants to search and retrieve project documentation efficiently.
+  icon: https://avatars.githubusercontent.com/u/57501900?s=200&v=4
+source:
+  project: https://github.com/otolab/search-docs
+  commit: e77a9fdd1db6958d2380a131908da68ab62b57b4
+run:
+  volumes:
+    - "{{search-docs.project_path|volume-target}}:/projects/current"
+  env:
+    EMBEDDING_URL: "{{search-docs.embedding_url}}"
+config:
+  description: Configure project directory to index and optional external Embedding server URL
+  parameters:
+    type: object
+    properties:
+      project_path:
+        type: string
+        description: Project directory containing documents to search
+        default: /Users/demo/my-project
+      embedding_url:
+        type: string
+        description: External Embedding server URL (optional, uses built-in server if not set)
+        default: ""
+    required:
+      - project_path


### PR DESCRIPTION
## Summary

Add **search-docs** — a local document vector search MCP server.

- **Source**: https://github.com/otolab/search-docs
- **Category**: search
- **Type**: Local (containerized, stdio)

## What it does

search-docs provides vector search over local Markdown documentation for AI coding assistants. Features include:

- Vector search using Ruri Embedding model (ONNX Runtime, CPU-optimized)
- Automatic background document indexing and re-indexing
- Section-based document splitting (H1-H4 headings, token-based)
- Document outline and full content retrieval
- Multi-project support with related project linking
- Built-in Embedding server (no external dependencies required)

## Configuration

- **project_path** (required): Project directory containing documents to search (mounted as volume)
- **embedding_url** (optional): External Embedding server URL for GPU/CoreML acceleration

## Docker image

The Dockerfile uses a multi-stage build:
1. Python dependencies + ONNX model pre-download
2. Node.js build + pnpm deploy
3. Minimal runtime (python:3.12-slim-bookworm + node binary)

Runs as non-root user, includes pre-baked ONNX model (~30MB), supports network-disabled operation.

## Testing

```bash
docker build -t search-docs .
docker run --rm -i -v /path/to/project:/projects/current search-docs
```