### PR TITLE
Add ai-seo MCP server

### DIFF
--- a/servers/ai-seo/server.yaml
+++ b/servers/ai-seo/server.yaml
@@ -1,0 +1,18 @@
+name: ai-seo
+image: mcp/ai-seo
+type: server
+meta:
+  category: marketing
+  tags:
+    - marketing
+    - seo
+    - aeo
+    - geo
+    - ai-search
+about:
+  title: AI-SEO
+  description: AI Citation Toolkit - audit, score, and rewrite web pages for AI-citation eligibility (AEO/GEO/LLM visibility). Read-only, no API keys.
+  icon: https://avatars.githubusercontent.com/u/284312388?s=200&v=4
+source:
+  project: https://github.com/AutomateLab-tech/ai-seo
+  commit: d86751f983c813dd83b5518a59d1e5ba45b181f6

--- a/servers/ai-seo/server.yaml
+++ b/servers/ai-seo/server.yaml
@@ -14,5 +14,5 @@ about:
   description: AI Citation Toolkit - audit, score, and rewrite web pages for AI-citation eligibility (AEO/GEO/LLM visibility). Read-only, no API keys.
   icon: https://avatars.githubusercontent.com/u/284312388?s=200&v=4
 source:
-  project: https://github.com/AutomateLab-tech/ai-seo
-  commit: d86751f983c813dd83b5518a59d1e5ba45b181f6
+  project: https://github.com/AutomateLab-tech/ai-seo-mcp
+  commit: 84d74d43e2d59cfbabc88b4360bf669ce9923696


### PR DESCRIPTION
Adds the **ai-seo** MCP server - the AI Citation Toolkit. Audits, scores, and rewrites web pages for AI-citation eligibility (AEO/GEO/LLM visibility). Read-only, no API keys, no secrets.

- **Source:** https://github.com/AutomateLab-tech/ai-seo
- **npm:** [`@automatelab/ai-seo-mcp`](https://www.npmjs.com/package/@automatelab/ai-seo-mcp)
- **License:** MIT
- **Transport:** stdio
- **Category:** marketing
- **Tools (14):** audit_page, audit_schema, audit_canonical, check_robots, check_sitemap, check_technical, score_ai_overview_eligibility, score_citation_worthiness, generate_llms_txt, validate_llms_txt, rewrite_for_aeo, rewrite_for_geo, extract_entities, diff_pages

No config, no env vars, no secrets required - the server lists tools immediately on startup.