### PR TITLE
Add mcpproxy — local-first MCP proxy with BM25 tool discovery and security quarantine

### DIFF
--- a/servers/mcpproxy/server.yaml
+++ b/servers/mcpproxy/server.yaml
@@ -1,0 +1,19 @@
+name: mcpproxy
+image: mcp/mcpproxy
+type: server
+longLived: true
+meta:
+  category: devops
+  tags:
+    - proxy
+    - gateway
+    - tool-discovery
+    - security
+    - devops
+about:
+  title: Smart Proxy Gateway
+  description: Local-first proxy/gateway with BM25 tool discovery (~99% token savings), security quarantine, tool-poisoning protection, sensitive-data scanning, Docker isolation, and OAuth.
+  icon: https://www.google.com/s2/favicons?domain=mcpproxy.app&sz=64
+source:
+  project: https://github.com/smart-mcp-proxy/mcpproxy-go
+  commit: 1356c60fc9fca6a27070a34bbfed07e33eeb6888

--- a/servers/mcpproxy/tools.json
+++ b/servers/mcpproxy/tools.json
@@ -1,0 +1,128 @@
+[
+  {
+    "name": "retrieve_tools",
+    "description": "BM25 keyword search across all upstream MCP server tools. Returns the most relevant tools with annotations and recommended tool variant. Saves ~99% of tokens compared to listing all tools.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Keyword query to search for relevant tools (e.g. 'create pull request', 'read file')"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of tools to return (default: 10)"
+      },
+      {
+        "name": "include_disabled",
+        "type": "boolean",
+        "desc": "When true, also returns disabled/locked tools with remediation hints"
+      }
+    ]
+  },
+  {
+    "name": "call_tool_read",
+    "description": "Proxy a read-only tool call to an upstream MCP server. Use for tools that only read or query data without making changes.",
+    "arguments": [
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Name of the upstream MCP server (e.g. 'github')"
+      },
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": "Name of the tool to call on the upstream server"
+      },
+      {
+        "name": "arguments",
+        "type": "object",
+        "desc": "Tool arguments as a JSON object passed to the upstream tool"
+      }
+    ]
+  },
+  {
+    "name": "call_tool_write",
+    "description": "Proxy a write tool call to an upstream MCP server. Use for tools that create or modify data.",
+    "arguments": [
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Name of the upstream MCP server (e.g. 'github')"
+      },
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": "Name of the tool to call on the upstream server"
+      },
+      {
+        "name": "arguments",
+        "type": "object",
+        "desc": "Tool arguments as a JSON object passed to the upstream tool"
+      }
+    ]
+  },
+  {
+    "name": "call_tool_destructive",
+    "description": "Proxy a destructive tool call to an upstream MCP server. Use for tools that delete or irreversibly modify data.",
+    "arguments": [
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Name of the upstream MCP server (e.g. 'github')"
+      },
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": "Name of the tool to call on the upstream server"
+      },
+      {
+        "name": "arguments",
+        "type": "object",
+        "desc": "Tool arguments as a JSON object passed to the upstream tool"
+      }
+    ]
+  },
+  {
+    "name": "upstream_servers",
+    "description": "CRUD operations for managing upstream MCP server connections. List, add, update, or remove upstream servers.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "Action to perform: list, get, add, update, delete, enable, disable"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name of the upstream server (required for get, add, update, delete, enable, disable)"
+      },
+      {
+        "name": "config",
+        "type": "object",
+        "desc": "Server configuration object for add/update actions (url, command, args, protocol, etc.)"
+      }
+    ]
+  },
+  {
+    "name": "quarantine_security",
+    "description": "Security quarantine management. List quarantined servers, inspect pending or changed tools, approve individual tools or all tools for a server.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "Action to perform: list, inspect, approve, approve-all"
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Name of the upstream server to inspect or approve"
+      },
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": "Name of the specific tool to approve (for approve action)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcpproxy
**Repository URL:** https://github.com/smart-mcp-proxy/mcpproxy-go
**Brief Description:** Local-first MCP proxy/gateway with BM25 tool discovery (~99% token savings), security quarantine, tool-poisoning protection, sensitive-data scanning, Docker isolation, and OAuth.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP via Streamable HTTP at `/mcp`; exposes `retrieve_tools`, `call_tool_read/write/destructive`, `upstream_servers`, `quarantine_security`
- [x] **Active Development**: Active — latest release v0.33.1 (2026-05-20)
- [x] **Docker Artifact**: Dockerfile at repo root builds the server edition
- [x] **Documentation**: Full README + https://mcpproxy.app
- [x] **Security Contact**: GitHub Issues on the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcpproxy` (all 11 checks pass)
- [x] `tools.json` is provided to bypass `task build --tools` execution (the server is a meta-proxy that requires upstream connections, so no tools are reachable without configuration)
- [ ] If the server requires credentials to test it, I have shared test credentials using the form

## Notes

- **Type**: local/containerized server edition built from the repo Dockerfile (server edition build tag)
- **No credentials required**: the MCP endpoint (`/mcp`) is unauthenticated by default; an API key is auto-generated for the REST API but is not needed for MCP tool access
- **tools.json rationale**: mcpproxy is a gateway — without upstream servers configured, its built-in tools respond normally but cannot proxy any calls. The `tools.json` lists the 6 built-in MCP tools accurately; `task build --tools` is bypassed per the documented approach for servers that require configuration before tool listing
- **Pinned commit**: `1356c60fc9fca6a27070a34bbfed07e33eeb6888` = tag v0.33.1 (latest stable release, 2026-05-20)