### PR TITLE
Add VINdata MCP remote server

### DIFF
--- a/servers/vindata-mcp/server.yaml
+++ b/servers/vindata-mcp/server.yaml
@@ -1,0 +1,25 @@
+name: vindata-mcp
+type: server
+
+meta:
+  category: "developer-tools"
+  tags:
+    - vin
+    - automotive
+    - vehicle-data
+    - europe
+    - dealers
+    - vin-decoder
+    - remote
+
+about:
+  title: "VINdata MCP"
+  description: "VINdata MCP provides VIN decoding and European vehicle data for automotive workflows. It exposes a decode_vin tool that returns structured vehicle information including make, model, year, equipment data, and derived feature flags."
+  icon: "https://vindata.io/assets/vin-logo-BWkY0BRe.png"
+
+source:
+  project: "https://github.com/bhuvanabala/vindata-mcp"
+
+remote:
+  transport_type: streamable-http
+  url: https://vindata-mcp.vindata.workers.dev/mcp


### PR DESCRIPTION
Adds VINdata MCP, a hosted remote MCP server for VIN decoding and European vehicle data.

Repository:
https://github.com/bhuvanabala/vindata-mcp

Endpoint:
https://vindata-mcp.vindata.workers.dev/mcp

Transport:
streamable-http

Tool:
decode_vin