### PR TITLE
fix: update sentry-remote url and transport type

### DIFF
--- a/servers/sentry-remote/server.yaml
+++ b/servers/sentry-remote/server.yaml
@@ -14,8 +14,8 @@ about:
   description: Track application errors, monitor performance, and debug issues in real-time across your entire development stack
   icon: https://www.google.com/s2/favicons?domain=sentry.io&sz=64
 remote:
-  transport_type: sse
-  url: https://mcp.sentry.dev/sse
+  transport_type: streamable-http
+  url: https://mcp.sentry.dev/mcp
 oauth:
   - provider: sentry-remote
     secret: sentry-remote.personal_access_token


### PR DESCRIPTION
# Issue

The current config for the `sentry-remote` MCP server points to [https://mcp.sentry.dev/sse](https://mcp.sentry.dev/sse) which was deprecated in https://github.com/getsentry/sentry-mcp/pull/593.

In fact when going to that URL you can see the error:

```
SSE transport has been removed
The SSE transport endpoint is no longer supported. Please use the HTTP transport at /mcp instead.
```

<img width="746" height="171" alt="Screenshot 2026-04-25 at 22 39 45" src="https://github.com/user-attachments/assets/54368653-c2de-4f14-b96a-62f70be6008d" />

As a result when running `docker mcp gateway run ...` I see the following error:

```
Can't start sentry-remote: failed to connect: missing endpoint: first event is "ping", want "endpoint"
```

and I wasn't able to actually connect to sentry.

# Fix

I updated the URL and transport type to match what described in the [official documentation](https://docs.sentry.io/ai/mcp/).

I tested it locally, by creating a custom catalog where I added a copy of `sentry-remote` server with just the config updated, and it was able to connect.

<img width="763" height="126" alt="Screenshot 2026-04-25 at 22 46 47" src="https://github.com/user-attachments/assets/e8ea2fcd-dafa-4b59-91d3-8d1fee99b890" />
