### PR TITLE
Add seo-performance MCP server

### DIFF
--- a/servers/seo-performance/server.yaml
+++ b/servers/seo-performance/server.yaml
@@ -1,0 +1,77 @@
+name: seo-performance
+image: mcp/seo-performance
+type: server
+meta:
+  category: marketing
+  tags:
+    - marketing
+    - seo
+    - analytics
+    - google-search-console
+    - matomo
+source:
+  project: https://github.com/AutomateLab-tech/seo-performance-mcp
+  commit: 80e4219a324c5d759b2470b786f7c5584c37e376
+about:
+  title: SEO Performance
+  description: Post-publish SEO performance server. Unifies Google Search Console, Matomo, GA4, Clarity, and AI-citation signals per URL and emits a verdict (refresh / expand / merge / kill / double_down / hold) per post with reason codes.
+  icon: https://avatars.githubusercontent.com/u/284312388?s=200&v=4
+config:
+  description: Configure Google Search Console, Matomo, GA4, Clarity, and Ghost connections
+  env:
+    - name: GSC_CREDENTIALS_JSON
+      example: '{"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}'
+      value: "{{seo-performance.gsc_credentials_json}}"
+    - name: GSC_SITE_URL
+      example: https://example.com/
+      value: "{{seo-performance.gsc_site_url}}"
+    - name: MATOMO_URL
+      example: https://matomo.example.com
+      value: "{{seo-performance.matomo_url}}"
+    - name: MATOMO_TOKEN
+      example: abc123def456
+      value: "{{seo-performance.matomo_token}}"
+    - name: MATOMO_SITE_ID
+      example: "1"
+      value: "{{seo-performance.matomo_site_id}}"
+    - name: GA4_PROPERTY_ID
+      example: "123456789"
+      value: "{{seo-performance.ga4_property_id}}"
+    - name: GA4_CREDENTIALS_JSON
+      example: '{"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}'
+      value: "{{seo-performance.ga4_credentials_json}}"
+    - name: CLARITY_PROJECT_ID
+      example: abc1def2gh
+      value: "{{seo-performance.clarity_project_id}}"
+    - name: GHOST_URL
+      example: https://example.com
+      value: "{{seo-performance.ghost_url}}"
+    - name: GHOST_ADMIN_API_KEY
+      example: 1234567890abcdef:1234567890abcdef1234567890abcdef
+      value: "{{seo-performance.ghost_admin_api_key}}"
+  parameters:
+    type: object
+    properties:
+      gsc_credentials_json:
+        type: string
+      gsc_site_url:
+        type: string
+      matomo_url:
+        type: string
+      matomo_token:
+        type: string
+      matomo_site_id:
+        type: string
+      ga4_property_id:
+        type: string
+      ga4_credentials_json:
+        type: string
+      clarity_project_id:
+        type: string
+      ghost_url:
+        type: string
+      ghost_admin_api_key:
+        type: string
+    required:
+      - gsc_credentials_json
+      - gsc_site_url


### PR DESCRIPTION
Adds the **seo-performance** MCP server - a post-publish SEO performance toolkit.

Unifies Google Search Console, Matomo, GA4, Clarity, and AI-citation signals per URL, and emits a structured verdict (refresh / expand / merge / kill / double_down / hold) per post with reason codes. Includes tools for decay curves, cohort reports, GSC/Bing quick wins, and refresh briefs.

- **Source:** https://github.com/AutomateLab-tech/seo-performance-mcp
- **npm:** [`@automatelab/seo-performance-mcp`](https://www.npmjs.com/package/@automatelab/seo-performance-mcp)
- **License:** MIT
- **Transport:** stdio
- **Category:** marketing
- **Landing page:** https://automatelab.tech/products/mcp/seo-performance-mcp/
- **Tools (9):** posts_list, posts_snapshot, posts_decay_curve, posts_verdict, posts_refresh_brief, cohort_report, gsc_quick_wins, bing_quick_wins, posts_cite_loss