### PR TITLE
Add MCHS MCP server

### DIFF
--- a/servers/mchs/readme.md
+++ b/servers/mchs/readme.md
@@ -1,0 +1,10 @@
+# MCHS NWAU Calculator MCP
+
+MCHS exposes a stdio MCP server for calculator schemas, validation, support
+status, and release evidence. The MCP adapter is intentionally thin and does not
+duplicate calculator formula logic.
+
+The local Docker path runs `mchs-mcp` inside a container. Discovery and read-only
+metadata calls do not require secrets. Do not send private healthcare data,
+patient-level records, or institutional costing submissions to public catalog
+validation environments.

--- a/servers/mchs/server.yaml
+++ b/servers/mchs/server.yaml
@@ -1,0 +1,21 @@
+name: mchs
+image: mcp/mchs
+type: server
+meta:
+  category: analytics
+  tags:
+    - healthcare
+    - analytics
+    - nwau
+    - calculator
+    - mcp
+about:
+  title: MCHS NWAU Calculator
+  description: Stdio MCP server for MCHS calculator schemas, validation, support status, and release evidence. It does not claim official IHACPA endorsement and does not bundle private healthcare data.
+  icon: https://avatars.githubusercontent.com/edithatogo
+source:
+  project: https://github.com/edithatogo/mchs
+  branch: master
+  commit: 0401b673f62aefa3976cf43ca6cfd00bab96bcf4
+config:
+  description: No secrets are required for MCP discovery or read-only metadata calls.

--- a/servers/mchs/tools.json
+++ b/servers/mchs/tools.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "mchs.list_calculators",
+    "description": "List calculators available through the MCHS MCP boundary.",
+    "arguments": [
+      {"name": "year", "type": "string", "desc": "Optional supported year filter.", "optional": true}
+    ]
+  },
+  {
+    "name": "mchs.get_schema",
+    "description": "Return a canonical schema for a calculator input or output.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "direction", "type": "string", "desc": "input or output."}
+    ]
+  },
+  {
+    "name": "mchs.validate_input",
+    "description": "Validate a calculator request at the MCP contract boundary.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "year", "type": "string", "desc": "Supported year."},
+      {"name": "inputs", "type": "object", "desc": "Calculator input object."}
+    ]
+  },
+  {
+    "name": "mchs.calculate",
+    "description": "Validate and delegate a calculation request.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "year", "type": "string", "desc": "Supported year."},
+      {"name": "inputs", "type": "object", "desc": "Calculator input object."}
+    ]
+  },
+  {
+    "name": "mchs.explain_result",
+    "description": "Explain the MCP boundary steps for a calculation request.",
+    "arguments": [
+      {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
+      {"name": "year", "type": "string", "desc": "Supported year."},
+      {"name": "inputs", "type": "object", "desc": "Calculator input object."}
+    ]
+  },
+  {
+    "name": "mchs.get_evidence",
+    "description": "Return release and MCP registry evidence.",
+    "arguments": [
+      {"name": "bundleId", "type": "string", "desc": "Optional evidence bundle id.", "optional": true}
+    ]
+  }
+]

--- a/servers/mchs/tools.json
+++ b/servers/mchs/tools.json
@@ -11,7 +11,7 @@
     "description": "Return a canonical schema for a calculator input or output.",
     "arguments": [
       {"name": "calculatorId", "type": "string", "desc": "Calculator identifier."},
-      {"name": "direction", "type": "string", "desc": "input or output."}
+      {"name": "direction", "type": "string", "desc": "Optional direction enum: input or output.", "optional": true}
     ]
   },
   {


### PR DESCRIPTION
Adds the MCHS Health Services Microcosting MCP server to the Docker MCP Registry.

Validation performed locally:
- `go run ./cmd/validate --name mchs` passed.
- Docker image build from current MCHS master passed locally as `mchs-mcp:master`.
- Container stdio smoke test passed for MCP `initialize` and `tools/list`.

Note: local `go run ./cmd/build --tools mchs` could not resolve the raw Git SHA through BuildKit in this environment even though `git ls-remote` confirms the SHA is on `edithatogo/mchs` master. The candidate includes `tools.json` fallback metadata and a pinned source commit.
