### PR TITLE
Add Forge Cascade MCP server

### DIFF
--- a/servers/forge-cascade-mcp/readme.md
+++ b/servers/forge-cascade-mcp/readme.md
@@ -1,0 +1,7 @@
+Docs: https://sunflash12.github.io/ForgeV3/mcp.html
+
+Buyer route: https://sunflash12.github.io/ForgeV3/mcp-agent-memory.html
+
+Public connector repository: https://github.com/SunFlash12/forge-cascade-mcp
+
+Official MCP Registry listing: https://registry.modelcontextprotocol.io/?search=io.github.SunFlash12%2Fforge-cascade-mcp

--- a/servers/forge-cascade-mcp/server.yaml
+++ b/servers/forge-cascade-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: forge-cascade-mcp
+image: ghcr.io/sunflash12/forge-cascade-mcp:v0.1.5
+type: server
+meta:
+  category: knowledge
+  tags:
+    - knowledge
+    - memory
+    - rag
+    - ai
+    - docker
+about:
+  title: Forge Cascade MCP Memory Server
+  description: AI memory buyer routing with Forge docs, pricing, enterprise intake, and MCP discovery. Exposes tools for enterprise AI memory fit checks and direct checkout paths.
+  icon: https://github.com/SunFlash12.png
+source:
+  project: https://github.com/SunFlash12/forge-cascade-mcp
+  commit: c6eed75a87aefa05f4531edc9f0f9ad7a84717cc

--- a/servers/forge-cascade-mcp/server.yaml
+++ b/servers/forge-cascade-mcp/server.yaml
@@ -1,5 +1,5 @@
 name: forge-cascade-mcp
-image: ghcr.io/sunflash12/forge-cascade-mcp:v0.1.5
+image: ghcr.io/sunflash12/forge-cascade-mcp:v0.1.7
 type: server
 meta:
   category: knowledge
@@ -11,8 +11,8 @@ meta:
     - docker
 about:
   title: Forge Cascade MCP Memory Server
-  description: AI memory buyer routing with Forge docs, pricing, enterprise intake, and MCP discovery. Exposes tools for enterprise AI memory fit checks and direct checkout paths.
+  description: AI memory buyer routing with Forge docs, pricing, enterprise intake, MCP discovery, direct checkout paths, and paid-route recommendations.
   icon: https://github.com/SunFlash12.png
 source:
   project: https://github.com/SunFlash12/forge-cascade-mcp
-  commit: c6eed75a87aefa05f4531edc9f0f9ad7a84717cc
+  commit: 23ad35c1f1a150d3a36fb5a49a777799276fea91

--- a/servers/forge-cascade-mcp/tools.json
+++ b/servers/forge-cascade-mcp/tools.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "forge_buyer_routes",
+    "description": "Return public Forge Cascade buyer, documentation, pricing, enterprise intake, OpenAPI, MCP, and A2A discovery routes for AI memory and private RAG buyers.",
+    "arguments": []
+  },
+  {
+    "name": "forge_checkout_links",
+    "description": "Return ranked Forge Cascade Stripe checkout paths, starting with enterprise annual, priority retainer, deployment deposit, and rush paid pilot routes.",
+    "arguments": []
+  }
+]

--- a/servers/forge-cascade-mcp/tools.json
+++ b/servers/forge-cascade-mcp/tools.json
@@ -8,5 +8,31 @@
     "name": "forge_checkout_links",
     "description": "Return ranked Forge Cascade Stripe checkout paths, starting with enterprise annual, priority retainer, deployment deposit, and rush paid pilot routes.",
     "arguments": []
+  },
+  {
+    "name": "forge_paid_route_for_context",
+    "description": "Recommend the highest-value Forge checkout route from buyer context, budget, urgency, and procurement authority signals.",
+    "arguments": [
+      {
+        "name": "buyer_context",
+        "description": "Buyer intent, corpus, risk, deployment, or procurement context.",
+        "required": false
+      },
+      {
+        "name": "budget_usd",
+        "description": "Known buyer budget in USD; use 0 when unknown.",
+        "required": false
+      },
+      {
+        "name": "urgency_days",
+        "description": "Days until the buyer needs action; use 0 when unknown.",
+        "required": false
+      },
+      {
+        "name": "has_procurement_authority",
+        "description": "Whether the buyer can approve or influence purchase.",
+        "required": false
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds Forge Cascade MCP Memory Server to the Docker MCP registry using the current public GHCR image.

## Proof and Metadata

- Image: `ghcr.io/sunflash12/forge-cascade-mcp:v0.1.7`
- Source: https://github.com/SunFlash12/forge-cascade-mcp
- Reviewer fast path: https://github.com/SunFlash12/forge-cascade-mcp#buyer-and-reviewer-fast-path
- Docs: https://forgecascade.org/docs/agents
- Official MCP Registry listing: https://registry.modelcontextprotocol.io/?search=io.github.SunFlash12%2Fforge-cascade-mcp
- Public proof pack: https://forgecascade.org/llms.txt
- MCP Server Hub listing: https://mcpserver.dev/s/forge-cascade-mcp-memory-server_uo525w0
- Buyer route: https://forgecascade.org/buy
- Checkout discovery JSON: https://forgecascade.org/buy.json

The server exposes public buyer-route, checkout-link, and buyer-context discovery tools only; it does not proxy private customer data or require secrets. The README puts reviewer and buyer routing first, including direct `forge_checkout_links` routes for enterprise annual, priority retainer, deployment deposit, and rush paid pilot paths.

## Reviewer Updates

- May 31, 2026 UTC: v0.1.7 adds `forge_paid_route_for_context`, a buyer-context tool that recommends the highest-value checkout route from budget, urgency, and procurement-authority signals. The official MCP Registry marks `io.github.SunFlash12/forge-cascade-mcp` version 0.1.7 as latest with OCI package `ghcr.io/sunflash12/forge-cascade-mcp:v0.1.7`, and ToolSDK package validation found all 3 tools: `forge_buyer_routes`, `forge_checkout_links`, and `forge_paid_route_for_context`.
- June 1, 2026 UTC: the public connector includes `LAUNCHGUIDE.md` for marketplace auto-fill and launch review: https://github.com/SunFlash12/forge-cascade-mcp/blob/main/LAUNCHGUIDE.md.
- June 5, 2026 UTC: Forge buyer and proof routing is route-first on the production domain. Use https://forgecascade.org/buy for buyer routing, https://forgecascade.org/llms.txt for the public proof pack, https://forgecascade.org/.well-known/mcp.json for MCP metadata, and https://forgecascade.org/buy.json for checkout discovery. Production Forge routes preserve attribution before Stripe handoff; the proof pack records the remaining MCP fallback field pending production redeploy.