### PR TITLE
Add wrg-mcp-server (security monitoring — governance, OSINT, Sigma, threat-intel)

### DIFF
--- a/servers/wrg-mcp-server/server.yaml
+++ b/servers/wrg-mcp-server/server.yaml
@@ -1,0 +1,18 @@
+name: wrg-mcp-server
+image: mcp/wrg-mcp-server
+type: server
+meta:
+  category: monitoring
+  tags:
+    - security
+    - osint
+    - threat-intel
+    - governance
+    - sigma
+about:
+  title: WinstonRedGuard MCP Server
+  description: Security monitoring MCP server — governance, OSINT (maigret, breach-search, attack-surface), Sigma rule lab, ransomware radar, dark-web watch. Tools from the WRG-11 portfolio.
+  icon: https://avatars.githubusercontent.com/u/281155251?v=4
+source:
+  project: https://github.com/WRG-11/wrg-mcp-server
+  commit: 30bd53c96dbff4292969d31064d8c8580f18d3f2


### PR DESCRIPTION
## Summary

Adds `wrg-mcp-server`, a security monitoring MCP server, to the Docker MCP Catalog.

## About the server

**WinstonRedGuard MCP Server** provides security operations tools accessible to MCP-compatible clients:

- **Governance**: app audits, pipeline management, release checks
- **OSINT**: username discovery (maigret), breach-search, attack-surface passive mapping
- **Threat-intel**: ransomware group lookup, dark-web brand watch, AI fingerprint detection
- **Sigma rule lab**: rule listing and testing
- **Research platform**: scan management, research history, structured reports

## Technical details

- **Source**: https://github.com/WRG-11/wrg-mcp-server (standalone public repo)
- **Commit**: `30bd53c96dbff4292969d31064d8c8580f18d3f2` (v1.0.8 tag: Dockerfile stdio-default for MCP Catalog compatibility)
- **Transport**: stdio (default via `docker run -i mcp/wrg-mcp-server`)
- **Dockerfile**: `python:3.12-slim` base; `pip install wrg-mcp-server`; CMD env-gated (`${MCP_TRANSPORT:-stdio}`)
- **License**: MIT
- **CI**: pytest matrix (ubuntu + windows × Python 3.11/3.12/3.13) + CodeQL — all green

## server.yaml fields

- `meta.category`: `monitoring` (observability and threat-intel framing)
- `meta.tags`: security, osint, threat-intel, governance, sigma
- `run.allowHosts`: omitted for initial ship (stdio local tools; remote tool egress allowlist deferred to follow-up PR)

## Checklist

- [x] Dockerfile present in source repo
- [x] MIT license
- [x] `docker run -i` stdio mode tested locally (see v1.0.8 release notes)
- [x] server.yaml authored following CONTRIBUTING.md schema