### PR TITLE
Add Ejentum Reasoning Harness to mcp-registry

### DIFF
--- a/servers/ejentum/readme.md
+++ b/servers/ejentum/readme.md
@@ -1,0 +1,3 @@
+Docs: https://ejentum.com/docs/mcp_guide
+
+Auth: `Authorization: Bearer EJENTUM_API_KEY` (https://ejentum.com/auth/register).

--- a/servers/ejentum/server.yaml
+++ b/servers/ejentum/server.yaml
@@ -1,0 +1,20 @@
+name: ejentum
+type: remote
+meta:
+  category: ai
+  tags:
+    - ai
+    - agents
+    - reasoning
+    - anti-deception
+    - cognitive-harness
+    - remote
+about:
+  title: Ejentum Reasoning Harness
+  description: Pre-generation cognitive scaffolds across four harness modes (reasoning, code, anti-deception, memory). Each call returns a named failure pattern, executable procedure, suppression vector, and falsification test.
+  icon: https://www.google.com/s2/favicons?domain=ejentum.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://api.ejentum.com/mcp
+source:
+  project: https://github.com/ejentum/ejentum-mcp

--- a/servers/ejentum/tools.json
+++ b/servers/ejentum/tools.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "harness_reasoning",
+    "description": "Retrieve a reasoning scaffold for analytical, planning, or multi-step decision tasks.",
+    "arguments": []
+  },
+  {
+    "name": "harness_code",
+    "description": "Retrieve an engineering scaffold for code generation, refactoring, or architecture tasks.",
+    "arguments": []
+  },
+  {
+    "name": "harness_anti_deception",
+    "description": "Retrieve an integrity scaffold for validation requests, ethical reasoning, or adversarial framings.",
+    "arguments": []
+  },
+  {
+    "name": "harness_memory",
+    "description": "Retrieve a perception scaffold for memory decisions and multi-turn context tracking.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ejentum
**Repository URL:** https://github.com/ejentum/ejentum-mcp
**Brief Description:** Pre-generation cognitive scaffolds across four harness modes (reasoning, code, anti-deception, memory). Each call returns a named failure pattern, executable procedure, suppression vector, and falsification test.

Remote streamable-HTTP endpoint at `https://api.ejentum.com/mcp`. Auth via `Authorization: Bearer EJENTUM_API_KEY` (free tier with 100 calls at `https://ejentum.com/auth/register`). Already published on the Official MCP Registry (`io.github.ejentum/ejentum-mcp`), Smithery, Glama, mcp.so, PulseMCP, and Continue Hub.

## Basic Requirements

- [x] **Open Source**: MIT (server, MCP wrapper, and skill files)
- [x] **MCP Compliant**: Implements MCP 2025-06-18 over streamable-HTTP; verified `initialize` / `tools/list` / `tools/call` round-trips against the live endpoint
- [x] **Active Development**: Source at `github.com/ejentum/ejentum-mcp` (recent commits, weekly releases since 2026-05-06)
- [ ] **Docker Artifact**: N/A — remote server, no container required
- [x] **Documentation**: https://ejentum.com/docs/mcp_guide (client-by-client install for Cursor, Claude Desktop, Cline, Windsurf, Continue, Zed, Claude Code, n8n)
- [x] **Security Contact**: `info@ejentum.com`; GitHub issues at `github.com/ejentum/ejentum-mcp/issues`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I have tested the MCP Server using `task validate -- --name ejentum` — ran `go run ./cmd/validate --name ejentum` locally; all 12 checks green (name, directory, title, YAML formatting, commit pin, secrets, config env, license, icon, tools.json (4 tools found), remote, OAuth dynamic config)
- [ ] I have built the MCP Server using `task build -- --tools ejentum` — N/A for remote servers (no image to build)
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6) — alternatively, a test key can be self-provisioned in <60s at `ejentum.com/auth/register` (free 100-call tier, no card)

## Notes for the reviewer

- The remote endpoint uses Bearer-token auth (the registry schema documents `oauth:` for remote, no explicit block for header-Bearer). I left auth declared in `readme.md` rather than fabricating a config shape. Happy to add a `config.secrets` block in the form you prefer.
- `tools.json` is populated (not empty) to give the Docker MCP Toolkit useful tool metadata at install time, matching the `notion-remote` precedent.
- Category `ai` follows the `apollo-mcp-server` precedent. `productivity` or `ai-ml` would also fit if you prefer.
- Local validation passed all 12 checks (`go run ./cmd/validate --name ejentum`).
