### PR TITLE
feat: add SigNoz MCP server

### DIFF
--- a/servers/signoz-mcp-server/readme.md
+++ b/servers/signoz-mcp-server/readme.md
@@ -1,0 +1,1 @@
+Docs: https://signoz.io/docs/ai/signoz-mcp-server/

--- a/servers/signoz-mcp-server/readme.md
+++ b/servers/signoz-mcp-server/readme.md
@@ -1,1 +1,56 @@
+# SigNoz MCP Server
+
+Query metrics, traces, logs, alerts, dashboards, and services from your [SigNoz](https://signoz.io) observability platform using natural language.
+
+This server runs as a local Docker container (stdio) and connects to your SigNoz instance — SigNoz Cloud (any region) or self-hosted — using an API key.
+
 Docs: https://signoz.io/docs/ai/signoz-mcp-server/
+
+## Prerequisite: create an API key
+
+In your SigNoz UI, go to **Settings → API Keys → New Key** (requires an **Admin** user) and copy the key. This is your `SIGNOZ_API_KEY`.
+
+## Configuration
+
+| Field            | Description                                                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `signoz_url`     | The URL of your **SigNoz instance** (not an MCP endpoint). Cloud: `https://your-org.us.signoz.cloud`. Self-hosted: `http://host.docker.internal:8080`. |
+| `SIGNOZ_API_KEY` | The API key created above (stored as a secret).                                                                                                        |
+
+> `signoz_url` is your SigNoz app/backend URL. Do **not** enter a hosted-MCP endpoint such as `https://mcp.us.signoz.cloud/mcp` here.
+
+## Install: SigNoz Cloud
+
+1. Docker Desktop → **MCP Toolkit → Catalog → SigNoz → Configure**.
+2. Set `signoz_url` to your Cloud instance URL, e.g. `https://your-org.us.signoz.cloud` (use your own region: `us`, `eu`, `in`, `us2`, `eu2`, `in2`).
+3. Set `SIGNOZ_API_KEY`.
+4. Enable the server, then connect your MCP client (Claude Desktop, Cursor, VS Code, …).
+
+CLI equivalent:
+
+```bash
+docker mcp server enable signoz-mcp-server
+docker mcp config write signoz-mcp-server signoz_url "https://your-org.us.signoz.cloud"
+docker mcp secret set signoz-mcp-server.signoz_api_key "<your-api-key>"
+```
+
+## Install: self-hosted SigNoz
+
+Same flow, pointing at your own instance:
+
+1. Docker Desktop → **MCP Toolkit → Catalog → SigNoz → Configure**.
+2. Set `signoz_url` to your self-hosted URL. Because the MCP server runs inside a container, use `http://host.docker.internal:8080` (not `http://localhost:8080`) to reach SigNoz running on your host.
+3. Set `SIGNOZ_API_KEY` from your self-hosted SigNoz's **Settings → API Keys**.
+4. Enable the server and connect your MCP client.
+
+CLI equivalent:
+
+```bash
+docker mcp server enable signoz-mcp-server
+docker mcp config write signoz-mcp-server signoz_url "http://host.docker.internal:8080"
+docker mcp secret set signoz-mcp-server.signoz_api_key "<your-api-key>"
+```
+
+## Verify
+
+Ask your client something like _"list my SigNoz services"_ — you should see your services with call rates, error rates, and latencies.

--- a/servers/signoz-mcp-server/server.yaml
+++ b/servers/signoz-mcp-server/server.yaml
@@ -1,0 +1,33 @@
+name: signoz-mcp-server
+image: mcp/signoz-mcp-server
+type: server
+meta:
+    category: monitoring
+    tags:
+        - monitoring
+        - observability
+        - tracing
+        - logs
+        - metrics
+about:
+    title: SigNoz
+    description: Query metrics, traces, logs, alerts, dashboards, and services from your SigNoz observability platform using natural language.
+    icon: https://www.google.com/s2/favicons?domain=signoz.io&sz=64
+source:
+    project: https://github.com/SigNoz/signoz-mcp-server
+    commit: 8a6bb34ea75775bbe678594219bc21a5babd8721
+config:
+    description: Configure the connection to SigNoz
+    secrets:
+        - name: signoz-mcp-server.signoz_api_key
+          env: SIGNOZ_API_KEY
+          example: your-signoz-api-key
+    env:
+        - name: SIGNOZ_URL
+          example: https://your-signoz-instance.com
+          value: "{{signoz-mcp-server.signoz_url}}"
+    parameters:
+        type: object
+        properties:
+            signoz_url:
+                type: string

--- a/servers/signoz-mcp-server/server.yaml
+++ b/servers/signoz-mcp-server/server.yaml
@@ -2,32 +2,35 @@ name: signoz-mcp-server
 image: mcp/signoz-mcp-server
 type: server
 meta:
-    category: monitoring
-    tags:
-        - monitoring
-        - observability
-        - tracing
-        - logs
-        - metrics
+  category: monitoring
+  tags:
+    - monitoring
+    - observability
+    - tracing
+    - logs
+    - metrics
 about:
-    title: SigNoz
-    description: Query metrics, traces, logs, alerts, dashboards, and services from your SigNoz observability platform using natural language.
-    icon: https://www.google.com/s2/favicons?domain=signoz.io&sz=64
+  title: SigNoz
+  description: Query metrics, traces, logs, alerts, dashboards, and services from your SigNoz observability platform using natural language.
+  icon: https://www.google.com/s2/favicons?domain=signoz.io&sz=64
 source:
-    project: https://github.com/SigNoz/signoz-mcp-server
-    commit: 8a6bb34ea75775bbe678594219bc21a5babd8721
+  project: https://github.com/SigNoz/signoz-mcp-server
+  commit: 8a6bb34ea75775bbe678594219bc21a5babd8721
 config:
-    description: Configure the connection to SigNoz
-    secrets:
-        - name: signoz-mcp-server.signoz_api_key
-          env: SIGNOZ_API_KEY
-          example: your-signoz-api-key
-    env:
-        - name: SIGNOZ_URL
-          example: https://your-signoz-instance.com
-          value: "{{signoz-mcp-server.signoz_url}}"
-    parameters:
-        type: object
-        properties:
-            signoz_url:
-                type: string
+  description: Configure the connection to SigNoz
+  secrets:
+    - name: signoz-mcp-server.signoz_api_key
+      env: SIGNOZ_API_KEY
+      example: your-signoz-api-key
+  env:
+    - name: SIGNOZ_URL
+      example: https://your-signoz-instance.com
+      value: "{{signoz-mcp-server.signoz_url}}"
+  parameters:
+    type: object
+    properties:
+      signoz_url:
+        type: string
+        description: The URL of your SigNoz instance (SigNoz Cloud, e.g. https://your-org.us.signoz.cloud, or self-hosted, e.g. http://localhost:8080)
+    required:
+      - signoz_url


### PR DESCRIPTION
## Summary

- Adds a Docker-based MCP server for [SigNoz](https://signoz.io) observability platform
- Supports querying metrics, traces, logs, alerts, dashboards, and services via natural language (38 tools)
- Works with both SigNoz Cloud (all regions) and self-hosted deployments
- Follows the same pattern as Grafana, Dynatrace, and Prometheus entries (user-configurable `SIGNOZ_URL` + API key, stdio transport)

## Server details

- **Image**: Built from [SigNoz/signoz-mcp-server](https://github.com/SigNoz/signoz-mcp-server) (pinned commit `8a6bb34`)
- **Transport**: stdio — Docker Desktop runs the MCP server locally as a container
- **Config**:
  - `SIGNOZ_URL` — your SigNoz **instance** URL (Cloud e.g. `https://your-org.us.signoz.cloud`, or self-hosted e.g. `http://host.docker.internal:8080`); required
  - `SIGNOZ_API_KEY` — service-account API key (secret)
- **Auth**: API key. (This entry does not use OAuth; the MCP server runs locally and connects to the SigNoz backend with the key.)
- **Docs**: https://signoz.io/docs/ai/signoz-mcp-server/

## How it works

For both Cloud and self-hosted, Docker Desktop runs the `mcp/signoz-mcp-server` container locally (stdio). The user only provides their SigNoz **backend** URL + API key — they do not stand up or point at a separate MCP server. "Cloud vs self-hosted" is simply which backend URL is entered. The `readme.md` documents both install flows (Docker Desktop UI and CLI).

## Test plan

Verified locally end to end:

- [x] `go run ./cmd/validate -name signoz-mcp-server` passes (name, directory, title, YAML formatting, commit pin, secrets, config env, license, icon)
- [x] `task build -- --tools signoz-mcp-server` builds the image and lists **38 tools** (no `tools.json` needed)
- [x] `task catalog -- signoz-mcp-server` generates the catalog
- [x] `docker mcp catalog import` — server appears in the Docker Desktop MCP Toolkit
- [x] Live query against a SigNoz Cloud (US) instance: `signoz_list_services` returned real service data (call rates, error rates, p99)
