### PR TITLE
Add Content Distribution MCP

### DIFF
--- a/servers/content-distribution-mcp/server.yaml
+++ b/servers/content-distribution-mcp/server.yaml
@@ -1,0 +1,31 @@
+name: content-distribution-mcp
+image: mcp/content-distribution-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - social-media
+    - content-distribution
+    - publishing
+    - automation
+about:
+  title: Content Distribution MCP
+  description: Publish one piece of content to DEV.to, Hashnode, GitHub Discussions, Reddit, Bluesky, LinkedIn, Medium, and Twitter with idempotent state and per-platform adaptation.
+  icon: https://avatars.githubusercontent.com/u/284312388?s=200&v=4
+source:
+  project: https://github.com/AutomateLab-tech/content-distribution-mcp
+  commit: 936209882a15af5eeb3f14a94bfb4e0323b38258
+run:
+  volumes:
+    - "{{content-distribution-mcp.backend_dir}}:/data"
+config:
+  description: Configure the Content Distribution MCP server. Requires a profiles.yaml file in the backend directory containing platform credentials.
+  parameters:
+    type: object
+    properties:
+      backend_dir:
+        type: string
+        description: Path to the directory where distribution profiles and publish state are stored (e.g. ~/.distribution-mcp). Must contain a profiles.yaml file with platform API credentials.
+    required:
+      - backend_dir


### PR DESCRIPTION
Adds [AutomateLab-tech/content-distribution-mcp](https://github.com/AutomateLab-tech/content-distribution-mcp) as a local containerized MCP server.

**What it does:** Publish one piece of content to DEV.to, Hashnode, GitHub Discussions, Reddit, Bluesky, LinkedIn, Medium, and Twitter with idempotent state and per-platform adaptation. One MCP tool call fans out to all configured platforms.

- **Type:** Local server (containerized, stdio transport)
- **Category:** productivity
- **License:** MIT
- **Config:** Requires a `profiles.yaml` in the mounted backend directory with platform API credentials

**Dockerfile:** Added at [repo root](https://github.com/AutomateLab-tech/content-distribution-mcp/blob/main/Dockerfile) — multi-stage Node 20 Alpine build, exposes `/data` volume for profile state.