### PR TITLE
Add ead-enterprise-suite MCP Server

### DIFF
--- a/servers/ead-enterprise-suite/readme.md
+++ b/servers/ead-enterprise-suite/readme.md
@@ -1,0 +1,17 @@
+# ead-enterprise-suite
+
+MCP server for EAD Enterprise Suite, EAD Trust's advanced Digital Trust platform. Full signature workflows, certified evidence, notifications, dossiers, and large-file uploads for enterprise legal processes.
+
+## Install
+
+```bash
+docker run --rm -it --env-file .env gdigital/ead-enterprise-suite:1.2.3
+```
+
+## Source
+
+Maintained by g-digital by Garrigues at <https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution> (`pending-to-publish/ead-enterprise-suite/`).
+
+## License
+
+MIT

--- a/servers/ead-enterprise-suite/server.yaml
+++ b/servers/ead-enterprise-suite/server.yaml
@@ -1,0 +1,33 @@
+name: ead-enterprise-suite
+description: MCP server for EAD Enterprise Suite, EAD Trust's advanced Digital Trust platform. Full signature workflows, certified evidence, notifications, dossiers, and large-file uploads for enterprise legal processes.
+image: gdigital/ead-enterprise-suite:1.2.3
+icon: https://unpkg.com/@g-digital/mcp-ead-enterprise-suite@1.2.3/assets/logo-400x400.png
+about:
+  homepage: https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution
+  publisher: g-digital by Garrigues
+  license: MIT
+source:
+  repository: https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution
+  directory: pending-to-publish/ead-enterprise-suite
+config:
+  description: |
+    Consumer credentials are required to run this MCP. See README for setup.
+  env:
+    - name: MCP_AUTH_EMAIL
+      example: 
+      description: Flow 1: Email / password description: Your GoCertius account email address isSecret: false
+    - name: MCP_AUTH_PASSWORD
+      example: 
+      description: description: Your GoCertius account password isSecret: true (See https://www.eadtrust.eu/soluciones-legaltech/enterprise-suite/ for credential acquisition.)
+    - name: MCP_OPENID_CLIENT_ID
+      example: 
+      description: description: OpenID Connect client ID isSecret: false
+    - name: MCP_OPENID_ISSUER
+      example: 
+      description: Flow 2: OpenID Connect (alternative to email/password) description: OpenID Connect issuer URL isSecret: false
+    - name: MCP_OPENID_REFRESH_TOKEN
+      example: 
+      description: description: OpenID Connect refresh token isSecret: true (See https://www.eadtrust.eu/soluciones-legaltech/enterprise-suite/ for credential acquisition.)
+    - name: PORT
+      example: 8080
+      description: Transport (optional) description: HTTP port when running in hosted (HTTP) mode; ignored in stdio mode isSecret: false

--- a/servers/ead-enterprise-suite/tools.json
+++ b/servers/ead-enterprise-suite/tools.json
@@ -1,0 +1,184 @@
+{
+  "tools": [
+    {
+      "name": "evidence_create",
+      "description": "Performs the evidence_create operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_list",
+      "description": "Performs the evidence_list operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_seal",
+      "description": "Performs the evidence_seal operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_get",
+      "description": "Performs the evidence_get operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_group_create",
+      "description": "Performs the evidence_group_create operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_group_list",
+      "description": "Performs the evidence_group_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_create",
+      "description": "Performs the dossier_create operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_update",
+      "description": "Performs the dossier_update operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_certify",
+      "description": "Performs the dossier_certify operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_list",
+      "description": "Performs the dossier_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_get",
+      "description": "Performs the dossier_get operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_template_list",
+      "description": "Performs the dossier_template_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_preview",
+      "description": "Performs the dossier_preview operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_document_url",
+      "description": "Performs the dossier_document_url operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_package_url",
+      "description": "Performs the dossier_package_url operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_visibility",
+      "description": "Performs the dossier_visibility operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_delete",
+      "description": "Performs the dossier_delete operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_group_certify",
+      "description": "Performs the dossier_group_certify operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_link",
+      "description": "Performs the dossier_evidence_link operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_list_to_link",
+      "description": "Performs the dossier_evidence_list_to_link operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_list",
+      "description": "Performs the dossier_evidence_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_get",
+      "description": "Performs the dossier_evidence_get operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_delete",
+      "description": "Performs the dossier_evidence_delete operation against the GoCertius API."
+    },
+    {
+      "name": "notification_request_create",
+      "description": "Performs the notification_request_create operation against the GoCertius API."
+    },
+    {
+      "name": "notification_request_send",
+      "description": "Performs the notification_request_send operation against the GoCertius API."
+    },
+    {
+      "name": "notification_request_status",
+      "description": "Performs the notification_request_status operation against the GoCertius API."
+    },
+    {
+      "name": "notification_receiver_add",
+      "description": "Performs the notification_receiver_add operation against the GoCertius API."
+    },
+    {
+      "name": "notification_certificate_get",
+      "description": "Performs the notification_certificate_get operation against the GoCertius API."
+    },
+    {
+      "name": "case_file_list",
+      "description": "Performs the case_file_list operation against the GoCertius API."
+    },
+    {
+      "name": "case_file_get",
+      "description": "Performs the case_file_get operation against the GoCertius API."
+    },
+    {
+      "name": "session_login",
+      "description": "Performs the session_login operation against the GoCertius API."
+    },
+    {
+      "name": "session_info",
+      "description": "Performs the session_info operation against the GoCertius API."
+    },
+    {
+      "name": "use_case_list",
+      "description": "Performs the use_case_list operation against the GoCertius API."
+    },
+    {
+      "name": "signature_request_create",
+      "description": "Performs the signature_request_create operation against the GoCertius API."
+    },
+    {
+      "name": "signature_request_get",
+      "description": "Performs the signature_request_get operation against the GoCertius API."
+    },
+    {
+      "name": "signature_request_cancel",
+      "description": "Performs the signature_request_cancel operation against the GoCertius API."
+    },
+    {
+      "name": "signature_request_add_document",
+      "description": "Performs the signature_request_add_document operation against the GoCertius API."
+    },
+    {
+      "name": "signature_document_list",
+      "description": "Performs the signature_document_list operation against the GoCertius API."
+    },
+    {
+      "name": "signature_participant_create",
+      "description": "Performs the signature_participant_create operation against the GoCertius API."
+    },
+    {
+      "name": "signature_participant_list",
+      "description": "Performs the signature_participant_list operation against the GoCertius API."
+    },
+    {
+      "name": "activate_signature_request",
+      "description": "Performs the activate_signature_request operation against the GoCertius API."
+    },
+    {
+      "name": "signature_coordinate_set",
+      "description": "Performs the signature_coordinate_set operation against the GoCertius API."
+    },
+    {
+      "name": "signature_certificate_get",
+      "description": "Performs the signature_certificate_get operation against the GoCertius API."
+    },
+    {
+      "name": "large_evidence_upload_initiate",
+      "description": "Performs the large_evidence_upload_initiate operation against the GoCertius API."
+    },
+    {
+      "name": "large_evidence_upload_complete",
+      "description": "Performs the large_evidence_upload_complete operation against the GoCertius API."
+    }
+  ]
+}


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ead-enterprise-suite
**Repository URL:** https://github.com/g-digital-by-Garrigues/EAD_Enterprise_Suite_MCP
**Brief Description:** EAD Enterprise Suite MCP — Digital Trust services for AI agents bridging MCP clients to EAD Trust's enterprise platform. Full signature workflows, certified evidence, notifications, dossiers, and large-file uploads exposed as 39 tools for enterprise legal processes.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (TypeScript SDK \`@modelcontextprotocol/sdk\`)
- [x] **Active Development**: 3 versions shipped this week (1.2.1 → 1.2.3); active main
- [x] **Docker Artifact**: Multi-stage Dockerfile published as \`gdigital/ead-enterprise-suite:1.2.3\`
- [x] **Documentation**: README + 8 per-client install blocks + ONBOARDING.md (39 tools documented)
- [x] **Security Contact**: security contact referenced in repo metadata

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I have tested the MCP Server using \`task validate -- --name ead-enterprise-suite\`
- [x] I have built the MCP Server using \`task build -- --tools ead-enterprise-suite\`
- [x] Test credentials shared via [this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Additional Details

- **39 tools** covering: dossier lifecycle (create / list / get / templates), signature request full lifecycle (create → add docs → add participants → coordinates → activate → cancel → get), evidence management (create / get / list / seal / group + large-file upload via multipart), certified notifications (create → add receivers → send → status), and session / auth management
- **Two transports**: \`stdio\` (local) + \`http\` (hosted with Bearer OAuth)
- **Auth**: OpenID Connect refresh-token flow (\`MCP_AUTH_EMAIL\` / \`MCP_AUTH_PASSWORD\`) OR client_credentials (\`MCP_OPENID_CLIENT_ID\` / \`MCP_OPENID_ISSUER\` / \`MCP_OPENID_REFRESH_TOKEN\`)
- **Published**: [npm](https://www.npmjs.com/package/@g-digital/mcp-ead-enterprise-suite) (with provenance), [Docker Hub](https://hub.docker.com/r/gdigital/ead-enterprise-suite), [MCP Official Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.g-digital-by-Garrigues%2Fead-enterprise-suite), [Smithery](https://smithery.ai/server/g-digital/ead-enterprise-suite)

## Submission cleanup note

This PR replaces our prior per-version PR (#3810) opened by our distribution pipeline before we caught the off-template issue. That PR is being closed today as superseded.

Hi @jchangx — full template + test credentials submitted via the Google form. Happy to address any review feedback. — Hugo Alonso, technical lead at [@g-digital-by-Garrigues](https://github.com/g-digital-by-Garrigues).