### PR TITLE
Add vardoger MCP server

### DIFF
--- a/servers/vardoger/server.yaml
+++ b/servers/vardoger/server.yaml
@@ -1,0 +1,75 @@
+name: vardoger
+image: mcp/vardoger
+type: server
+meta:
+  category: productivity
+  tags:
+    - personalization
+    - local-first
+    - history
+    - rules
+    - skills
+    - cursor
+    - claude-code
+    - codex
+    - openclaw
+    - copilot
+    - windsurf
+about:
+  title: Vardoger
+  description: |
+    Personalize AI coding assistants by analyzing local conversation history.
+
+    vardoger reads the JSONL conversation logs that Cursor, Claude Code,
+    OpenAI Codex, GitHub Copilot CLI, Windsurf, and OpenClaw already store
+    under your $HOME, extracts behavioral patterns (communication style,
+    preferred stack, workflow habits, pain points), and writes a tailored
+    personalization file the host assistant picks up natively on its next
+    session.
+
+    All processing is local — no network calls, no API keys, no data
+    transmitted to any external service. See
+    https://github.com/dstrupl/vardoger/blob/main/PRIVACY.md.
+
+    Note: Cline history is not accessible from this containerized build
+    because Cline's on-disk layout depends on the host-OS VS Code
+    globalStorage location. Cline users should install via
+    `pipx install vardoger` instead.
+  icon: https://raw.githubusercontent.com/dstrupl/vardoger/main/assets/logo-400.png
+source:
+  project: https://github.com/dstrupl/vardoger
+  branch: main
+  # Pinned at submission time to the vardoger 0.3.1 release tag commit.
+  commit: 1090cf27ee75bec233b78c7234c56d68b30f6651
+run:
+  volumes:
+    - "{{vardoger.home_path}}:/host-home"
+config:
+  description: |
+    vardoger reads and writes under the mounted host $HOME. It reads
+    conversation history from ~/.cursor, ~/.claude, ~/.codex, ~/.openclaw,
+    ~/.copilot, and ~/.codeium/windsurf, and writes the generated
+    personalization back to the matching platform's native rules file plus
+    ~/.vardoger/state.json for incremental processing. Point `home_path` at
+    your host $HOME and leave `platform` blank unless you want to pin the
+    server to one specific host.
+  env:
+    - name: VARDOGER_MCP_PLATFORM
+      example: cursor
+      value: "{{vardoger.platform}}"
+  parameters:
+    type: object
+    properties:
+      home_path:
+        type: string
+        description: Absolute path to your host $HOME (vardoger reads and writes under it).
+        default: /home/you
+      platform:
+        type: string
+        description: >-
+          Optional host platform identifier (cursor, claude-code, codex, copilot,
+          windsurf, openclaw). Leave blank to auto-detect from the calling MCP
+          client.
+        default: ""
+    required:
+      - home_path

--- a/servers/vardoger/server.yaml
+++ b/servers/vardoger/server.yaml
@@ -39,8 +39,9 @@ about:
 source:
   project: https://github.com/dstrupl/vardoger
   branch: main
-  # Pinned at submission time to the vardoger 0.3.1 release tag commit.
-  commit: 1090cf27ee75bec233b78c7234c56d68b30f6651
+  # Peeled commit SHA of the vardoger 0.3.1 release tag (`git rev-list -1 v0.3.1`).
+  # Must be a commit SHA, not the annotated tag object SHA.
+  commit: 98c9006f87880d907944557d343028f2b53cf635
 run:
   volumes:
     - "{{vardoger.home_path}}:/host-home"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** vardoger
**Repository URL:** https://github.com/dstrupl/vardoger
**Brief Description:** Personalize AI coding assistants by analyzing local conversation history. vardoger reads the JSONL logs that Cursor, Claude Code, OpenAI Codex, GitHub Copilot CLI, Windsurf, and OpenClaw already store under `$HOME`, extracts behavioral patterns, and writes a tailored personalization file that each host assistant picks up natively on its next session. All processing is local — no network calls, no API keys.

## Basic Requirements

- [x] **Open Source**: Apache-2.0 (LICENSE in repo root)
- [x] **MCP Compliant**: Implements MCP stdio transport via `vardoger mcp`
- [x] **Active Development**: Released `v0.3.1` on 2026-04-24; regular commits
- [x] **Docker Artifact**: Multi-stage `Dockerfile` at repo root, non-root UID 1000
- [x] **Documentation**: README, PRIVACY, CHANGELOG, plus `plugins/docker-mcp/README.md`
- [x] **Security Contact**: https://github.com/dstrupl/vardoger/security (GitHub private advisories)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name vardoger` (ran as `go run ./cmd/validate --name vardoger`; all 11 checks pass)
- [x] I have built the MCP Server using `task build -- --tools vardoger` (ran as `go run ./cmd/build --tools vardoger`; image built, 9 tools discovered)
- [x] No test credentials needed — vardoger is fully local and reads only the user's own host files

## Notes for reviewers

- **Commit pinned to the `v0.3.1` release tag (peeled commit SHA):** `98c9006f87880d907944557d343028f2b53cf635`. (Previously listed `1090cf27ee75bec233b78c7234c56d68b30f6651`, which is the annotated tag object SHA; corrected to the commit SHA that `source.commit` expects.)
- **Host volume:** `server.yaml` binds `{{vardoger.home_path}}` → `/host-home` so vardoger's history adapters can read `~/.cursor`, `~/.claude`, `~/.codex`, `~/.openclaw`, `~/.copilot`, `~/.codeium/windsurf`, and write the generated personalization back to the matching platform's native rules file plus `~/.vardoger/state.json` (incremental state).
- **Known limitation:** the Cline adapter derives its VS Code `globalStorage` path from `sys.platform`, so inside a Linux container it resolves to the Linux path rather than macOS/Windows. Cline users should `pipx install vardoger` instead — this is documented in `server.yaml` and `plugins/docker-mcp/README.md`.
- The server is also now live on the Official MCP Registry as `io.github.dstrupl/vardoger@0.3.1` and on PyPI as `vardoger==0.3.1`.

