### PR TITLE
Add pricepilot-mcp server

### DIFF
--- a/servers/pricepilot-mcp/server.yaml
+++ b/servers/pricepilot-mcp/server.yaml
@@ -1,0 +1,28 @@
+name: pricepilot-mcp
+image: mcp/pricepilot-mcp
+type: server
+meta:
+  category: e-commerce
+  tags:
+    - mcp
+    - pricing
+    - cpg
+    - amazon
+    - retail
+    - benchmarks
+    - competitive-intelligence
+    - multi-channel
+about:
+  title: PricePilot
+  description: |
+    Cross-channel CPG pricing intelligence — Amazon category benchmarks
+    (percentile rank, trend, tier breakdown) for multi-channel CPG brands
+    selling on Amazon plus retail / DTC / wholesale. Six tools across 800+
+    tracked products in Grocery, Health & Beauty, Household, and Pet
+    Supplies. Free alternative to NielsenIQ / SPINS syndicated data.
+  icon: https://raw.githubusercontent.com/vantage-meridian-group/pricepilot-mcp/main/logo.svg
+source:
+  project: https://github.com/vantage-meridian-group/pricepilot-mcp
+  commit: 30e5128dc4c050b164d2062ac2c26abdf2f1e46d
+config:
+  description: PricePilot MCP requires no configuration — read-only public CPG pricing data.

--- a/servers/pricepilot-mcp/tools.json
+++ b/servers/pricepilot-mcp/tools.json
@@ -1,0 +1,66 @@
+[
+    {
+        "name": "get_price_position",
+        "description": "Percentile-rank a single product price against tracked Amazon competitors in a CPG category. Returns position (Value/Parity/Premium), Price Index, percentile rank, and category metadata.",
+        "arguments": [
+            {
+                "name": "price",
+                "type": "number",
+                "desc": "Product price in dollars (e.g. 4.99). Must be > 0 and <= 10000."
+            },
+            {
+                "name": "category",
+                "type": "string",
+                "desc": "Exact category name — Grocery & Gourmet Food, Health & Beauty, Household, or Pet Supplies. Case-insensitive. Call list_categories first to confirm available names."
+            }
+        ]
+    },
+    {
+        "name": "get_category_trend",
+        "description": "Report the 30-day Amazon price-trend direction (Rising / Stable / Falling / Insufficient Data) for a CPG category, with sample size and confidence note.",
+        "arguments": [
+            {
+                "name": "category",
+                "type": "string",
+                "desc": "Exact category name — Grocery & Gourmet Food, Health & Beauty, Household, or Pet Supplies. Case-insensitive."
+            }
+        ]
+    },
+    {
+        "name": "get_category_overview",
+        "description": "Return pricing-tier breakdown (budget / midmarket / premium dollar bands), median price, and trend direction for an Amazon CPG category. Tier bounds rounded to nearest $0.50.",
+        "arguments": [
+            {
+                "name": "category",
+                "type": "string",
+                "desc": "Exact category name — Grocery & Gourmet Food, Health & Beauty, Household, or Pet Supplies. Case-insensitive."
+            }
+        ]
+    },
+    {
+        "name": "compare_products",
+        "description": "Compare multiple product prices against an Amazon CPG category's peers. Returns per-product percentile rank, position, and distance from category median.",
+        "arguments": [
+            {
+                "name": "products",
+                "type": "array",
+                "desc": "List of items, each a dict with 'name' (string) and 'price' (number in dollars). Minimum 1 item; 3-20 is the useful range."
+            },
+            {
+                "name": "category",
+                "type": "string",
+                "desc": "Exact category name — Grocery & Gourmet Food, Health & Beauty, Household, or Pet Supplies. Case-insensitive."
+            }
+        ]
+    },
+    {
+        "name": "list_categories",
+        "description": "List Amazon CPG categories with current product counts and trend direction. Returns the exact category names expected by other tools. Lightweight; safe to call first in any analysis workflow.",
+        "arguments": []
+    },
+    {
+        "name": "server_status",
+        "description": "Report PricePilot server health, data freshness, and degraded-state reason. Returns status (healthy/degraded), categories available, last-seed timestamp, and degraded-reason if seed is overdue.",
+        "arguments": []
+    }
+]


### PR DESCRIPTION
## What this PR adds

`servers/pricepilot-mcp/` — registry entry for **PricePilot**, a cross-channel CPG pricing intelligence MCP server.

PricePilot exposes Amazon category benchmarks (percentile rank, trend, tier breakdown) for multi-channel CPG brands selling on Amazon plus retail / DTC / wholesale. Six read-only tools span 800+ tracked products in Grocery & Gourmet Food, Health & Beauty, Household, and Pet Supplies. Free alternative to NielsenIQ / SPINS syndicated category data.

Typical user: a $2M–$50M CPG brand's pricing ops lead asking *"where does my Amazon listing price sit against 100+ category peers?"* — useful for retail buyer prep, MAP audits, and cross-channel pricing reviews.

## Files

- `servers/pricepilot-mcp/server.yaml` — server entry, category `e-commerce`
- `servers/pricepilot-mcp/tools.json` — 6 tool definitions (provided to skip live `task build --tools` validation per CONTRIBUTING)

## Compliance

- **License:** MIT (allows registry consumption — see [LICENSE](https://github.com/vantage-meridian-group/pricepilot-mcp/blob/main/LICENSE))
- **Configuration:** none required. No env vars, no secrets, no OAuth. Server reads only from public CPG benchmark snapshots.
- **Source pin:** `commit: 30e5128dc4c050b164d2062ac2c26abdf2f1e46d` on `vantage-meridian-group/pricepilot-mcp:main`
- **Image:** `mcp/pricepilot-mcp` (Docker-built — no `--image` override)
- **Tool annotations:** all 6 tools `readOnlyHint=true, destructiveHint=false, openWorldHint=false`
- **Icon:** brand SVG hosted in the source repo at `raw.githubusercontent.com/vantage-meridian-group/pricepilot-mcp/main/logo.svg`

## Existing listings

- Glama: [`vantage-meridian-group/pricepilot-mcpb`](https://glama.ai/mcp/servers/vantage-meridian-group/pricepilot-mcpb) (existing .mcpb bundle listing); a second listing for this server source is in Glama's review queue
- Smithery: [`scott-noa4/pricepilot`](https://smithery.ai/server/scott-noa4/pricepilot)
- Official MCP Registry: `io.github.vantage-meridian-group/pricepilot` v1.0.1
- Anthropic Connectors Directory: submitted (Remote MCP form)

## Sync-drift note

The `commit:` SHA pins to a specific source state. The `pricepilot-mcp` repo is a curated public mirror of the MCP-server slice of our private monorepo; when MCP-side code changes upstream, we re-port and re-tag the mirror, then can submit a follow-up PR to bump this SHA. This is a known maintenance pattern, not ghost updates.

## Testing

- Mirror `pricepilot-mcp` builds cleanly via `docker build .` (Python 3.13-slim, FastMCP)
- All 6 tools verified to register at server startup (smoke-tested via Python import)
- Live hosted instance at `https://pricepilot-mcp.onrender.com/mcp` (independent deployment) has been in production since 2026-04-10 with rate limiting and weekly data refresh