### PR TITLE
Add Halal Terminal remote MCP server

### DIFF
--- a/servers/halalterminal/server.yaml
+++ b/servers/halalterminal/server.yaml
@@ -35,4 +35,4 @@ metadata:
   maintainer:
     name: Yassir
     email: yassir@halalterminal.com
-  logo: https://halalterminal.com/og.png
+  logo: https://halalterminal.com/android-chrome-192x192.png

--- a/servers/halalterminal/server.yaml
+++ b/servers/halalterminal/server.yaml
@@ -1,0 +1,38 @@
+name: halalterminal
+displayName: Halal Terminal
+description: |
+  Shariah-compliant stock & ETF screening across AAOIFI, DJIM, FTSE, MSCI and S&P
+  methodologies, plus portfolio audit, zakat, dividend purification, market data,
+  news, and SEC filings — for any MCP-compatible AI agent.
+type: server
+remote:
+  transport: sse
+  url: https://mcp.halalterminal.com/sse
+  headers:
+    - name: X-API-Key
+      description: Halal Terminal API key (prefix ht_). Free tier at https://api.halalterminal.com — no credit card.
+      required: true
+      secret: true
+metadata:
+  license: Apache-2.0
+  category: finance
+  tags:
+    - halal
+    - shariah
+    - islamic-finance
+    - stock-screening
+    - etf-screening
+    - zakat
+    - aaoifi
+    - djim
+    - ftse-shariah
+    - msci-islamic
+    - sp-shariah
+  homepage: https://halalterminal.com
+  source:
+    type: github
+    url: https://github.com/goww7/halalterminal-mcp
+  maintainer:
+    name: Yassir
+    email: yassir@halalterminal.com
+  logo: https://halalterminal.com/og.png


### PR DESCRIPTION
## Add Halal Terminal remote MCP server

This PR adds the **Halal Terminal** MCP server — Shariah-compliant stock & ETF screening — to the Docker MCP Registry as a **remote server** (transport: SSE).

### What it does

22 tools across 8 categories:

- **Screening** — `screen_stock`, `screen_etf`, `bulk_screen` across five Shariah methodologies (AAOIFI, DJIM, FTSE, MSCI, S&P)
- **Portfolio audit** — per-stock verdict + aggregate compliant % + purification owed
- **Zakat & purification** — 2.5% zakat against a live nisab; impure-portion calculation per dividend
- **Market data, news, SEC filings** — quotes, history, dividends, EDGAR XBRL facts
- **Watchlists, comparisons, generated reports, Islamic-finance education**

### Why a remote server (no Dockerfile)

The MCP server runs on Halal Terminal infrastructure and exposes SSE at `https://mcp.halalterminal.com/sse`. There's also an npm-published stdio bridge (`@halalterminal/mcp`) for clients that need stdio, but the canonical surface is the remote endpoint — which is what `server.yaml` reflects.

### Auth

Per-user `X-API-Key` header. Free tier at https://api.halalterminal.com (50 tokens/month, no credit card).

### License

Apache-2.0 — repo: https://github.com/goww7/halalterminal-mcp

### Test credentials

Submitted via https://forms.gle/6Lw3nsvu2d6nFg8e6 with a Docker-review-dedicated key.

### Checklist

- [x] License is MIT or Apache-2.0 (Apache-2.0)
- [x] `server.yaml` placed under `servers/halalterminal/`
- [x] `type: server` + `remote:` block (SSE)
- [x] Categorized under `finance`
- [x] Maintainer attribution single-source: `Yassir <yassir@halalterminal.com>`
- [x] Logo URL provided
