### PR TITLE
Add Bilig WorkPaper MCP server

### DIFF
--- a/servers/bilig-workpaper/readme.md
+++ b/servers/bilig-workpaper/readme.md
@@ -1,0 +1,12 @@
+# Bilig WorkPaper MCP
+
+Bilig WorkPaper gives MCP clients a formula-backed workbook runtime for agents and backend workflows. The server can read sheets and ranges, write individual cells, recalculate formulas, verify readback, and export the updated WorkPaper JSON document.
+
+Docker uses the `bilig-workpaper-mcp` image target from the Bilig source repository. For clients that support hosted MCP, the same package is published in the official MCP Registry with a Streamable HTTP remote endpoint at `https://bilig.proompteng.ai/mcp`.
+
+Documentation: https://proompteng.github.io/bilig/mcp-client-setup.html
+Remote MCP endpoint: https://bilig.proompteng.ai/mcp
+Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.proompteng%2Fbilig-workpaper&limit=100
+Smithery: https://smithery.ai/servers/gkonushev/bilig-workpaper
+Source: https://github.com/proompteng/bilig
+npm: https://www.npmjs.com/package/@bilig/workpaper

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/234536857?v=4
 source:
   project: https://github.com/proompteng/bilig
-  commit: efe72d5fbd7c0d6ac4832a1498f173e89a6164ea
+  commit: 35d4911c482dc124248516f552e415331da5b95d
   dockerfile: Dockerfile
   buildTarget: bilig-workpaper-mcp
 config:

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/234536857?v=4
 source:
   project: https://github.com/proompteng/bilig
-  commit: 26dabc39e4a73c5d287a7452b154072739ed7188
+  commit: 378cf322faa8ae211c305c75f597dd41ff67fea8
   dockerfile: Dockerfile
   buildTarget: bilig-workpaper-mcp
 config:

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -1,0 +1,22 @@
+name: bilig-workpaper
+image: mcp/bilig-workpaper
+type: server
+meta:
+  category: development
+  tags:
+    - development
+    - spreadsheet
+    - formulas
+    - workpaper
+    - agents
+about:
+  title: Bilig WorkPaper
+  description: "Formula WorkPaper MCP server for coding agents and Node services: edit cells, recalculate, verify readback, and persist JSON."
+  icon: https://avatars.githubusercontent.com/u/234536857?v=4
+source:
+  project: https://github.com/proompteng/bilig
+  commit: ace2fdce31d0bbb13ff270b517ffb730e0f1965a
+  dockerfile: Dockerfile
+  buildTarget: bilig-workpaper-mcp
+config:
+  description: Runs a writable demo WorkPaper JSON document for formula-backed workbook edits and readback.

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/234536857?v=4
 source:
   project: https://github.com/proompteng/bilig
-  commit: ace2fdce31d0bbb13ff270b517ffb730e0f1965a
+  commit: 4d2da4f86779d2d927b5c0fee46a4953b99960f8
   dockerfile: Dockerfile
   buildTarget: bilig-workpaper-mcp
 config:

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/234536857?v=4
 source:
   project: https://github.com/proompteng/bilig
-  commit: 378cf322faa8ae211c305c75f597dd41ff67fea8
+  commit: efe72d5fbd7c0d6ac4832a1498f173e89a6164ea
   dockerfile: Dockerfile
   buildTarget: bilig-workpaper-mcp
 config:

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -11,7 +11,7 @@ meta:
     - agents
 about:
   title: Bilig WorkPaper
-  description: "Formula WorkPaper MCP server for coding agents and Node services: edit cells, recalculate, verify readback, and persist JSON."
+  description: "Formula readback, input edits, JSON persistence, and verified workbook state for agents."
   icon: https://avatars.githubusercontent.com/u/234536857?v=4
 source:
   project: https://github.com/proompteng/bilig
@@ -19,4 +19,4 @@ source:
   dockerfile: Dockerfile
   buildTarget: bilig-workpaper-mcp
 config:
-  description: Runs a writable demo WorkPaper JSON document for formula-backed workbook edits and readback.
+  description: Runs a writable demo WorkPaper JSON document for formula-backed workbook edits, recalculation, and readback.

--- a/servers/bilig-workpaper/server.yaml
+++ b/servers/bilig-workpaper/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/234536857?v=4
 source:
   project: https://github.com/proompteng/bilig
-  commit: 4d2da4f86779d2d927b5c0fee46a4953b99960f8
+  commit: 26dabc39e4a73c5d287a7452b154072739ed7188
   dockerfile: Dockerfile
   buildTarget: bilig-workpaper-mcp
 config:

--- a/servers/bilig-workpaper/tools.json
+++ b/servers/bilig-workpaper/tools.json
@@ -1,0 +1,85 @@
+[
+  {
+    "name": "list_sheets",
+    "description": "Discover sheet names and used dimensions before reading or editing a WorkPaper."
+  },
+  {
+    "name": "read_range",
+    "description": "Read a WorkPaper range with calculated values, display text, formulas, and serialized cell contents.",
+    "arguments": [
+      {
+        "name": "range",
+        "type": "string",
+        "desc": "A1 range with optional sheet name, for example Summary!A1:B5."
+      }
+    ]
+  },
+  {
+    "name": "read_cell",
+    "description": "Read one cell with calculated value, display text, formula text, and serialized content.",
+    "arguments": [
+      {
+        "name": "sheetName",
+        "type": "string",
+        "desc": "Sheet name."
+      },
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "A1 cell address, for example B3."
+      }
+    ]
+  },
+  {
+    "name": "set_cell_contents",
+    "description": "Set one cell, recalculate dependent formulas, verify readback, and persist the WorkPaper JSON when writable.",
+    "arguments": [
+      {
+        "name": "sheetName",
+        "type": "string",
+        "desc": "Sheet name."
+      },
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "A1 cell address to edit."
+      },
+      {
+        "name": "value",
+        "type": "string | number | boolean | null",
+        "desc": "Raw replacement cell content. Formula strings must start with =."
+      }
+    ]
+  },
+  {
+    "name": "get_cell_display_value",
+    "description": "Return the display text for one WorkPaper cell after calculation.",
+    "arguments": [
+      {
+        "name": "sheetName",
+        "type": "string",
+        "desc": "Sheet name."
+      },
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "A1 cell address."
+      }
+    ]
+  },
+  {
+    "name": "export_workpaper_document",
+    "description": "Export the current WorkPaper document as JSON after edits and recalculation."
+  },
+  {
+    "name": "validate_formula",
+    "description": "Validate WorkPaper formula syntax before writing a formula to a cell.",
+    "arguments": [
+      {
+        "name": "formula",
+        "type": "string",
+        "desc": "Formula text to validate, including the leading =."
+      }
+    ]
+  }
+]

