### PR TITLE
Add mcp-aemps - Spanish AEMPS CIMA pharmaceutical registry

### DIFF
--- a/servers/mcp-aemps/server.yaml
+++ b/servers/mcp-aemps/server.yaml
@@ -1,0 +1,33 @@
+name: mcp-aemps
+image: mcp/mcp-aemps
+type: server
+meta:
+  category: healthcare
+  tags:
+    - healthcare
+    - pharmaceutical
+    - regulatory
+    - aemps
+    - cima
+    - spain
+about:
+  title: MCP AEMPS — CIMA
+  description: |
+    Open-source, regulatory-compliant MCP server for the Spanish AEMPS CIMA
+    pharmaceutical registry. Real-time access to 20,000+ authorised medicines,
+    technical sheets, supply problems, safety notes, and clinical equivalents.
+    Read-only proxy, no PII processed. Apache-2.0.
+  icon: https://raw.githubusercontent.com/romanpert/mcp-aemps/master/docs/mcp_aemps_logo_v2.jpg
+source:
+  project: https://github.com/romanpert/mcp-aemps
+  commit: 1741b3795ea5d7721778e903a1d2381c7476f21e
+config:
+  description: |
+    No required configuration. The server queries the public AEMPS CIMA API
+    (https://cima.aemps.es/cima/rest) — no API key, no authentication needed.
+    The container listens on port 8765. Optional advanced env vars
+    (REDIS_URL, ALLOWED_ORIGINS) are documented in the project README.
+  env:
+    - name: LOG_LEVEL
+      example: INFO
+      value: INFO

--- a/servers/mcp-aemps/tools.json
+++ b/servers/mcp-aemps/tools.json
@@ -1,0 +1,527 @@
+[
+  {
+    "name": "obtener_medicamento",
+    "description": "Obtener descripcion general de un medicamento (por CN o nregistro)",
+    "arguments": [
+      {
+        "name": "cn",
+        "type": "string",
+        "desc": "Codigo Nacional (CN)."
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro AEMPS."
+      }
+    ]
+  },
+  {
+    "name": "buscar_medicamentos",
+    "description": "Listado de medicamentos con filtros regulatorios avanzados",
+    "arguments": [
+      {
+        "name": "nombre",
+        "type": "string",
+        "desc": "Nombre del medicamento (coincidencia parcial o exacta)."
+      },
+      {
+        "name": "laboratorio",
+        "type": "string",
+        "desc": "Nombre del laboratorio fabricante."
+      },
+      {
+        "name": "practiv1",
+        "type": "string",
+        "desc": "Nombre del principio activo principal."
+      },
+      {
+        "name": "practiv2",
+        "type": "string",
+        "desc": "Nombre de un segundo principio activo."
+      },
+      {
+        "name": "idpractiv1",
+        "type": "string",
+        "desc": "ID numerico del principio activo principal."
+      },
+      {
+        "name": "idpractiv2",
+        "type": "string",
+        "desc": "ID numerico de un segundo principio activo."
+      },
+      {
+        "name": "cn",
+        "type": "string",
+        "desc": "Codigo Nacional del medicamento."
+      },
+      {
+        "name": "atc",
+        "type": "string",
+        "desc": "Codigo ATC o descripcion parcial del mismo."
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro AEMPS."
+      },
+      {
+        "name": "npactiv",
+        "type": "string",
+        "desc": "Numero de principios activos."
+      },
+      {
+        "name": "triangulo",
+        "type": "string",
+        "desc": "1 = Tienen triangulo, 0 = No."
+      },
+      {
+        "name": "huerfano",
+        "type": "string",
+        "desc": "1 = Huerfano, 0 = No."
+      },
+      {
+        "name": "biosimilar",
+        "type": "string",
+        "desc": "1 = Biosimilar, 0 = No."
+      },
+      {
+        "name": "sust",
+        "type": "string",
+        "desc": "Tipo de medicamento especial (1-5)."
+      },
+      {
+        "name": "vmp",
+        "type": "string",
+        "desc": "ID del codigo VMP para buscar equivalentes clinicos."
+      },
+      {
+        "name": "comerc",
+        "type": "string",
+        "desc": "1 = Comercializados, 0 = No."
+      },
+      {
+        "name": "autorizados",
+        "type": "string",
+        "desc": "1 = Solo autorizados, 0 = No."
+      },
+      {
+        "name": "receta",
+        "type": "string",
+        "desc": "1 = Con receta, 0 = Sin receta."
+      },
+      {
+        "name": "estupefaciente",
+        "type": "string",
+        "desc": "1 = Incluye estupefacientes, 0 = Excluye."
+      },
+      {
+        "name": "psicotropo",
+        "type": "string",
+        "desc": "1 = Incluye psicotropos, 0 = Excluye."
+      },
+      {
+        "name": "estuopsico",
+        "type": "string",
+        "desc": "1 = Incluye estupefacientes o psicotropos, 0 = Excluye."
+      },
+      {
+        "name": "pagina",
+        "type": "string",
+        "desc": "Numero de pagina de resultados (minimo 1)."
+      }
+    ]
+  },
+  {
+    "name": "listar_presentaciones",
+    "description": "Listar presentaciones de un medicamento con filtros (cn, nregistro, etc.)",
+    "arguments": [
+      {
+        "name": "cn",
+        "type": "string",
+        "desc": "Codigo Nacional del medicamento."
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro AEMPS."
+      },
+      {
+        "name": "vmp",
+        "type": "string",
+        "desc": "ID del codigo VMP para equivalentes clinicos."
+      },
+      {
+        "name": "vmpp",
+        "type": "string",
+        "desc": "ID del codigo VMPP."
+      },
+      {
+        "name": "idpractiv1",
+        "type": "string",
+        "desc": "ID del principio activo."
+      },
+      {
+        "name": "comerc",
+        "type": "string",
+        "desc": "1 = Comercializados, 0 = No."
+      },
+      {
+        "name": "estupefaciente",
+        "type": "string",
+        "desc": "1 = Incluye estupefacientes, 0 = Excluye."
+      },
+      {
+        "name": "psicotropo",
+        "type": "string",
+        "desc": "1 = Incluye psicotropos, 0 = Excluye."
+      },
+      {
+        "name": "estuopsico",
+        "type": "string",
+        "desc": "1 = Incluye estupefacientes o psicotropos, 0 = Excluye."
+      }
+    ]
+  },
+  {
+    "name": "obtener_presentacion",
+    "description": "Detalle de una o varias presentaciones (por uno o varios CN)",
+    "arguments": [
+      {
+        "name": "cn",
+        "type": "array",
+        "desc": "Uno o varios Codigos Nacionales. Repetir: ?cn=123&cn=456"
+      }
+    ]
+  },
+  {
+    "name": "buscar_vmpp",
+    "description": "Equivalentes clinicos VMP/VMPP filtrables por principio activo, dosis, forma, etc.",
+    "arguments": [
+      {
+        "name": "practiv1",
+        "type": "string",
+        "desc": "Nombre del principio activo principal."
+      },
+      {
+        "name": "idpractiv1",
+        "type": "string",
+        "desc": "ID del principio activo principal."
+      },
+      {
+        "name": "dosis",
+        "type": "string",
+        "desc": "Dosis del medicamento."
+      },
+      {
+        "name": "forma",
+        "type": "string",
+        "desc": "Nombre de la forma farmaceutica."
+      },
+      {
+        "name": "atc",
+        "type": "string",
+        "desc": "Codigo ATC o descripcion parcial."
+      },
+      {
+        "name": "nombre",
+        "type": "string",
+        "desc": "Nombre del medicamento."
+      },
+      {
+        "name": "modoArbol",
+        "type": "string",
+        "desc": "0=plano, 1=jerarquico"
+      },
+      {
+        "name": "pagina",
+        "type": "string",
+        "desc": "Numero de pagina (si aplica)"
+      }
+    ]
+  },
+  {
+    "name": "consultar_maestras",
+    "description": "Consultar catalogos maestros: ATC, Principios Activos, Formas, Laboratorios...",
+    "arguments": [
+      {
+        "name": "maestra",
+        "type": "string",
+        "desc": "ID de la maestra a consultar."
+      },
+      {
+        "name": "nombre",
+        "type": "string",
+        "desc": "Nombre del elemento a recuperar."
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "ID del elemento a recuperar."
+      },
+      {
+        "name": "codigo",
+        "type": "string",
+        "desc": "Codigo del elemento a recuperar."
+      },
+      {
+        "name": "estupefaciente",
+        "type": "string",
+        "desc": "1 = Solo PA estupefacientes."
+      },
+      {
+        "name": "psicotropo",
+        "type": "string",
+        "desc": "1 = Solo PA psicotropos."
+      },
+      {
+        "name": "estuopsico",
+        "type": "string",
+        "desc": "PA estupefacientes o psicotropos."
+      },
+      {
+        "name": "enuso",
+        "type": "string",
+        "desc": "0 = PA asociados o no a medicamentos."
+      },
+      {
+        "name": "pagina",
+        "type": "string",
+        "desc": "Numero de pagina (si la API lo soporta)."
+      }
+    ]
+  },
+  {
+    "name": "doc_secciones",
+    "description": "Metadatos de secciones de Ficha Tecnica/prospecto",
+    "arguments": [
+      {
+        "name": "tipo_doc",
+        "type": "integer",
+        "desc": "1=FT, 2=Prospecto, 3-4 otros"
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Uno o varios numeros de registro"
+      },
+      {
+        "name": "cn",
+        "type": "string",
+        "desc": "Uno o varios codigos nacionales"
+      }
+    ]
+  },
+  {
+    "name": "doc_contenido",
+    "description": "Contenido de secciones de Ficha Tecnica/prospecto",
+    "arguments": [
+      {
+        "name": "tipo_doc",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "N Registro medicamento"
+      },
+      {
+        "name": "cn",
+        "type": "string",
+        "desc": "Codigo Nacional del Medicamento"
+      },
+      {
+        "name": "seccion",
+        "type": "string",
+        "desc": "Seccion estilo <2.1>, <4.2>, ..."
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Formato: json, html o txt"
+      }
+    ]
+  },
+  {
+    "name": "html_ficha_tecnica_multiple",
+    "description": "Fichas tecnicas HTML para varios registros",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "array",
+        "desc": "N de registro (repetir)"
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Nombre de archivo HTML ('FichaTecnica.html')"
+      }
+    ]
+  },
+  {
+    "name": "html_prospecto_multiple",
+    "description": "Prospectos HTML para varios registros",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "array",
+        "desc": "N de registro (repetir)"
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Nombre de archivo HTML ('Prospecto.html')"
+      }
+    ]
+  },
+  {
+    "name": "html_ficha_tecnica",
+    "description": "HTML completo de ficha tecnica (unico registro)",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro"
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Ruta y nombre de archivo HTML"
+      }
+    ]
+  },
+  {
+    "name": "html_prospecto",
+    "description": "HTML completo de prospecto (unico registro)",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro"
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Ruta y nombre de archivo HTML"
+      }
+    ]
+  },
+  {
+    "name": "registro_cambios",
+    "description": "Historial de altas, bajas y modificaciones de medicamentos",
+    "arguments": [
+      {
+        "name": "fecha",
+        "type": "string",
+        "desc": "Fecha (dd/mm/yyyy)."
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro AEMPS (repetir)."
+      },
+      {
+        "name": "metodo",
+        "type": "string",
+        "desc": "Metodo HTTP interno."
+      }
+    ]
+  },
+  {
+    "name": "problemas_suministro",
+    "description": "Problemas de suministro: global paginado o detalle por CN (v2 con fallback v1)",
+    "arguments": [
+      {
+        "name": "cn",
+        "type": "string",
+        "desc": "Uno o mas Codigos Nacionales."
+      },
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Uno o mas numeros de registro."
+      },
+      {
+        "name": "pagina",
+        "type": "integer",
+        "desc": "Pagina (solo en listado global)"
+      },
+      {
+        "name": "tamanioPagina",
+        "type": "integer",
+        "desc": "Tamano de pagina (solo en listado global)"
+      }
+    ]
+  },
+  {
+    "name": "problemas_suministro_dcp",
+    "description": "Presentaciones comercializadas y con problemas de suministro para un DCP",
+    "arguments": [
+      {
+        "name": "cod_dcp",
+        "type": "string",
+        "desc": "Codigo DCP (descripcion clinica del producto)"
+      }
+    ]
+  },
+  {
+    "name": "problemas_suministro_dcpf",
+    "description": "Presentaciones comercializadas y con problemas de suministro para un DCPF",
+    "arguments": [
+      {
+        "name": "cod_dcpf",
+        "type": "string",
+        "desc": "Codigo DCPF (descripcion clinica del producto con formato)"
+      }
+    ]
+  },
+  {
+    "name": "listar_notas",
+    "description": "Notas de seguridad para uno o varios registros",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "array",
+        "desc": "Repite: ?nregistro=AAA&nregistro=BBB"
+      }
+    ]
+  },
+  {
+    "name": "obtener_notas",
+    "description": "Detalle de notas de seguridad de uno o varios registros",
+    "arguments": [
+      {
+        "name": "nregistros",
+        "type": "string",
+        "desc": "Registro(s) separados por comas: AAA,BBB,CCC"
+      }
+    ]
+  },
+  {
+    "name": "listar_materiales",
+    "description": "Materiales informativos para uno o varios registros",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "array",
+        "desc": "Repite: ?nregistro=AAA&nregistro=BBB"
+      }
+    ]
+  },
+  {
+    "name": "obtener_materiales",
+    "description": "Materiales informativos de un registro",
+    "arguments": [
+      {
+        "name": "nregistro",
+        "type": "string",
+        "desc": "Numero de registro"
+      }
+    ]
+  },
+  {
+    "name": "get_system_info_prompt",
+    "description": "Obtener el Prompt del sistema para el agente MCP",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
  ## Summary

  Adds **mcp-aemps**, an open-source, regulatory-compliant MCP server for
  the Spanish AEMPS CIMA pharmaceutical registry — real-time access to
  20,000+ authorised medicines, technical sheets, supply problems, safety
  notes, and clinical equivalents.

  ## Why this is a good fit

  - **Healthcare category** — currently no MCP server in the registry
  covers the Spanish pharmaceutical market specifically.
  - **Regulatory compliance by design** — read-only proxy over the AEMPS
  public API; no PII processed; structured audit logs; no patient data.
  - **Already on PyPI** (`pip install mcp-aemps`) and the **official MCP
  Registry** (`io.github.romanpert/mcp-aemps@0.1.6`).
  - **Multi-arch GHCR image** at `ghcr.io/romanpert/mcp-aemps:latest`
  (linux/amd64 + linux/arm64).
  - **Apache-2.0** licensed.

  ## Validation

  End-to-end Dockerfile validation passes — image size 193 MB, non-root
  user (UID 10001), 21 MCP tools exposed, `/mcp` initialize returns 200,
  healthcheck green:

  https://github.com/romanpert/mcp-aemps/blob/master/.docker-mcp-registry/
  verify.sh

  Local `task build -- --tools mcp-aemps` and `task catalog -- mcp-aemps`
  both pass. Local `docker mcp catalog import` step skipped because the
  `import` subcommand is not exposed in Docker Desktop 4.71.0 CLI; relying
   on the registry's CI to validate.

  ## Source

  - Repo:    https://github.com/romanpert/mcp-aemps
  - License: Apache-2.0
  - Author:  Román Pérez Dumpert <roman.p98@gmail.com>
  - PyPI:    https://pypi.org/project/mcp-aemps/
  - MCP Registry:
  https://registry.modelcontextprotocol.io/v0/servers?search=mcp-aemps