### PR TITLE
Add Tide Agent Pack MCP server

### DIFF
--- a/servers/tideorg-mcp/server.yaml
+++ b/servers/tideorg-mcp/server.yaml
@@ -1,0 +1,20 @@
+name: tideorg-mcp
+type: remote
+meta:
+  category: security
+  tags:
+    - security
+    - authentication
+    - tidecloak
+    - threshold-cryptography
+    - remote
+about:
+  title: Tide Agent Pack
+  description: AI coding agent guidance for TideCloak — auth, threshold cryptography, Forseti contracts, and server-side security patterns
+  icon: https://tide.org/favicon.ico
+source:
+  project: https://github.com/tide-foundation/tide-agent-pack
+remote:
+  transport_type: streamable-http
+  url: https://mcp.tide.org/mcp
+


### PR DESCRIPTION
Adds the Tide Agent Pack — an MCP server providing AI coding agents with operational guidance for TideCloak (auth, threshold cryptography, Forseti smart contracts, server-side security).

- **Type**: Remote (streamable-http)
- **URL**: https://mcp.tide.org/mcp
- **Category**: Security
- **Source**: https://github.com/tide-foundation/tide-agent-pack
- **npm**: @tideorg/mcp
- **Docker Hub**: tideorg/mcp
- **License**: MIT