### PR TITLE
Add Arra Oracle MCP server

### DIFF
--- a/servers/arra-oracle-v3/server.yaml
+++ b/servers/arra-oracle-v3/server.yaml
@@ -1,0 +1,43 @@
+name: arra-oracle-v3
+image: mcp/arra-oracle-v3
+type: server
+meta:
+  category: knowledge
+  tags:
+    - memory
+    - semantic-search
+    - sqlite
+    - lancedb
+    - oracle
+about:
+  title: Arra Oracle
+  description: Personal MCP memory server with semantic search over an Oracle vault. Stores knowledge in SQLite FTS5 + LanceDB and exposes oracle_* tools for search, learnings, handoffs, traces, and verification.
+  icon: https://avatars.githubusercontent.com/u/214694947?s=200&v=4
+source:
+  project: https://github.com/Soul-Brews-Studio/arra-oracle-v3
+  commit: 274216f78740b5230916ef75fd8b91f7bf78c560
+  buildTarget: mcp-stdio
+run:
+  env:
+    ORACLE_API: embedded
+  volumes:
+    - arra-oracle-data:/data
+config:
+  description: Optional semantic embedding backend and HTTP-writer routing. Arra works without configuration via SQLite FTS5 in the persistent /data volume.
+  env:
+    - name: OLLAMA_BASE_URL
+      example: http://host.docker.internal:11434
+      value: "{{arra-oracle-v3.ollama_base_url}}"
+    - name: ORACLE_API
+      example: embedded
+      value: "{{arra-oracle-v3.oracle_api}}"
+  parameters:
+    type: object
+    properties:
+      ollama_base_url:
+        type: string
+        description: Optional Ollama endpoint for semantic vector embeddings. Leave blank for FTS5-only search.
+      oracle_api:
+        type: string
+        description: Use embedded for standalone Docker MCP usage, or http://host.docker.internal:47778 to proxy through a long-running Arra HTTP writer.
+        default: embedded

--- a/servers/arra-oracle-v3/tools.json
+++ b/servers/arra-oracle-v3/tools.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "oracle_search",
+    "description": "Hybrid FTS5 + vector search over the Oracle vault."
+  },
+  {
+    "name": "oracle_read",
+    "description": "Read a specific vault file by path or document id."
+  },
+  {
+    "name": "oracle_learn",
+    "description": "Add a learning or pattern and index it into the vault."
+  },
+  {
+    "name": "oracle_list",
+    "description": "List indexed knowledge entries with filters and pagination."
+  },
+  {
+    "name": "oracle_stats",
+    "description": "Report vector, FTS5, vault, and backend health statistics."
+  },
+  {
+    "name": "oracle_concepts",
+    "description": "Aggregate concept tags across the indexed corpus."
+  },
+  {
+    "name": "oracle_thread",
+    "description": "Start or continue an Oracle discussion thread."
+  },
+  {
+    "name": "oracle_threads",
+    "description": "List Oracle discussion threads."
+  },
+  {
+    "name": "oracle_thread_read",
+    "description": "Read a full Oracle discussion thread."
+  },
+  {
+    "name": "oracle_thread_update",
+    "description": "Update an Oracle discussion thread status."
+  },
+  {
+    "name": "oracle_trace",
+    "description": "Log a trace event with files, commits, issues, and findings."
+  },
+  {
+    "name": "oracle_trace_list",
+    "description": "List recent traces with optional filters."
+  },
+  { "name": "oracle_trace_get", "description": "Read a trace by id." },
+  {
+    "name": "oracle_trace_link",
+    "description": "Link two traces into a causal or topical chain."
+  },
+  { "name": "oracle_trace_unlink", "description": "Remove a trace link." },
+  { "name": "oracle_trace_chain", "description": "Walk a linked trace chain." },
+  {
+    "name": "oracle_supersede",
+    "description": "Mark an older document as superseded without deleting it."
+  },
+  {
+    "name": "oracle_handoff",
+    "description": "Write session context to the Oracle inbox."
+  },
+  {
+    "name": "oracle_inbox",
+    "description": "List and preview pending handoff files."
+  },
+  {
+    "name": "oracle_reflect",
+    "description": "Return a random principle or learning for reflection."
+  },
+  {
+    "name": "oracle_verify",
+    "description": "Verify disk-vs-index knowledge base integrity."
+  }
+]


### PR DESCRIPTION
Add Arra Oracle as a Docker-built MCP server.

Arra is a personal MCP memory server for Oracle vaults. It exposes `oracle_*` tools for semantic/FTS search, learnings, handoffs, traces, supersession, and index verification.

Implementation notes:
- Uses `source.buildTarget: mcp-stdio` because Arra's default Docker target remains its HTTP server for `docker compose` compatibility.
- Uses `ORACLE_API=embedded` and a persistent `arra-oracle-data:/data` volume for standalone Docker MCP Toolkit use.
- Optional `OLLAMA_BASE_URL` enables vector embeddings; without it Arra serves SQLite FTS5-only search.

Validation run locally:
- `npx prettier --check servers/arra-oracle-v3/server.yaml servers/arra-oracle-v3/tools.json`
- `go run ./cmd/validate --name arra-oracle-v3` (via golang container with npm installed)
- `docker buildx build --target mcp-stdio -t arra-oracle-v3:registry-source-smoke --load https://github.com/Soul-Brews-Studio/arra-oracle-v3.git#274216f78740b5230916ef75fd8b91f7bf78c560`
- stdio smoke: `initialize` + `tools/list` returned JSON on stdout and 22 runtime tools
