### PR TITLE
Add CONFLUENCE_SSL_VERIFY and JIRA_SSL_VERIFY env vars to atlassian server

### DIFF
--- a/servers/atlassian/server.yaml
+++ b/servers/atlassian/server.yaml
@@ -43,6 +43,12 @@ config:
     - name: JIRA_USERNAME
       example: your.email@company.com
       value: "{{atlassian.jira.username}}"
+    - name: CONFLUENCE_SSL_VERIFY
+      example: "true"
+      value: "{{atlassian.confluence.ssl_verify}}"
+    - name: JIRA_SSL_VERIFY
+      example: "true"
+      value: "{{atlassian.jira.ssl_verify}}"
   parameters:
     type: object
     properties:
@@ -53,6 +59,9 @@ config:
             type: string
           username:
             type: string
+          ssl_verify:
+            type: boolean
+            description: Verify SSL certificates for Confluence (set to false for self-signed or corporate CA certificates)
         required:
           - url
       jira:
@@ -62,6 +71,9 @@ config:
             type: string
           username:
             type: string
+          ssl_verify:
+            type: boolean
+            description: Verify SSL certificates for Jira (set to false for self-signed or corporate CA certificates)
         required:
           - url
     anyOf:


### PR DESCRIPTION
## Summary

The upstream [`sooperset/mcp-atlassian`](https://github.com/sooperset/mcp-atlassian) server already supports `JIRA_SSL_VERIFY` and `CONFLUENCE_SSL_VERIFY` environment variables to allow connecting to Jira Server/Data Center instances with self-signed or corporate CA certificates. These variables were not exposed in the Docker MCP catalog manifest, forcing enterprise users to manually patch their local catalog after every Docker Desktop update.

This PR exposes both env vars in `servers/atlassian/server.yaml` so they are configurable through the standard UI.

## Changes

**File**: `servers/atlassian/server.yaml`

- Added `CONFLUENCE_SSL_VERIFY` and `JIRA_SSL_VERIFY` to the `env` section
- Added `ssl_verify` boolean property to `parameters.properties.confluence.properties` and `parameters.properties.jira.properties`

## Upstream Evidence

- [`sooperset/mcp-atlassian` `.env.example` L108-109](https://github.com/sooperset/mcp-atlassian/blob/main/.env.example#L108-L109): documents both vars as Server/DC-specific settings
- [`jira/config.py` L236](https://github.com/sooperset/mcp-atlassian/blob/main/src/mcp_atlassian/jira/config.py#L236): `ssl_verify = is_env_ssl_verify("JIRA_SSL_VERIFY")`
- [`confluence/config.py` L163](https://github.com/sooperset/mcp-atlassian/blob/main/src/mcp_atlassian/confluence/config.py#L163): `ssl_verify = is_env_ssl_verify("CONFLUENCE_SSL_VERIFY")`

## Fixes

Closes #3302