### PR TITLE
Add docker-hub-security MCP server

### DIFF
--- a/servers/docker-hub-security/server.yaml
+++ b/servers/docker-hub-security/server.yaml
@@ -1,0 +1,37 @@
+name: docker-hub-security
+image: mcp/docker-hub-security
+type: server
+meta:
+  category: security
+  tags:
+    - docker
+    - security
+    - cve
+    - vulnerabilities
+    - docker-scout
+about:
+  title: Docker Hub Security
+  description: |
+    Connects to Docker Hub and Docker Scout to provide CVE vulnerability information
+    and remediation guidance for all images in your Docker Hub namespace.
+
+    Features:
+    • List all repositories and Scout-tracked images in your namespace
+    • Get full CVE details for any image by digest, with severity filtering
+    • Prioritised remediation plans showing which packages to update and to what version
+    • Org-wide vulnerability summary ranked by severity and CVSS score
+    • CISA Known Exploited Vulnerability (KEV) flagging
+    • EPSS exploit probability scores
+  icon: https://www.google.com/s2/favicons?domain=hub.docker.com&sz=64
+source:
+  project: https://github.com/hovdb/docker-hub-security-mcp
+  commit: c0efc3931614cc262fd9be33bddce1e84e171409
+config:
+  description: Configure Docker Hub credentials for Scout API access
+  secrets:
+    - name: docker-hub-security.username
+      env: DOCKER_USERNAME
+      example: myusername
+    - name: docker-hub-security.pat
+      env: DOCKER_HUB_PAT
+      example: dckr_pat_****


### PR DESCRIPTION
## MCP Server Information

**Server Name:** docker-hub-security
**Repository URL:** https://github.com/hovdb/docker-hub-security-mcp
**Brief Description:** MCP server that connects to Docker Hub and Docker Scout to surface CVE vulnerability data and remediation guidance for all images in a Docker Hub namespace.

## Basic Requirements

- [x] **Open Source**: MIT / Apache-2.0 compatible (Python, open source dependencies)
- [x] **MCP Compliant**: Implements MCP API specification via `mcp[cli]` SDK
- [x] **Active Development**: Freshly built and maintained
- [x] **Docker Artifact**: Multi-stage Dockerfile using `dhi.io/python:3.14-debian13-dev` (build) and `dhi.io/python:3.14-debian13` (runtime)
- [x] **Documentation**: README with setup instructions at https://github.com/hovdb/docker-hub-security-mcp
- [x] **Security Contact**: GitHub issues on the source repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name docker-hub-security`
- [x] I have built the MCP Server using `task build -- --tools docker-hub-security`

## Tools Provided

| Tool | Description |
|---|---|
| `list_repositories` | List all repositories in a Docker Hub namespace |
| `list_images` | List Scout-tracked images with digests and tags |
| `get_image_vulnerabilities` | Get CVEs for an image digest, with optional severity filter |
| `get_remediation` | Prioritised fix plan — packages to update and target versions |
| `scan_organization` | Org-wide CVE summary ranked by severity and CVSS score |

🤖 Generated with [Claude Code](https://claude.com/claude-code)