### PR TITLE
Add Tuning Engines MCP server

### DIFF
--- a/servers/tuning-engines/server.yaml
+++ b/servers/tuning-engines/server.yaml
@@ -1,0 +1,27 @@
+name: tuning-engines
+image: mcp/tuning-engines
+type: server
+meta:
+  category: devops
+  tags:
+    - ai
+    - governance
+    - observability
+    - llm
+    - mcp
+about:
+  title: Tuning Engines
+  description: Govern model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics.
+  icon: https://app.tuningengines.com/icon.png
+source:
+  project: https://github.com/cerebrixos-org/tuning-engines-cli
+  commit: b6369de5658b7df2f8e3c3794333eb9645b7cec2
+run:
+  allowHosts:
+    - app.tuningengines.com:443
+config:
+  description: Configure your tenant-scoped Tuning Engines API key. Create a key in the Tuning Engines web app or with the Tuning Engines CLI.
+  secrets:
+    - name: tuning-engines.api_key
+      env: TE_API_KEY
+      example: te_your_api_key


### PR DESCRIPTION
## Summary
Add the Tuning Engines MCP server to Docker MCP Registry. Tuning Engines is a governed AI runtime for model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics.

The public MCP server is containerized from the source repository and requires one tenant-scoped `TE_API_KEY` secret. It intentionally refuses raw secret-bearing mutation fields and keeps credential-bearing S3 setup workflows in the CLI/web UI.

## Verification
- `go run ./cmd/validate --name tuning-engines`
- `go run ./cmd/build --tools tuning-engines`
  - built `mcp/tuning-engines` from pinned commit
  - discovered 69 tools
- `go run ./cmd/catalog tuning-engines`
- `go test ./...`