### PR TITLE
ci: declare workflow-level `contents: read` on ci and update-pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "Code and Server Validation"

--- a/.github/workflows/update-pins.yaml
+++ b/.github/workflows/update-pins.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: update-pins
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   update-pins:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Both workflows run validation; no GitHub API writes from the workflows.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.