### PR TITLE
Add mcpskills MCP server

### DIFF
--- a/servers/mcpskills/server.yaml
+++ b/servers/mcpskills/server.yaml
@@ -1,0 +1,17 @@
+name: mcpskills
+image: mcp/mcpskills
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - trust
+    - safety-scanner
+    - mcp
+about:
+  title: MCP Skills
+  description: Pre-install trust scoring and safety scanning for MCP servers, AI skills, and npm packages — 15 signals including OSV/KEV/EPSS vulnerability intelligence, with a go/no-go auto_gate tool.
+  icon: https://avatars.githubusercontent.com/u/196358725?v=4
+source:
+  project: https://github.com/BeBraveBeKind/mcpskills-server
+  commit: 52bf471ab5916475100369e5bb48b6646d992fb6

--- a/servers/mcpskills/server.yaml
+++ b/servers/mcpskills/server.yaml
@@ -11,7 +11,7 @@ meta:
 about:
   title: MCP Skills
   description: Pre-install trust scoring and safety scanning for MCP servers, AI skills, and npm packages — 15 signals including OSV/KEV/EPSS vulnerability intelligence, with a go/no-go auto_gate tool.
-  icon: https://avatars.githubusercontent.com/u/196358725?v=4
+  icon: https://raw.githubusercontent.com/BeBraveBeKind/mcpskills-server/9b9c52b38f4cca7f92c545f67d7a4abeca9b55cc/icon.png
 source:
   project: https://github.com/BeBraveBeKind/mcpskills-server
   commit: 52bf471ab5916475100369e5bb48b6646d992fb6


### PR DESCRIPTION
Adds **MCP Skills** (`servers/mcpskills/`) — a pre-install trust layer for MCP servers, AI skills, and npm packages.

It scores any repo or package across 15 signals (including OSV/KEV/EPSS vulnerability intelligence) and runs safety scanning for prompt injection, credential theft, and supply-chain risk. The `auto_gate` tool returns a go/no-go install decision.

- **Source:** https://github.com/BeBraveBeKind/mcpskills-server (MIT, includes a Dockerfile)
- **npm:** `@mcpskillsio/server` (published with provenance)
- **Official MCP Registry:** `io.mcpskills/server`
- **Type:** stdio, zero-config (free tier; optional `MCPSKILLS_API_KEY` for higher limits)

Submitted as **Docker-built** (no `run`/`config` needed). The server answers introspection (`initialize` + `tools/list`) without any config, so tool discovery should succeed at build time.