### PR TITLE
Add mcp-a2a-bridge: Bidirectional MCP ↔ A2A protocol bridge

### DIFF
--- a/servers/mcp-a2a-bridge/readme.md
+++ b/servers/mcp-a2a-bridge/readme.md
@@ -1,0 +1,1 @@
+For full documentation, see [mcp-a2a-bridge on GitHub](https://github.com/naveenkumarbaskaran/mcp-a2a-bridge).

--- a/servers/mcp-a2a-bridge/server.yaml
+++ b/servers/mcp-a2a-bridge/server.yaml
@@ -1,0 +1,37 @@
+name: mcp-a2a-bridge
+image: naveenkumarbaskaran/mcp-a2a-bridge
+type: server
+meta:
+  category: devops
+  tags:
+    - mcp
+    - a2a
+    - agent
+    - bridge
+    - protocol
+    - devops
+about:
+  title: MCP ↔ A2A Bridge
+  description: >-
+    Bidirectional bridge between MCP (Model Context Protocol) and A2A (Agent-to-Agent) protocols.
+    Connect A2A agents as MCP tools or expose MCP servers as A2A agents. Config-driven via YAML,
+    supports stdio/SSE/streamable-http transports, and includes LLM-powered natural language routing.
+  icon: https://avatars.githubusercontent.com/u/65524514?v=4
+source:
+  project: https://github.com/naveenkumarbaskaran/mcp-a2a-bridge
+  commit: f1755ea2964b27e1e2ec08a3f39edee4c76d0b58
+run:
+  command:
+    - serve
+    - --config
+    - /app/bridge.yaml
+    - --direction
+    - a2a-to-mcp
+  volumes:
+    - mcp-a2a-bridge-config:/app
+config:
+  description: Configure the MCP ↔ A2A Bridge
+  secrets:
+    - name: mcp-a2a-bridge.openai_api_key
+      env: OPENAI_API_KEY
+      example: sk-YOUR_OPENAI_API_KEY

--- a/servers/mcp-a2a-bridge/tools.json
+++ b/servers/mcp-a2a-bridge/tools.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "ask_agent",
+    "description": "Send a natural language message to a connected A2A agent and get a response. The bridge automatically discovers A2A agents from the config and creates one tool per agent skill.",
+    "arguments": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "The natural language message to send to the A2A agent"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## New MCP Server: mcp-a2a-bridge

**Category:** Developer Tools

**Description:** Bidirectional bridge between MCP (Model Context Protocol) and A2A (Agent-to-Agent) protocols. Connect A2A agents as MCP tools or expose MCP servers as A2A agents.

### Features
- **A2A → MCP**: Connect to A2A agents and auto-generate MCP tools from their skills
- **MCP → A2A**: Connect to MCP servers and expose them as an A2A agent with LLM-powered routing
- **Bidirectional**: Run both directions simultaneously
- Config-driven via YAML
- Supports stdio, SSE, and streamable-http transports
- Uses `a2a-sdk v1.0+` and `mcp v1.27+` (latest)

### Links
- **GitHub:** https://github.com/naveenkumarbaskaran/mcp-a2a-bridge
- **PyPI:** https://pypi.org/project/mcp-a2a-bridge/
- **Docker Hub:** https://hub.docker.com/r/naveenkumarbaskaran/mcp-a2a-bridge

### Checklist
- [x] MIT License
- [x] Dockerfile included in source repo
- [x] Docker Hub image available (`naveenkumarbaskaran/mcp-a2a-bridge:latest`)
- [x] `server.yaml` with proper configuration
- [x] `tools.json` provided (dynamic tools generated at runtime from connected A2A agents)
- [x] `readme.md` with documentation link
- [x] CI passing on source repo

### Notes
This bridge dynamically generates MCP tools based on connected A2A agents' skills at startup. The `tools.json` lists the generic `ask_agent` tool pattern — actual tool names are derived from A2A agent skill names at runtime.
