### PR TITLE
Add SousChef MCP server

### DIFF
--- a/servers/souschef/server.yaml
+++ b/servers/souschef/server.yaml
@@ -1,0 +1,19 @@
+name: souschef
+image: mcp/souschef
+type: server
+meta:
+  category: devops
+  tags:
+    - souschef
+    - devops
+    - ansible
+    - chef
+    - migration
+about:
+  title: SousChef
+  description: Multi-platform to Ansible migration and Ansible upgrade planning MCP server.
+  icon: https://avatars.githubusercontent.com/u/2867691?v=4
+source:
+  project: https://github.com/kpeacocke/souschef
+  branch: main
+  commit: ab599cf03994e25516f81bb05240e44d83520d38

--- a/servers/souschef/server.yaml
+++ b/servers/souschef/server.yaml
@@ -16,4 +16,4 @@ about:
 source:
   project: https://github.com/kpeacocke/souschef
   branch: main
-  commit: ab599cf03994e25516f81bb05240e44d83520d38
+  commit: 08305d25262504699a3e39708b23b1ea82ac8f28


### PR DESCRIPTION
## MCP Server Information

**Server Name:** SousChef

**Repository URL:** https://github.com/kpeacocke/souschef

**Brief Description:** AI-powered MCP server for Chef, SaltStack, Puppet, PowerShell, and Bash to Ansible migration, plus Ansible upgrade planning. Verified from [README](https://github.com/kpeacocke/souschef/blob/main/README.md) and [pyproject.toml](https://github.com/kpeacocke/souschef/blob/main/pyproject.toml).

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT in [LICENSE](https://github.com/kpeacocke/souschef/blob/main/LICENSE)).
- [x] **MCP Compliant**: `pyproject.toml` exposes the MCP entrypoint (`souschef-mcp = "souschef.server:main"`) and the [Dockerfile](https://github.com/kpeacocke/souschef/blob/main/Dockerfile) starts the MCP server with `python -m souschef.server`.
- [x] **Active Development**: The updated [README](https://github.com/kpeacocke/souschef/blob/main/README.md) no longer contains the prior maintenance-mode wording, and the repo shows recent commits on 2026-08-10: https://github.com/kpeacocke/souschef/commit/5d774c7721f28257daf7d071b785ff33dff8ad71, https://github.com/kpeacocke/souschef/commit/fd226e06b0f6ee386222a0d176edd345aadfa7a5, https://github.com/kpeacocke/souschef/commit/b0004c04de7d7bf290be24fb15ebdfde1985ca25.
- [x] **Docker Artifact**: Root [Dockerfile](https://github.com/kpeacocke/souschef/blob/main/Dockerfile) present.
- [x] **Documentation**: [README](https://github.com/kpeacocke/souschef/blob/main/README.md) includes installation/setup instructions and links to configuration docs; [pyproject.toml](https://github.com/kpeacocke/souschef/blob/main/pyproject.toml) also points to the project documentation site.
- [x] **Security Contact**: [SECURITY.md](https://github.com/kpeacocke/souschef/blob/main/SECURITY.md) documents private reporting via GitHub Security Advisories or email.

## Submitter Checklist

- [x] This server meets the basic requirements listed above.
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name souschef`.
- [x] I have built the MCP Server using `task build -- --tools souschef`.
- [x] I have shared test credentials using this form (not required for this server; no credentials were needed).

## Notes

- `task validate -- --name souschef` passed locally.
- `task build -- --tools souschef` now passes after:
  - pinning `mcp` to `<2.0.0` in [pyproject.toml](https://github.com/kpeacocke/souschef/blob/main/pyproject.toml)
  - updating [souschef/server.py](https://github.com/kpeacocke/souschef/blob/main/souschef/server.py) to import `FastMCP` from `mcp.server.fastmcp`
  - refreshing [poetry.lock](https://github.com/kpeacocke/souschef/blob/main/poetry.lock)
- No test credentials were needed for validation or build.