### PR TITLE
feat: make grafana use service account token env var

### DIFF
--- a/servers/grafana/server.yaml
+++ b/servers/grafana/server.yaml
@@ -20,7 +20,7 @@ config:
   description: Configure the connection to Grafana
   secrets:
     - name: grafana.api_key
-      env: GRAFANA_API_KEY
+      env: GRAFANA_SERVICE_ACCOUNT_TOKEN
       example: <your service account token>
   env:
     - name: GRAFANA_URL


### PR DESCRIPTION
## Summary

Grafana mcp has deprecated the use of `GRAFANA_API_KEY` and changed it `GRAFANA_SERVICE_ACCOUNT_TOKEN` 