### PR TITLE
Add Spreadsheet Kit MCP server

### DIFF
--- a/servers/spreadsheet-kit/server.yaml
+++ b/servers/spreadsheet-kit/server.yaml
@@ -1,0 +1,37 @@
+name: spreadsheet-kit
+image: ghcr.io/psu3d0/spreadsheet-mcp:0.10.1-full
+type: server
+meta:
+  category: productivity
+  tags:
+    - spreadsheet
+    - excel
+    - xlsx
+    - analysis
+    - automation
+    - agents
+    - recalc
+about:
+  title: Spreadsheet Kit
+  description: Agent-safe Excel workbook analysis, editing, recalculation, and verification tools.
+  icon: https://avatars.githubusercontent.com/u/10227908?s=200&v=4
+source:
+  project: https://github.com/PSU3D0/spreadsheet-mcp
+  commit: 50a33a590ff26e2c0cb9386fa8d6d4545ff00ddf
+run:
+  command:
+    - "--workspace-root=/data"
+    - "--transport=stdio"
+  volumes:
+    - "{{spreadsheet-kit.workbook_dir}}:/data"
+config:
+  description: Configure the workbook directory exposed to spreadsheet-kit MCP
+  parameters:
+    type: object
+    properties:
+      workbook_dir:
+        type: string
+        description: Host directory containing Excel workbooks to expose to spreadsheet-kit MCP
+        default: /Users/local-test
+    required:
+      - workbook_dir


### PR DESCRIPTION
## Summary
- add Spreadsheet Kit MCP server to the Docker MCP Catalog
- use the published GHCR full image for write/recalc-capable spreadsheet workflows
- expose a configurable workbook directory mounted at /data with stdio transport

## Validation
- mise x go@1.24 -- go run ./cmd/validate --name spreadsheet-kit

Upstream project PR with registry metadata: https://github.com/PSU3D0/spreadsheet-mcp/pull/8