### PR TITLE
Add dr-mcp MCP server

### DIFF
--- a/servers/dr-mcp/server.yaml
+++ b/servers/dr-mcp/server.yaml
@@ -1,0 +1,19 @@
+name: dr-mcp
+image: mcp/dr-mcp
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - mcp
+    - cleanup
+    - audit
+    - developer-tools
+    - coding-agents
+about:
+  title: dr-mcp
+  description: Clean and audit messy MCP setups. Detect stale, unused, abandoned, context-heavy, duplicate, broken, and outdated MCP servers, then generate safe repair plans.
+  icon: https://raw.githubusercontent.com/Inferensys/dr-mcp/main/docs/logo.png
+source:
+  project: https://github.com/Inferensys/dr-mcp
+  branch: main
+  commit: 4090536d154b75f239b5b3c6513b504f986661cd


### PR DESCRIPTION
## Summary

Adds `dr-mcp` to the Docker MCP Registry.

dr-mcp is a local-first MCP cleanup and audit server for developer MCP setups. It detects stale, unused, abandoned, context-heavy, duplicate, broken, and outdated MCP servers, then generates safe repair plans.

## Source

- Project: https://github.com/Inferensys/dr-mcp
- npm: https://www.npmjs.com/package/@inferensys/dr-mcp
- Official MCP Registry: `io.github.Inferensys/dr-mcp`

## Verification

- Added Dockerfile upstream in `Inferensys/dr-mcp`.
- Built local image from source repo with `docker build -t dr-mcp:local .`.
- Verified CLI with `docker run --rm dr-mcp:local --help`.
- Verified MCP stdio `tools/list` against the local Docker image.
- Parsed `servers/dr-mcp/server.yaml` successfully with Ruby Psych.
