### PR TITLE
Add gocertius MCP Server

### DIFF
--- a/servers/gocertius/readme.md
+++ b/servers/gocertius/readme.md
@@ -1,0 +1,17 @@
+# gocertius
+
+MCP server for GoCertius, EAD Trust's Digital Trust platform. Provides certified evidence management, dossier creation, certified notifications, and certified chats via AI agents.
+
+## Install
+
+```bash
+docker run --rm -it --env-file .env gdigital/gocertius:1.1.3
+```
+
+## Source
+
+Maintained by g-digital by Garrigues at <https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution> (`pending-to-publish/gocertius/`).
+
+## License
+
+MIT

--- a/servers/gocertius/server.yaml
+++ b/servers/gocertius/server.yaml
@@ -1,0 +1,33 @@
+name: gocertius
+description: MCP server for GoCertius, EAD Trust's Digital Trust platform. Provides certified evidence management, dossier creation, certified notifications, and certified chats via AI agents.
+image: gdigital/gocertius:1.1.3
+icon: https://unpkg.com/@g-digital/mcp-gocertius@1.1.3/assets/logo-400x400.png
+about:
+  homepage: https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution
+  publisher: g-digital by Garrigues
+  license: MIT
+source:
+  repository: https://github.com/g-digital-by-Garrigues/MCP_Market_Distribution
+  directory: pending-to-publish/gocertius
+config:
+  description: |
+    Consumer credentials are required to run this MCP. See README for setup.
+  env:
+    - name: MCP_AUTH_EMAIL
+      example: 
+      description: Flow 1: Email / password description: Your GoCertius account email address isSecret: false
+    - name: MCP_AUTH_PASSWORD
+      example: 
+      description: description: Your GoCertius account password isSecret: true (See https://www.gocertius.io for credential acquisition.)
+    - name: MCP_OPENID_CLIENT_ID
+      example: 
+      description: description: OpenID Connect client ID isSecret: false
+    - name: MCP_OPENID_ISSUER
+      example: 
+      description: Flow 2: OpenID Connect (alternative to email/password) description: OpenID Connect issuer URL isSecret: false
+    - name: MCP_OPENID_REFRESH_TOKEN
+      example: 
+      description: description: OpenID Connect refresh token isSecret: true (See https://www.gocertius.io for credential acquisition.)
+    - name: PORT
+      example: 8080
+      description: Transport (optional) description: HTTP port when running in hosted (HTTP) mode; ignored in stdio mode isSecret: false

--- a/servers/gocertius/tools.json
+++ b/servers/gocertius/tools.json
@@ -1,0 +1,156 @@
+{
+  "tools": [
+    {
+      "name": "evidence_create",
+      "description": "Performs the evidence_create operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_list",
+      "description": "Performs the evidence_list operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_seal",
+      "description": "Performs the evidence_seal operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_get",
+      "description": "Performs the evidence_get operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_group_create",
+      "description": "Performs the evidence_group_create operation against the GoCertius API."
+    },
+    {
+      "name": "evidence_group_list",
+      "description": "Performs the evidence_group_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_create",
+      "description": "Performs the dossier_create operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_update",
+      "description": "Performs the dossier_update operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_certify",
+      "description": "Performs the dossier_certify operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_list",
+      "description": "Performs the dossier_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_get",
+      "description": "Performs the dossier_get operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_template_list",
+      "description": "Performs the dossier_template_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_preview",
+      "description": "Performs the dossier_preview operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_document_url",
+      "description": "Performs the dossier_document_url operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_package_url",
+      "description": "Performs the dossier_package_url operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_visibility",
+      "description": "Performs the dossier_visibility operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_delete",
+      "description": "Performs the dossier_delete operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_group_certify",
+      "description": "Performs the dossier_group_certify operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_link",
+      "description": "Performs the dossier_evidence_link operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_list_to_link",
+      "description": "Performs the dossier_evidence_list_to_link operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_list",
+      "description": "Performs the dossier_evidence_list operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_get",
+      "description": "Performs the dossier_evidence_get operation against the GoCertius API."
+    },
+    {
+      "name": "dossier_evidence_delete",
+      "description": "Performs the dossier_evidence_delete operation against the GoCertius API."
+    },
+    {
+      "name": "notification_request_create",
+      "description": "Performs the notification_request_create operation against the GoCertius API."
+    },
+    {
+      "name": "notification_request_send",
+      "description": "Performs the notification_request_send operation against the GoCertius API."
+    },
+    {
+      "name": "notification_request_status",
+      "description": "Performs the notification_request_status operation against the GoCertius API."
+    },
+    {
+      "name": "notification_receiver_add",
+      "description": "Performs the notification_receiver_add operation against the GoCertius API."
+    },
+    {
+      "name": "notification_certificate_get",
+      "description": "Performs the notification_certificate_get operation against the GoCertius API."
+    },
+    {
+      "name": "case_file_create",
+      "description": "Performs the case_file_create operation against the GoCertius API."
+    },
+    {
+      "name": "case_file_list",
+      "description": "Performs the case_file_list operation against the GoCertius API."
+    },
+    {
+      "name": "case_file_get",
+      "description": "Performs the case_file_get operation against the GoCertius API."
+    },
+    {
+      "name": "chat_create",
+      "description": "Performs the chat_create operation against the GoCertius API."
+    },
+    {
+      "name": "chat_get",
+      "description": "Performs the chat_get operation against the GoCertius API."
+    },
+    {
+      "name": "chat_invitation_url",
+      "description": "Performs the chat_invitation_url operation against the GoCertius API."
+    },
+    {
+      "name": "chat_certificate_create",
+      "description": "Performs the chat_certificate_create operation against the GoCertius API."
+    },
+    {
+      "name": "chat_certificate_get",
+      "description": "Performs the chat_certificate_get operation against the GoCertius API."
+    },
+    {
+      "name": "session_login",
+      "description": "Performs the session_login operation against the GoCertius API."
+    },
+    {
+      "name": "session_info",
+      "description": "Performs the session_info operation against the GoCertius API."
+    }
+  ]
+}


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gocertius
**Repository URL:** https://github.com/g-digital-by-Garrigues/GoCertius_MCP
**Brief Description:** GoCertius MCP — Digital Trust services for AI agents. Bridges MCP clients to GoCertius's Digital Trust platform: certified evidence management, dossier creation, certified notifications, and certified chats exposed as 26 tools.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (TypeScript SDK \`@modelcontextprotocol/sdk\`)
- [x] **Active Development**: Latest release 1.1.3 (this week); active main
- [x] **Docker Artifact**: Multi-stage Dockerfile published as \`gdigital/gocertius:1.1.3\`
- [x] **Documentation**: README + 8 per-client install blocks + ONBOARDING.md
- [x] **Security Contact**: security contact referenced in repo metadata

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I have tested the MCP Server using \`task validate -- --name gocertius\`
- [x] I have built the MCP Server using \`task build -- --tools gocertius\`
- [x] Test credentials shared via [this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Additional Details

- **26 tools** covering: dossier creation + certification + linking to evidence + group certify, evidence management + groups + sealing, certified notifications (create / send / receivers / status + certificate retrieval), certified chats (create / invite / get / certificate), case files
- **Two transports**: \`stdio\` (local) + \`http\` (hosted with Bearer OAuth)
- **Auth**: OpenID Connect refresh-token (\`MCP_AUTH_EMAIL\` / \`MCP_AUTH_PASSWORD\`) OR client_credentials
- **Published**: [npm](https://www.npmjs.com/package/@g-digital/mcp-gocertius), [Docker Hub](https://hub.docker.com/r/gdigital/gocertius), [MCP Official Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.g-digital-by-Garrigues%2Fgocertius), [Smithery](https://smithery.ai/server/g-digital/gocertius)

## Submission cleanup note

This PR replaces our prior per-version PR (#3811) opened by our distribution pipeline before we caught the off-template issue. That PR is being closed today as superseded.

Hi @jchangx — full template + test credentials submitted via the Google form. Happy to address any review feedback. — Hugo Alonso, technical lead at [@g-digital-by-Garrigues](https://github.com/g-digital-by-Garrigues).