### PR TITLE
Add Memory Vault MCP server

### DIFF
--- a/servers/memory-vault/server.yaml
+++ b/servers/memory-vault/server.yaml
@@ -1,0 +1,52 @@
+name: memory-vault
+image: mcp/memory-vault
+type: server
+meta:
+    category: ai
+    tags:
+        - ai
+        - memory
+        - rag
+        - vector-search
+        - postgres
+        - pgvector
+        - self-hosted
+about:
+    title: Memory Vault
+    description: |
+        Local-first AI memory layer for Claude and other MCP clients. Hybrid search (semantic + keyword) over your knowledge base, backed by Postgres + pgvector. Self-hosted, MIT-licensed, no telemetry.
+    icon: https://avatars.githubusercontent.com/u/270030627?v=4
+source:
+    project: https://github.com/MihaiBuilds/memory-vault
+    commit: 5586ebc86179b03d353ecf02b3ffb91f87c56510
+    dockerfile: Dockerfile.mcp
+config:
+    description: Configure the connection to Memory Vault
+    secrets:
+        - name: memory-vault.db_password
+          env: DB_PASSWORD
+          example: memory_vault
+    env:
+        - name: DB_HOST
+          example: host.docker.internal
+          value: '{{memory-vault.db_host}}'
+        - name: DB_PORT
+          example: "5432"
+          value: '{{memory-vault.db_port}}'
+        - name: DB_NAME
+          example: memory_vault
+          value: '{{memory-vault.db_name}}'
+        - name: DB_USER
+          example: memory_vault
+          value: '{{memory-vault.db_user}}'
+    parameters:
+        type: object
+        properties:
+            db_host:
+                type: string
+            db_port:
+                type: string
+            db_name:
+                type: string
+            db_user:
+                type: string


### PR DESCRIPTION
## Summary

Adds **Memory Vault** — a local-first AI memory layer for Claude and other MCP clients. Hybrid search (semantic + keyword) over a personal knowledge base, backed by Postgres + pgvector. Self-hosted, MIT-licensed.

## Details

- **Server name:** `memory-vault`
- **Category:** `ai`
- **License:** MIT ✅
- **Source:** https://github.com/MihaiBuilds/memory-vault (pinned at commit `5586ebc`, which is the v1.0.6 release)
- **Dockerfile:** `Dockerfile.mcp` (a thin MCP-stdio-only variant — the main `Dockerfile` builds the full app with API + dashboard; the `.mcp` variant strips both and only ships the MCP server)
- **External dependencies:** Postgres + pgvector (configured via 4 env vars + 1 secret)

## Already in the official MCP Registry

Memory Vault is published in the official MCP Registry as `io.github.MihaiBuilds/memory-vault`:
https://registry.modelcontextprotocol.io/v0/servers?search=memory-vault

The OCI image at `ghcr.io/mihaibuilds/memory-vault-mcp:1.0.6` carries the matching `io.modelcontextprotocol.server.name` ownership label, verified by that registry at publish time.

## Verified locally

- `task wizard -- memory-vault` ✅ generated the initial `server.yaml`
- `task build -- memory-vault` ✅ Docker successfully built `mcp/memory-vault` from the pinned commit using `Dockerfile.mcp`
- `task catalog -- memory-vault` ✅ catalog entry generated cleanly (full source + license + stars + tags auto-detected)
- `task import` skipped — the Taskfile invokes a `docker mcp catalog import` subcommand that the current Docker MCP CLI no longer exposes (only `create`, `list`, `pull`, `push`, `remove`, `server`, `show`, `tag` are available). Likely a tooling-drift issue; happy to retry whatever the current import equivalent is if helpful.

## Image size note

The image is ~2.2 GB on linux/arm64. Bulk is from `torch` + `sentence-transformers` + `spacy` (required for the embedding pipeline). Size-optimization work (e.g. ONNX-quantized embeddings, runtime model download) is tracked for a future release.