--- a/servers/bilig-workpaper/tools.json
+++ b/servers/bilig-workpaper/tools.json
@@ -52,6 +52,32 @@
     ]
   },
   {
+    "name": "set_cell_contents_and_readback",
+    "description": "Set one cell, recalculate formulas, and return the edited cell plus dependent readback evidence in one tool call.",
+    "arguments": [
+      {
+        "name": "sheetName",
+        "type": "string",
+        "desc": "Sheet name."
+      },
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "A1 cell address to edit."
+      },
+      {
+        "name": "value",
+        "type": "string | number | boolean | null",
+        "desc": "Raw replacement cell content. Formula strings must start with =."
+      },
+      {
+        "name": "readback",
+        "type": "string",
+        "desc": "A1 cell or range to read after recalculation, for example Summary!B3."
+      }
+    ]
+  },
+  {
     "name": "get_cell_display_value",
     "description": "Return the display text for one WorkPaper cell after calculation.",
     "arguments": [


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Bilig WorkPaper MCP
**Repository URL:** https://github.com/proompteng/bilig
**Brief Description:** Formula WorkPaper MCP server for coding agents and Node services: edit cells, recalculate formulas, verify readback, and persist WorkPaper JSON.

## Basic Requirements

- [x] **Open Source**: MIT licensed
- [x] **MCP Compliant**: exposes MCP tools for sheet/range reads, cell edits, combined edit-and-readback, display-value readback, formula validation, and WorkPaper JSON export
- [x] **Active Development**: Bilig has active releases and current package work
- [x] **Docker Artifact**: source repository has a `bilig-workpaper-mcp` Dockerfile target
- [x] **Documentation**: docs and setup guide are linked below
- [x] **Security Contact**: repository security policy is available through GitHub

## Links

Source: https://github.com/proompteng/bilig
Docs: https://proompteng.github.io/bilig/mcp-client-setup.html
Remote MCP endpoint: https://bilig.proompteng.ai/mcp
Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.proompteng%2Fbilig-workpaper&limit=100
Smithery: https://smithery.ai/servers/gkonushev/bilig-workpaper
npm: https://www.npmjs.com/package/@bilig/workpaper

## Public Package Evidence

Verified 2026-06-03:

- npm latest: `@bilig/workpaper@0.161.0`
- npm latest: `@bilig/workbook@0.161.0`
- npm latest: `@bilig/headless@0.161.0`
- Official MCP Registry latest-marked entry: `io.github.proompteng/bilig-workpaper@0.161.0`, package `@bilig/workpaper@0.161.0`, updated `2026-06-03T19:54:13.359111Z`
- Docker source pin: `proompteng/bilig@35d4911c482dc124248516f552e415331da5b95d`
- The pinned Bilig Dockerfile target installs `@bilig/workpaper@0.161.0` for `bilig-workpaper-mcp`.

One-command evaluator check, no clone required:

```sh
npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json
```

That evaluator verifies the file-backed MCP tool surface, resource/prompt listing, formula validation, dependent formula readback, persistence, export, restart readback, display-value readback, and prints `verified: true`.

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `go run ./cmd/validate --name bilig-workpaper`
- [x] I have built the MCP Server from the pinned source Docker target
- [x] This server does not require credentials to test

## Validation

- `npm view @bilig/workpaper version` -> `0.161.0`
- `npm view @bilig/workbook version` -> `0.161.0`
- `npm view @bilig/headless version` -> `0.161.0`
- Official MCP Registry API latest-marked entry -> server `0.161.0`, package `0.161.0`, active, remote `https://bilig.proompteng.ai/mcp`
- `npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json` -> `verified: true`, 8 tools, `afterRestart: 96000`
- `python3 -m json.tool servers/bilig-workpaper/tools.json`
- `git diff --check -- servers/bilig-workpaper`
- `go run ./cmd/validate --name bilig-workpaper`
- `go run ./cmd/catalog bilig-workpaper`
- `docker buildx build --builder desktop-linux --pull=false -f Dockerfile -t check -t mcp/bilig-workpaper --label org.opencontainers.image.revision=35d4911c482dc124248516f552e415331da5b95d --load --target bilig-workpaper-mcp https://github.com/proompteng/bilig.git#35d4911c482dc124248516f552e415331da5b95d`
- container `tools/list` smoke from `mcp/bilig-workpaper` -> 8 tools: `list_sheets`, `read_range`, `read_cell`, `set_cell_contents`, `set_cell_contents_and_readback`, `get_cell_display_value`, `export_workpaper_document`, `validate_formula`

The Docker build completed locally from the pinned Bilig source commit, installed `@bilig/workpaper@0.161.0`, and produced `mcp/bilig-workpaper`.