### PR TITLE
feat: add KubeStellar Console MCP server

### DIFF
--- a/servers/kubestellar-console/server.yaml
+++ b/servers/kubestellar-console/server.yaml
@@ -1,0 +1,31 @@
+name: kubestellar-console
+image: mcp/kubestellar-console
+type: server
+meta:
+  category: devops
+  tags:
+    - kubernetes
+    - multi-cluster
+    - devops
+    - dashboard
+    - mcp
+about:
+  title: KubeStellar Console
+  description: AI-powered multi-cluster Kubernetes management dashboard with built-in MCP server (kc-agent) for AI-assisted operations, compliance auditing, and cross-cluster resource management
+  icon: https://avatars.githubusercontent.com/u/110614386?s=200&v=4
+source:
+  project: https://github.com/kubestellar/console
+  commit: fa9759ce6659d721222d324d9561a0cd461f395b
+run:
+  volumes:
+    - "{{kubestellar-console.kubeconfig_path}}:/root/.kube/config"
+config:
+  description: Configure the path to your kubeconfig file for multi-cluster access
+  parameters:
+    type: object
+    properties:
+      kubeconfig_path:
+        description: the path to the host .kube/config file
+        type: string
+    required:
+      - kubeconfig_path


### PR DESCRIPTION
## MCP Server Information

**Server Name:** kubestellar-console
**Repository URL:** https://github.com/kubestellar/console
**Brief Description:** AI-powered multi-cluster Kubernetes management dashboard with built-in MCP server (kc-agent) for AI-assisted operations, compliance auditing, and cross-cluster resource management.

## Basic Requirements

- [x] **Open Source**: Apache-2.0 license
- [x] **MCP Compliant**: kc-agent implements MCP protocol, bridging AI assistants to Kubernetes clusters via kubeconfig
- [x] **Active Development**: Daily commits, actively maintained by the KubeStellar team (CNCF project)
- [x] **Docker Artifact**: Dockerfile included in the repository root
- [x] **Documentation**: Comprehensive README with setup instructions
- [x] **Security Contact**: SECURITY.md and SECURITY_CONTACTS in repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [ ] I have tested the MCP Server using `task validate -- --name kubestellar-console`
- [ ] I have built the MCP Server using `task build -- --tools kubestellar-console`
- [ ] If the server requires credentials to test it, I have shared test credentials

## Additional Context

KubeStellar Console is part of the [KubeStellar](https://kubestellar.io) CNCF project. The kc-agent component acts as an MCP server that bridges AI coding assistants (Claude, GPT, Gemini) to Kubernetes clusters, enabling natural language operations across multiple clusters.