### PR TITLE
Add Doxa MCP: Christian Bible MCP (remote server)

### DIFF
--- a/servers/doxa-remote/server.yaml
+++ b/servers/doxa-remote/server.yaml
@@ -3,7 +3,7 @@ type: remote
 dynamic:
   tools: true
 meta:
-  category: faith
+  category: ai
   tags:
     - faith
     - bible

--- a/servers/doxa-remote/server.yaml
+++ b/servers/doxa-remote/server.yaml
@@ -1,0 +1,20 @@
+name: doxa-remote
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: faith
+  tags:
+    - faith
+    - bible
+    - scripture
+    - christian
+    - encouragement
+    - remote
+about:
+  title: Doxa MCP
+  description: Christian Bible MCP for Scripture lookup (Berean Standard Bible, public domain), Christian encouragement in the Doxa voice, and the Doxa Way journey map. Three tools, doxa_encourage, doxa_scripture, doxa_way_movement. Free hosted, BYOL via X-Anthropic-Key header for unlimited.
+  icon: https://doxa.app/doxa-logo.png
+remote:
+  transport_type: streamable-http
+  url: https://doxa.app/mcp/v1


### PR DESCRIPTION
Adds Doxa MCP as a remote server entry under category `faith`.

## What it is

Christian Bible MCP for Scripture lookup, Christian encouragement, and the Doxa Way journey map.

## Server details
- **Name**: `doxa-remote`
- **Type**: `remote` (streamable-http transport)
- **URL**: https://doxa.app/mcp/v1
- **Source**: https://github.com/The-Doxa-Way/doxa-mcp-schema
- **License**: MIT (schema repo), prompt + implementation hosted (Doxa retains)

## Tools (3)
- `doxa_encourage` — Christian encouragement in the Doxa voice, anchored in Scripture
- `doxa_scripture` — Bible verse lookup (Berean Standard Bible, public domain)
- `doxa_way_movement` — the nine-movement Doxa Way journey map

## Auth model
- **Open**: free 50 calls/day per source IP, no signup
- **API Key**: BYOL via `X-Anthropic-Key` header for unlimited (uses the developer's own Anthropic key)
- No OAuth required

## Already listed on
- Official MCP Registry: `io.github.TheDoxaWay/doxa-mcp` (https://registry.modelcontextprotocol.io/)
- npm: `@thedoxaway/mcp-client`
- Smithery, mcp.so (pending approval)
- punkpeye/awesome-mcp-servers (PR #6762, open)
- jaw9c/awesome-remote-mcp-servers (PR #353, open)

## Live verification
`POST https://doxa.app/mcp/v1` with `user-agent` header + JSON-RPC `initialize` returns the full `serverInfo.description` and three tool definitions.