### PR TITLE
Add ead-factory MCP Server

### DIFF
--- a/servers/ead-factory/readme.md
+++ b/servers/ead-factory/readme.md
@@ -1,0 +1,17 @@
+# ead-factory
+
+EAD Factory MCP — Digital Trust services APIs for your agents
+
+## Install
+
+```bash
+docker run --rm -it --env-file .env gdigital/ead-factory:1.0.12
+```
+
+## Source
+
+Maintained by g-digital by Garrigues at <https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution> (`pending-to-publish/ead-factory/`).
+
+## License
+
+MIT

--- a/servers/ead-factory/server.yaml
+++ b/servers/ead-factory/server.yaml
@@ -1,0 +1,51 @@
+name: ead-factory
+description: EAD Factory MCP — Digital Trust services APIs for your agents
+image: gdigital/ead-factory:1.0.12
+icon: https://unpkg.com/@g-digital/mcp-ead-factory@1.0.12/assets/logo-400x400.png
+about:
+  homepage: https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution
+  publisher: g-digital by Garrigues
+  license: MIT
+source:
+  repository: https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution
+  directory: pending-to-publish/ead-factory
+config:
+  description: |
+    Consumer credentials are required to run this MCP. See README for setup.
+  env:
+    - name: API_BASE_URL
+      example: https://api.int.gcloudfactory.com/digital-trust
+      description: Evidence Manager API base URL
+    - name: FULL_FLOW_EMAIL_BASE
+      example: user@example.com
+      description: Full flow base email — used to compose participant emails (user+signatory@domain, etc.)
+    - name: FULL_FLOW_FILE_PATH
+      example: assets/dama.jpg
+      description: Full flow default file path
+    - name: HTTP_PORT
+      example: 3000
+      description: TCP port for the HTTP transport. Used only when TRANSPORT=http; ignored in stdio mode.
+    - name: OKTA_CLIENT_ID
+      example: 
+      description: Okta application client ID (client_credentials grant).
+    - name: OKTA_CLIENT_SECRET
+      example: 
+      description: Okta application client secret. See https://eadtrust.example.com/onboarding for credential acquisition.
+    - name: OKTA_SCOPE
+      example: token
+      description: OAuth scope requested. Defaults to 'token' if not provided.
+    - name: OKTA_TOKEN_URL
+      example: https://legalappfactory.okta.com/oauth2/aus5zlw4kr0vhHKyx417/v1/token
+      description: Okta token endpoint (client_credentials grant). Used both for outbound API calls and for verifying inbound Bearer tokens in HTTP mode.
+    - name: POLL_INTERVAL_MS
+      example: 3000
+      description: Polling interval in milliseconds for the evidence-status check.
+    - name: POLL_MAX_ATTEMPTS
+      example: 20
+      description: Maximum polling attempts before timing out the evidence-status check.
+    - name: SIGNATURE_API_BASE_URL
+      example: https://api.int.gcloudfactory.com/signature-manager
+      description: Signature Manager API base URL
+    - name: TRANSPORT
+      example: stdio
+      description: Transport: "stdio" for local Claude Code, "http" for remote deployment with auth

--- a/servers/ead-factory/tools.json
+++ b/servers/ead-factory/tools.json
@@ -1,0 +1,40 @@
+{
+  "tools": [
+    {
+      "name": "generate_evidence",
+      "description": "Full workflow: authenticate with Okta, SHA-256 hash the file, register the evidence, upload to S3, and poll until COMPLETED or ERROR."
+    },
+    {
+      "name": "get_evidence",
+      "description": "Retrieve full evidence details by ID (status, timestamps, custody, metadata)."
+    },
+    {
+      "name": "create_signature_request",
+      "description": "Create a new signature request in DRAFT state. Supports fullFlow=true to complete the entire flow with preconfigured participants in a single call."
+    },
+    {
+      "name": "add_document_to_signature_request",
+      "description": "Add a document to a DRAFT signature request and upload the file to S3."
+    },
+    {
+      "name": "add_signatory_to_document",
+      "description": "Add a signatory to a document within a signature request."
+    },
+    {
+      "name": "add_validator_to_signatory",
+      "description": "Add a validator to a signatory; the validator must approve before the signatory can sign."
+    },
+    {
+      "name": "add_observer_to_document",
+      "description": "Add an observer to a document; observers receive notifications but do not sign."
+    },
+    {
+      "name": "activate_signature_request",
+      "description": "Activate a signature request (DRAFT → ACTIVE), triggering notifications to signatories."
+    },
+    {
+      "name": "get_signature_request",
+      "description": "Retrieve full details of a signature request by ID (status, documents, participants, history)."
+    }
+  ]
+}


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ead-factory
**Repository URL:** https://github.com/g-digital-by-Garrigues/EAD-Factory-MCP
**Brief Description:** EAD Factory MCP — Digital Trust services for AI agents. Bridges any MCP-compatible client (Claude Code, Claude Desktop, Cursor, etc.) to EAD Trust's Evidence Manager + Signature Manager APIs, exposing full evidence-generation + signature-request lifecycle as 9 tools.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (TypeScript SDK `@modelcontextprotocol/sdk`)
- [x] **Active Development**: 13 releases shipped in the last 30 days; main branch active
- [x] **Docker Artifact**: Multi-stage Dockerfile published as `gdigital/ead-factory:1.0.12`
- [x] **Documentation**: README + per-client install blocks (8 clients) + ONBOARDING.md
- [x] **Security Contact**: security contact referenced in repo metadata

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I have tested the MCP Server using \`task validate -- --name ead-factory\`
- [x] I have built the MCP Server using \`task build -- --tools ead-factory\`
- [x] Test credentials shared via [this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Additional Details

- **9 tools** covering evidence generation (SHA-256 hash + S3 upload + Okta auth + status polling) and signature request lifecycle (create → add documents → add signatories / validators / observers → activate → retrieve)
- **Two transports**: \`stdio\` for local Claude Code / Claude Desktop, \`http\` for hosted deployments with Bearer OAuth2 inbound auth
- **Auth model**: Okta \`client_credentials\` grant; the integration server obtains its own token, no end-user token exchange required
- **Published on npm** as [\`@g-digital/mcp-ead-factory\`](https://www.npmjs.com/package/@g-digital/mcp-ead-factory) (with npm OIDC provenance) and on Docker Hub as [\`gdigital/ead-factory\`](https://hub.docker.com/r/gdigital/ead-factory)
- Already listed on the [MCP Official Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.g-digital-by-Garrigues%2Fead-factory) and on [Smithery](https://smithery.ai/server/g-digital/ead-factory)

## Submission cleanup note

This PR replaces a series of off-template per-version PRs (#3589, #3605, #3607, #3646, #3648, #3685, #3686, #3721, #3801) that our distribution pipeline opened automatically before we caught the issue. Those are being closed today as superseded by this consolidated submission. Going forward, our pipeline will edit this single PR on version bumps instead of opening new ones.

Hi @jchangx — submitted with the full template + test credentials via the Google form. Happy to address any review feedback. — Hugo Alonso, technical lead at [@g-digital-by-Garrigues](https://github.com/g-digital-by-Garrigues).