### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "Code and Server Validation"


### PR DESCRIPTION
The CI workflow's `validate` job:

1. checks out `main` for tooling, builds Go binaries from `cmd/validate`, `cmd/build`, `cmd/catalog`, `cmd/clean`
2. checks out the PR branch
3. runs `arduino/setup-task` (uses `repo-token` to read the action release index)
4. runs `docker/setup-docker-action` + `docker/setup-buildx-action`
5. runs Task targets against the PR's mcp-registry tree

No GitHub API write. The third-party actions only read from the workflow context. `permissions: contents: read` at workflow scope captures that.

Style matches `security-review-trigger.yaml` (per-job `contents: read`), `security-review-changes.yaml`, `security-review-manual.yaml`, and the workflow-level block in `auto-merge-pins.yaml` (`contents: write, pull-requests: write, checks: read`).

`update-pins.yaml` is the other workflow without a permissions block but it's a 230-line cron-driven version-bumper that authenticates via the `MCP_REGISTRY_BOT` GitHub App; that one deserves a separate, more careful review.

No behavioural change.