### PR TITLE
Add Dart and Flutter MCP server

### DIFF
--- a/servers/dart-flutter/server.yaml
+++ b/servers/dart-flutter/server.yaml
@@ -1,0 +1,37 @@
+name: dart-flutter
+image: ghcr.io/cirruslabs/flutter:stable
+type: server
+meta:
+  category: devops
+  tags:
+    - dart
+    - flutter
+    - development
+about:
+  title: Dart and Flutter
+  description: Exposes Dart and Flutter development tools for project analysis, package search, dependency management, testing, formatting, and running app introspection.
+  icon: https://avatars.githubusercontent.com/u/1609975?s=200&v=4
+source:
+  project: https://github.com/dart-lang/ai
+  commit: cc2d19a0e676f450f4b361435d8e3461d3bfc90a
+  directory: pkgs/dart_mcp_server
+run:
+  command:
+    - dart
+    - mcp-server
+    - --force-roots-fallback
+  volumes:
+    - "{{dart-flutter.project_paths|volume|into}}"
+config:
+  description: Configure local Dart and Flutter project paths that the MCP server can access.
+  parameters:
+    type: object
+    properties:
+      project_paths:
+        type: array
+        items:
+          type: string
+        default:
+          - /Users/local-test
+    required:
+      - project_paths


### PR DESCRIPTION
## MCP Server Information

**Server Name:** dart-flutter
**Repository URL:** https://github.com/dart-lang/ai/tree/cc2d19a0e676f450f4b361435d8e3461d3bfc90a/pkgs/dart_mcp_server
**Brief Description:** Official Dart Tooling MCP Server exposing Dart and Flutter development tools to MCP clients.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (BSD-3-Clause)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Runs through a container image (`ghcr.io/cirruslabs/flutter:stable`)
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Dart security policy is available at https://dart.dev/security

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `go run ./cmd/validate --name dart-flutter` (`task` equivalent)
- [x] I have built the MCP Server using `go run ./cmd/build --tools --pull-community dart-flutter` (`task` equivalent for a non-`mcp/` image)
- [x] If the server requires credentials to test it, I have shared test credentials using this form (not applicable)

## Validation

- `go run ./cmd/validate --name dart-flutter`
- `go test ./...`
- `go run ./cmd/build --tools --pull-community dart-flutter` (13 tools found)
- `go run ./cmd/catalog dart-flutter`

## Notes

An existing `dart` entry already points to the Dart AI product, so this entry uses `dart-flutter` for the official Dart and Flutter tooling server.
