### PR TITLE
feat: add mcp-android — Android device control server (37 tools)

### DIFF
--- a/servers/mcp-android/server.yaml
+++ b/servers/mcp-android/server.yaml
@@ -1,0 +1,43 @@
+name: mcp-android
+image: ghcr.io/ismail-kattakath/mcp-android
+type: server
+meta:
+  category: devops
+  tags:
+    - android
+    - adb
+    - mobile
+    - automation
+    - scrcpy
+about:
+  title: Android Device Control
+  description: Comprehensive Android device control — ADB shell, screencap, UI dump, tap/swipe/text input via scrcpy fast-path, APK install, logcat, Activity Manager, Package Manager, WiFi ADB. 37 tools. Works over USB or WiFi with no device agent required.
+  icon: https://raw.githubusercontent.com/ismail-kattakath/mcp-android/main/icon-256.png
+source:
+  project: https://github.com/ismail-kattakath/mcp-android
+  commit: b9ec8fa3b3af5f9d8b496babe5c2dd87de8f737e
+config:
+  description: Configure connection to the host ADB daemon. Set ADB_SERVER_HOST to host.docker.internal so the container delegates to the ADB daemon running on your host machine.
+  env:
+    - name: ADB_SERVER_HOST
+      example: host.docker.internal
+      value: "{{mcp-android.adb_server_host}}"
+    - name: ADB_SERVER_PORT
+      example: "5037"
+      value: "{{mcp-android.adb_server_port}}"
+    - name: LOG_LEVEL
+      example: "2"
+      value: "{{mcp-android.log_level}}"
+  parameters:
+    type: object
+    properties:
+      adb_server_host:
+        type: string
+        description: Hostname of the ADB server (use host.docker.internal to reach the host daemon)
+      adb_server_port:
+        type: string
+        description: Port of the ADB server (default 5037)
+      log_level:
+        type: string
+        description: "Log verbosity: 0=silent 1=errors 2=info 3=debug (default 2)"
+    required: []

--- a/servers/mcp-android/server.yaml
+++ b/servers/mcp-android/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://raw.githubusercontent.com/ismail-kattakath/mcp-android/main/icon-256.png
 source:
   project: https://github.com/ismail-kattakath/mcp-android
-  commit: b9ec8fa3b3af5f9d8b496babe5c2dd87de8f737e
+  commit: 9480a242a6c52b86c526ecce7c6f4d4f0eb25288
 config:
   description: Configure connection to the host ADB daemon. Set ADB_SERVER_HOST to host.docker.internal so the container delegates to the ADB daemon running on your host machine.
   env:


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcp-android
**Repository URL:** https://github.com/ismail-kattakath/mcp-android
**Brief Description:** Comprehensive Android device control — ADB shell, screencap, UI dump, tap/swipe/text input via scrcpy fast-path, APK install, logcat, Activity Manager, Package Manager, WiFi ADB. 37 tools. Works over USB or WiFi with no device agent required.

## Basic Requirements

- [x] **Open Source**: MIT License
- [x] **MCP Compliant**: Uses `@modelcontextprotocol/sdk ^1.25.1`, stdio transport, 37 registered tools + 1 resource
- [x] **Active Development**: Initial release, actively maintained
- [x] **Docker Artifact**: Multi-stage Dockerfile (node:22-alpine + android-tools + ffmpeg)
- [x] **Documentation**: README with full tool reference, client setup for Claude Desktop/Code/Cursor/Zed, WiFi ADB guide
- [x] **Security Contact**: IsmailK@infin8it.ca (listed in CODE_OF_CONDUCT.md)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcp-android` ✅ all checks pass
- [ ] I have built the MCP Server using `task build -- --tools mcp-android` — multi-arch (amd64+arm64) image is currently building at https://github.com/ismail-kattakath/mcp-android/actions; will be available at `ghcr.io/ismail-kattakath/mcp-android:latest` once complete
- [x] No credentials required to test (server connects to local ADB daemon via `host.docker.internal:5037`)

## Notes

The server delegates ADB commands to the host machine's ADB daemon via `ADB_SERVER_HOST=host.docker.internal`. This means users need:
1. `adb` running on their host (`adb start-server`)
2. Android device connected via USB or WiFi ADB

No API tokens or secrets needed.