### PR TITLE
feat: add geomelon-mcp server

### DIFF
--- a/servers/geomelon-mcp/server.yaml
+++ b/servers/geomelon-mcp/server.yaml
@@ -1,0 +1,21 @@
+name: geomelon-mcp
+image: mcp/geomelon-mcp
+type: server
+meta:
+  category: search
+  tags:
+    - geography
+    - cities
+    - countries
+about:
+  title: Geomelon
+  description: MCP server for the Geomelon geographic API that exposes cities, countries, regions, and languages as tools. Supports searching cities, looking up countries and regions, finding cities by coordinates, calculating distances, and more.
+  icon: https://raw.githubusercontent.com/930m310n/geomelon-mcp/main/icon.png
+source:
+  project: https://github.com/930m310n/geomelon-mcp
+  commit: 9b70af3bb0f28049bc15fdbbebc8dd7d78b998bc
+config:
+  secrets:
+    - name: geomelon-mcp.api_key
+      env: GEOMELON_API_KEY
+      example: your_rapidapi_key_here


### PR DESCRIPTION
## MCP Server Information

**Server Name:** geomelon-mcp
**Repository URL:** https://github.com/930m310n/geomelon-mcp
**Brief Description:** MCP server for the Geomelon geographic API that exposes cities, countries, regions, and languages as tools for MCP-compatible AI clients.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile added to the repo
- [x] **Documentation**: README with setup instructions
- [ ] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name geomelon-mcp`
- [ ] I have built the MCP Server using `task build -- --tools geomelon-mcp` (Docker daemon unavailable locally; Dockerfile is standard Node.js/tsup build)
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)