### PR TITLE
Add mcp-broker server

### DIFF
--- a/servers/mcp-broker/server.yaml
+++ b/servers/mcp-broker/server.yaml
@@ -1,0 +1,21 @@
+name: mcp-broker
+image: mcp/mcp-broker
+type: server
+meta:
+  category: devops
+  tags:
+    - ai-tools
+    - claude
+    - codex
+    - developer-tools
+    - gemini-cli
+    - mcp-client
+    - mcp-gateway
+    - model-context-protocol
+about:
+  title: Broker
+  description: Local MCP process broker that exposes one broker entry for discovering and calling profile-scoped upstream MCP tools.
+  icon: https://avatars.githubusercontent.com/u/30372885?v=4
+source:
+  project: https://github.com/NavinAgrawal/mcp-broker
+  commit: 6b3c743941eb529427d84c77a9f18095b8fb4c9c


### PR DESCRIPTION
Adds mcp-broker as a local MCP broker server.

Validation performed:
- go run ./cmd/create --category devops --name mcp-broker https://github.com/NavinAgrawal/mcp-broker
- go run ./cmd/validate --name mcp-broker
- go run ./cmd/build mcp-broker
- go run ./cmd/catalog mcp-broker
- Docker MCP Toolkit temporary catalog create from servers/mcp-broker/server.yaml, verified mcp-broker appears, then removed the catalog

Source commit pinned to public mcp-broker commit 6b3c743941eb529427d84c77a9f18095b8fb4c9c.