### PR TITLE
feat: add evc-team-relay-mcp — collaborative Obsidian vault access

### DIFF
--- a/servers/evc-team-relay-mcp/server.yaml
+++ b/servers/evc-team-relay-mcp/server.yaml
@@ -1,0 +1,33 @@
+name: evc-team-relay-mcp
+image: mcp/evc-team-relay-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - obsidian
+    - productivity
+    - collaboration
+    - notes
+    - sync
+about:
+  title: EVC Team Relay MCP
+  description: Give your AI agent read/write access to your Obsidian vault via Team Relay — create, read, update, and sync notes with real-time CRDT-based conflict resolution.
+  icon: https://cdn.simpleicons.org/obsidian/7C3AED
+source:
+  project: https://github.com/entire-vc/evc-team-relay-mcp
+  branch: main
+config:
+  description: Configure your EVC Team Relay credentials and control plane URL
+  secrets:
+    - name: relay.password
+      env: RELAY_PASSWORD
+      example: YOUR_PASSWORD
+      description: Your EVC Team Relay account password
+  env:
+    - name: RELAY_CP_URL
+      example: https://cp.tr.entire.vc
+      value: https://cp.tr.entire.vc
+      description: Team Relay control plane URL
+    - name: RELAY_EMAIL
+      example: you@example.com
+      description: Your EVC Team Relay account email


### PR DESCRIPTION
## Summary

Adds [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the Docker MCP Registry.

### What it does
Give your AI agent read/write access to your Obsidian vault via Team Relay — create, read, update, and sync notes with real-time CRDT-based conflict resolution.

### Details
- **Category:** productivity
- **Transport:** HTTP (port 8888)
- **Auth:** RELAY_EMAIL + RELAY_PASSWORD credentials
- **PyPI:** `pip install evc-team-relay-mcp`
- **License:** MIT
- **Language:** Python 3.10+
- **Dockerfile:** yes (in repo root)

### Required config
- `RELAY_CP_URL` (default: https://cp.tr.entire.vc)
- `RELAY_EMAIL` — account email
- `RELAY_PASSWORD` (secret) — account password