### PR TITLE
Add SearXNG HTTP MCP server

### DIFF
--- a/servers/searxng-http-mcp/server.yaml
+++ b/servers/searxng-http-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: searxng-http-mcp
+image: mcp/searxng-http-mcp
+type: server
+meta:
+  category: general
+  tags:
+    - search
+    - metasearch
+    - searxng
+    - privacy
+about:
+  title: SearXNG
+  description: Privacy-respecting metasearch engine aggregating 200+ search engines (Google, Bing, DuckDuckGo, Brave, etc.) with zero configuration
+  icon: https://raw.githubusercontent.com/searxng/searxng/master/searx/static/themes/simple/img/favicon.png
+source:
+  project: https://github.com/whw23/searxng-http-mcp
+  branch: main
+  commit: 72aed2f807c975a99ec016c5967f521edf485654

--- a/servers/searxng-http-mcp/tools.json
+++ b/servers/searxng-http-mcp/tools.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "search",
+    "description": "Search the web using SearXNG metasearch engine. Aggregates results from 200+ search engines (Google, Bing, DuckDuckGo, Brave, etc.) with privacy. Returns results, answers, suggestions, corrections, and infoboxes. Use 'categories' to focus on specific content types. Use 'pages' for more results.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "The search query to use"
+      },
+      {
+        "name": "categories",
+        "type": "string",
+        "desc": "Comma-separated category names to focus on (e.g., 'general,news,science')"
+      },
+      {
+        "name": "engines",
+        "type": "string",
+        "desc": "Comma-separated engine names to use (e.g., 'google,arxiv,wikipedia')"
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Search language code (e.g., 'en', 'zh', 'ja', 'de')"
+      },
+      {
+        "name": "time_range",
+        "type": "string",
+        "desc": "Restrict results to those published within this time window"
+      },
+      {
+        "name": "safesearch",
+        "type": "integer",
+        "desc": "Safe search level: 0=off, 1=moderate, 2=strict"
+      },
+      {
+        "name": "pageno",
+        "type": "integer",
+        "desc": "Starting page number"
+      },
+      {
+        "name": "pages",
+        "type": "integer",
+        "desc": "Number of pages to fetch in parallel (multi-page fanout)"
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": "Maximum number of results to return"
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Result detail level: 'compact' returns title/url/content only, 'full' includes engines/score/category/date/thumbnails"
+      }
+    ]
+  },
+  {
+    "name": "autocomplete",
+    "description": "Get search query suggestions from SearXNG. Returns a list of autocomplete suggestions for the given partial query. Use this to discover relevant search terms before performing a full search.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Partial query string to get suggestions for"
+      }
+    ]
+  },
+  {
+    "name": "engine_info",
+    "description": "Get available search engines and categories from the SearXNG instance. Returns the list of enabled engines grouped by category. Use this to discover what engines and categories are available before calling search with specific engines or categories filters.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** searxng-http-mcp
**Repository URL:** https://github.com/whw23/searxng-http-mcp
**Brief Description:** Privacy-respecting metasearch engine aggregating 200+ search engines (Google, Bing, DuckDuckGo, Brave, etc.) with zero configuration. Bundles SearXNG in the container image — no external dependencies needed.

## Basic Requirements

- [x] **Open Source**: MIT License
- [x] **MCP Compliant**: Implements MCP API specification (FastMCP with stdio and streamable-http transport)
- [x] **Active Development**: Actively maintained with CI/CD, multi-arch Docker builds, and Cosign signing
- [x] **Docker Artifact**: Dockerfile (multi-stage build based on official SearXNG image)
- [x] **Documentation**: Comprehensive README with examples in English and Chinese
- [x] **Security Contact**: SECURITY.md with responsible disclosure policy

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

> Note: This server requires no credentials — it is fully self-contained with zero configuration.
> `tools.json` is provided because the bundled SearXNG needs ~40s to initialize before tools can be auto-discovered.