### PR TITLE
Add MCHS MCP server

### DIFF
--- a/servers/mchs/readme.md
+++ b/servers/mchs/readme.md
@@ -1,0 +1,10 @@
+# MCHS NWAU Calculator MCP
+
+MCHS exposes a stdio MCP server for calculator schemas, validation, support
+status, and release evidence. The MCP adapter is intentionally thin and does not
+duplicate calculator formula logic.
+
+The local Docker path runs `mchs-mcp` inside a container. Discovery and read-only
+metadata calls do not require secrets. Do not send private healthcare data,
+patient-level records, or institutional costing submissions to public catalog
+validation environments.

--- a/servers/mchs/server.yaml
+++ b/servers/mchs/server.yaml
@@ -1,0 +1,21 @@
+name: mchs
+image: mcp/mchs
+type: server
+meta:
+  category: analytics
+  tags:
+    - healthcare
+    - analytics
+    - nwau
+    - calculator
+    - mcp
+about:
+  title: MCHS NWAU Calculator
+  description: Stdio MCP server for MCHS calculator schemas, validation, support status, and release evidence. It does not claim official IHACPA endorsement and does not bundle private healthcare data.
+  icon: https://avatars.githubusercontent.com/edithatogo
+source:
+  project: https://github.com/edithatogo/mchs
+  branch: master
+  commit: a33823b0b607b42e7bf2782bd9a513b01434e3ce
+config:
+  description: No secrets are required for MCP discovery or read-only metadata calls.

--- a/servers/mchs/tools.json
+++ b/servers/mchs/tools.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "mchs.list_calculators",
+    "description": "List calculators available through the MCHS MCP boundary.",
+    "arguments": [
+      {"name": "year", "type": "string", "desc": "Optional supported year filter."}
+    ]
+  },
+  {
+    "name": "mchs.get_schema",
+    "description": "Return a canonical schema for a calculator input or output.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "direction", "type": "string", "desc": "input or output."}
+    ]
+  },
+  {
+    "name": "mchs.validate_input",
+    "description": "Validate a calculator request at the MCP contract boundary.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "year", "type": "string", "desc": "Supported year."},
+      {"name": "inputs", "type": "object", "desc": "Calculator input object."}
+    ]
+  },
+  {
+    "name": "mchs.calculate",
+    "description": "Validate and delegate a calculation request.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "year", "type": "string", "desc": "Supported year."},
+      {"name": "inputs", "type": "object", "desc": "Calculator input object."}
+    ]
+  },
+  {
+    "name": "mchs.explain_result",
+    "description": "Explain the MCP boundary steps for a calculation request.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "year", "type": "string", "desc": "Supported year."},
+      {"name": "inputs", "type": "object", "desc": "Calculator input object."}
+    ]
+  },
+  {
+    "name": "mchs.get_evidence",
+    "description": "Return release and MCP registry evidence.",
+    "arguments": [
+      {"name": "bundleId", "type": "string", "desc": "Optional evidence bundle id."}
+    ]
+  }
+]

--- a/servers/mchs/tools.json
+++ b/servers/mchs/tools.json
@@ -3,7 +3,7 @@
     "name": "mchs.list_calculators",
     "description": "List calculators available through the MCHS MCP boundary.",
     "arguments": [
-      {"name": "year", "type": "string", "desc": "Optional supported year filter."}
+      {"name": "year", "type": "string", "desc": "Optional supported year filter.", "optional": true}
     ]
   },
   {
@@ -45,7 +45,7 @@
     "name": "mchs.get_evidence",
     "description": "Return release and MCP registry evidence.",
     "arguments": [
-      {"name": "bundleId", "type": "string", "desc": "Optional evidence bundle id."}
+      {"name": "bundleId", "type": "string", "desc": "Optional evidence bundle id.", "optional": true}
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds the MCHS NWAU Calculator MCP server to the Docker MCP Registry as a local Docker-backed server.

## Server

- Name: `mchs`
- Image: `mcp/mchs`
- Source: https://github.com/edithatogo/mchs
- Source commit: `a33823b0b607b42e7bf2782bd9a513b01434e3ce`
- Runtime: stdio MCP entry point `mchs-mcp`
- Secrets: none required for discovery or read-only metadata calls

## Validation evidence

From the Docker MCP Registry checkout:

```text
$ task validate -- --name mchs
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid
```

From the source repository clean checkout:

```text
$ docker build -t mchs-mcp:local .
Successfully built and tagged mchs-mcp:local

$ python3 scripts/smoke_mcp_container.py mchs-mcp:local
# passed

$ PYTHONPATH=. uv run pytest tests/test_mcp_server.py
13 passed

$ uv run ruff check nwau_py/mcp_server.py tests/test_mcp_server.py
All checks passed!
```

## Known local tooling note

`task build -- --tools mchs` launched Docker BuildKit with the pinned remote git context but produced no output and had to be cancelled locally. The same source commit and Dockerfile build successfully from a clean local checkout, and the resulting image passes the repository MCP smoke test.
