### PR TITLE
Add AlgoVault remote MCP server (algovault-remote)

### DIFF
--- a/servers/algovault-remote/readme.md
+++ b/servers/algovault-remote/readme.md
@@ -1,6 +1,6 @@
 # AlgoVault
 
-AI trading signal intelligence with 91.7% verified accuracy across 152,000+ calls. Composite BUY/SELL/HOLD verdicts with confidence scores, regime classification, and cross-venue funding analysis. Track record Merkle-verified on Base L2. 760+ assets, 11 timeframes. Free tier available.
+AI trading intelligence with 91.6% verified accuracy across 375,000+ calls. Composite BUY/SELL/HOLD verdicts with confidence, regime classification, and cross-venue funding analysis. Track record Merkle-verified on Base L2. 1,300+ assets, 11 timeframes. Free tier available.
 
 Docs: https://algovault.com/docs.html
 

--- a/servers/algovault-remote/readme.md
+++ b/servers/algovault-remote/readme.md
@@ -1,0 +1,9 @@
+# AlgoVault
+
+AI trading signal intelligence with 91.7% verified accuracy across 152,000+ calls. Composite BUY/SELL/HOLD verdicts with confidence scores, regime classification, and cross-venue funding analysis. Track record Merkle-verified on Base L2. 760+ assets, 11 timeframes. Free tier available.
+
+Docs: https://algovault.com/docs.html
+
+MCP endpoint: https://api.algovault.com/mcp (Streamable HTTP)
+
+Built by AlgoVault Labs.

--- a/servers/algovault-remote/readme.md
+++ b/servers/algovault-remote/readme.md
@@ -1,6 +1,6 @@
 # AlgoVault
 
-AI trading intelligence with 91.6% verified accuracy across 375,000+ calls. Composite BUY/SELL/HOLD verdicts with confidence, regime classification, and cross-venue funding analysis. Track record Merkle-verified on Base L2. 1,300+ assets, 11 timeframes. Free tier available.
+AI trading intelligence with 91.7% verified accuracy across 500,000+ calls. Composite BUY/SELL/HOLD verdicts with confidence, regime classification, and cross-venue funding analysis. Track record Merkle-verified on Base L2. 1,700+ assets, 11 timeframes. Free tier available.
 
 Docs: https://algovault.com/docs.html
 

--- a/servers/algovault-remote/server.yaml
+++ b/servers/algovault-remote/server.yaml
@@ -10,7 +10,7 @@ meta:
     - remote
 about:
   title: AlgoVault
-  description: "91.7% verified trading signals for AI agents. Composite verdicts, regime classification, 760+ assets. Merkle-verified on Base L2."
+  description: "91.6% verified trading intelligence for AI agents. Composite verdicts, regime classification, 1,300+ assets. Merkle-verified on Base L2."
   icon: https://www.google.com/s2/favicons?domain=algovault.com&sz=64
 remote:
   transport_type: streamable-http

--- a/servers/algovault-remote/server.yaml
+++ b/servers/algovault-remote/server.yaml
@@ -1,0 +1,17 @@
+name: algovault-remote
+type: remote
+meta:
+  category: ai-ml
+  tags:
+    - ai
+    - finance
+    - trading
+    - crypto
+    - remote
+about:
+  title: AlgoVault
+  description: "91.7% verified trading signals for AI agents. Composite verdicts, regime classification, 760+ assets. Merkle-verified on Base L2."
+  icon: https://www.google.com/s2/favicons?domain=algovault.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://api.algovault.com/mcp

--- a/servers/algovault-remote/server.yaml
+++ b/servers/algovault-remote/server.yaml
@@ -10,7 +10,7 @@ meta:
     - remote
 about:
   title: AlgoVault
-  description: "91.6% verified trading intelligence for AI agents. Composite verdicts, regime classification, 1,300+ assets. Merkle-verified on Base L2."
+  description: "91.7% verified trading intelligence for AI agents. Composite verdicts, regime classification, 1,700+ assets. Merkle-verified on Base L2."
   icon: https://www.google.com/s2/favicons?domain=algovault.com&sz=64
 remote:
   transport_type: streamable-http

--- a/servers/algovault-remote/tools.json
+++ b/servers/algovault-remote/tools.json
@@ -1,37 +1,37 @@
 [
   {
     "name": "get_trade_call",
-    "description": "Composite verdict BUY SELL HOLD trade call for crypto perpetual futures on Binance Bybit OKX Bitget Hyperliquid. Returns verdict, confidence, market regime, funding rate, reasoning. Verified track record, merkle anchor on Base — on-chain verified. MCP tool for trading. Cross-venue multi-exchange AI trading signal for Claude trading agents.",
+    "description": "Returns a composite verdict — BUY SELL HOLD trade call with confidence and market regime — for one crypto or tokenized-stock perpetual futures. One asset only; for a whole-market scan use scan_trade_calls, for US stocks use get_equity_call. Read-only: reads live exchange APIs, no orders. Verified track record, on-chain verified merkle anchor.",
     "arguments": []
   },
   {
     "name": "get_trade_signal",
-    "description": "Composite verdict BUY SELL HOLD trade call for crypto perpetual futures on Binance Bybit OKX Bitget Hyperliquid. Returns verdict, confidence, market regime, funding rate, reasoning. Verified track record, merkle anchor on Base — on-chain verified. MCP tool for trading. Cross-venue multi-exchange AI trading signal for Claude trading agents. [ALIAS] This tool is an alias of get_trade_call — same behavior, kept for backward compatibility.",
-    "arguments": []
-  },
-  {
-    "name": "scan_funding_arb",
-    "description": "Cross-venue funding arbitrage scanner. Funding rate spreads across Binance Bybit OKX Bitget Hyperliquid perpetual futures — long one, short other. Composite verdict, multi-exchange funding intelligence. MCP tool for trading. AI trading signal for crypto quant + Claude trading agents. Verified track record, on-chain verified merkle anchor on Base.",
+    "description": "Returns a composite verdict — BUY SELL HOLD trade call with confidence and market regime — for one crypto or tokenized-stock perpetual futures. One asset only; for a whole-market scan use scan_trade_calls, for US stocks use get_equity_call. Read-only: reads live exchange APIs, no orders. Verified track record, on-chain verified merkle anchor. [ALIAS] This tool is an alias of get_trade_call — same behavior, kept for backward compatibility.",
     "arguments": []
   },
   {
     "name": "get_market_regime",
-    "description": "Market regime classifier — TRENDING_UP TRENDING_DOWN RANGING VOLATILE — for crypto perpetual futures on Binance Bybit OKX Bitget Hyperliquid. Composite verdict blends trend ranging signals, volatility, cross-venue funding rate sentiment. Returns label, confidence, strategy hint. MCP tool for trading. Verified track record, merkle anchor on Base.",
+    "description": "Returns the market regime — TRENDING_UP TRENDING_DOWN RANGING VOLATILE — with confidence and a strategy hint, for one crypto perpetual futures. Composite verdict blends trend ranging and cross-venue funding rate sentiment. For a US equity use get_equity_regime. Read-only, live exchange APIs. Verified track record, on-chain verified merkle anchor.",
+    "arguments": []
+  },
+  {
+    "name": "scan_funding_arb",
+    "description": "Ranked cross-venue funding arbitrage across major crypto perpetual futures venues — funding rate spreads, long one venue short another, as a BUY SELL HOLD composite verdict per pair. AI trading signal for crypto quant and Claude trading agents. Trade call via get_trade_call, market regime via get_market_regime. On-chain verified merkle anchor.",
     "arguments": []
   },
   {
     "name": "scan_trade_calls",
-    "description": "Cross-asset market scanner — composite verdict BUY SELL HOLD trade calls across the top 1-100 crypto perpetual futures by open interest on Binance Bybit OKX Bitget Hyperliquid. Returns ranked non-HOLD calls with confidence and market regime. One scan, whole-market coverage for AI trading agents. Use get_trade_call for per-coin depth and reasoning.",
-    "arguments": []
-  },
-  {
-    "name": "search_knowledge",
-    "description": "Ask AlgoVault any question about its MCP tools, response shapes, integration patterns (LangChain / LlamaIndex / MAF / CrewAI), or code examples. Returns ranked snippets from the canonical knowledge bundle. Use this BEFORE attempting any tool call to confirm correct parameter usage and avoid hallucinating tool shapes. Fast (BM25 lexical search, no LLM call, no quota cost). For natural-language synthesized answers, use chat_knowledge instead.",
+    "description": "Returns ranked BUY SELL HOLD trade calls across the top crypto perpetual futures by open interest — one scan for whole-market coverage, each with confidence and market regime. Use this for breadth; use get_trade_call for per-coin depth and reasoning. Read-only: reads live exchange APIs, places no orders.",
     "arguments": []
   },
   {
     "name": "chat_knowledge",
-    "description": "Ask AlgoVault a natural-language question — get a synthesized answer with citations, grounded in the canonical knowledge bundle (every MCP tool description, response shape, integration tutorial, and code example). Use this when you need an explanation, code pattern, or \"how do I\" answer. For raw ranked snippets without LLM synthesis, use search_knowledge (faster, no quota cost). Quota: Free 10/month, Starter 50/month, Pro 200/month, Enterprise 2000/month.",
+    "description": "Returns a synthesized natural-language answer with citations, grounded in the AlgoVault knowledge bundle (every MCP tool description, response shape, integration tutorial, and code example). Use when you need an explanation, code pattern, or how-to; for raw ranked snippets without LLM synthesis use search_knowledge (faster, no quota cost). Read-only: calls an LLM, no other side effects. Quota: Free 10/month, Starter 50, Pro 200, Enterprise 2000.",
+    "arguments": []
+  },
+  {
+    "name": "search_knowledge",
+    "description": "Returns ranked snippets from the AlgoVault knowledge bundle answering a question about its MCP tools, response shapes, integration patterns (LangChain, LlamaIndex, MAF, CrewAI), or code examples. Call this BEFORE other tool calls to confirm parameter usage and avoid hallucinating tool shapes. Fast: BM25 lexical search, no LLM call, no quota cost. For a synthesized natural-language answer use chat_knowledge. Read-only, no side effects.",
     "arguments": []
   }
 ]

--- a/servers/algovault-remote/tools.json
+++ b/servers/algovault-remote/tools.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "get_trade_call",
+    "description": "Composite verdict BUY SELL HOLD trade call for crypto perpetual futures on Binance Bybit OKX Bitget Hyperliquid. Returns verdict, confidence, market regime, funding rate, reasoning. Verified track record, merkle anchor on Base — on-chain verified. MCP tool for trading. Cross-venue multi-exchange AI trading signal for Claude trading agents.",
+    "arguments": []
+  },
+  {
+    "name": "get_trade_signal",
+    "description": "Composite verdict BUY SELL HOLD trade call for crypto perpetual futures on Binance Bybit OKX Bitget Hyperliquid. Returns verdict, confidence, market regime, funding rate, reasoning. Verified track record, merkle anchor on Base — on-chain verified. MCP tool for trading. Cross-venue multi-exchange AI trading signal for Claude trading agents. [ALIAS] This tool is an alias of get_trade_call — same behavior, kept for backward compatibility.",
+    "arguments": []
+  },
+  {
+    "name": "scan_funding_arb",
+    "description": "Cross-venue funding arbitrage scanner. Funding rate spreads across Binance Bybit OKX Bitget Hyperliquid perpetual futures — long one, short other. Composite verdict, multi-exchange funding intelligence. MCP tool for trading. AI trading signal for crypto quant + Claude trading agents. Verified track record, on-chain verified merkle anchor on Base.",
+    "arguments": []
+  },
+  {
+    "name": "get_market_regime",
+    "description": "Market regime classifier — TRENDING_UP TRENDING_DOWN RANGING VOLATILE — for crypto perpetual futures on Binance Bybit OKX Bitget Hyperliquid. Composite verdict blends trend ranging signals, volatility, cross-venue funding rate sentiment. Returns label, confidence, strategy hint. MCP tool for trading. Verified track record, merkle anchor on Base.",
+    "arguments": []
+  },
+  {
+    "name": "scan_trade_calls",
+    "description": "Cross-asset market scanner — composite verdict BUY SELL HOLD trade calls across the top 1-100 crypto perpetual futures by open interest on Binance Bybit OKX Bitget Hyperliquid. Returns ranked non-HOLD calls with confidence and market regime. One scan, whole-market coverage for AI trading agents. Use get_trade_call for per-coin depth and reasoning.",
+    "arguments": []
+  },
+  {
+    "name": "search_knowledge",
+    "description": "Ask AlgoVault any question about its MCP tools, response shapes, integration patterns (LangChain / LlamaIndex / MAF / CrewAI), or code examples. Returns ranked snippets from the canonical knowledge bundle. Use this BEFORE attempting any tool call to confirm correct parameter usage and avoid hallucinating tool shapes. Fast (BM25 lexical search, no LLM call, no quota cost). For natural-language synthesized answers, use chat_knowledge instead.",
+    "arguments": []
+  },
+  {
+    "name": "chat_knowledge",
+    "description": "Ask AlgoVault a natural-language question — get a synthesized answer with citations, grounded in the canonical knowledge bundle (every MCP tool description, response shape, integration tutorial, and code example). Use this when you need an explanation, code pattern, or \"how do I\" answer. For raw ranked snippets without LLM synthesis, use search_knowledge (faster, no quota cost). Quota: Free 10/month, Starter 50/month, Pro 200/month, Enterprise 2000/month.",
+    "arguments": []
+  }
+]

--- a/servers/algovault-remote/tools.json
+++ b/servers/algovault-remote/tools.json
@@ -1,17 +1,17 @@
 [
   {
     "name": "get_trade_call",
-    "description": "Returns a composite verdict — BUY SELL HOLD trade call with confidence and market regime — for one crypto or tokenized-stock perpetual futures. One asset only; for a whole-market scan use scan_trade_calls, for US stocks use get_equity_call. Read-only: reads live exchange APIs, no orders. Verified track record, on-chain verified merkle anchor.",
+    "description": "Returns a composite verdict — BUY SELL HOLD trade call with confidence and market regime — for one crypto or tokenized-stock perpetual futures. One asset only; for a whole-market scan use scan_trade_calls. Read-only: reads live exchange APIs, no orders. Verified track record via performance://signal-performance; on-chain verified merkle anchor.",
     "arguments": []
   },
   {
     "name": "get_trade_signal",
-    "description": "Returns a composite verdict — BUY SELL HOLD trade call with confidence and market regime — for one crypto or tokenized-stock perpetual futures. One asset only; for a whole-market scan use scan_trade_calls, for US stocks use get_equity_call. Read-only: reads live exchange APIs, no orders. Verified track record, on-chain verified merkle anchor. [ALIAS] This tool is an alias of get_trade_call — same behavior, kept for backward compatibility.",
+    "description": "Returns a composite verdict — BUY SELL HOLD trade call with confidence and market regime — for one crypto or tokenized-stock perpetual futures. One asset only; for a whole-market scan use scan_trade_calls. Read-only: reads live exchange APIs, no orders. Verified track record via performance://signal-performance; on-chain verified merkle anchor. [ALIAS] This tool is an alias of get_trade_call — same behavior, kept for backward compatibility. Prefer get_trade_call for new integrations.",
     "arguments": []
   },
   {
     "name": "get_market_regime",
-    "description": "Returns the market regime — TRENDING_UP TRENDING_DOWN RANGING VOLATILE — with confidence and a strategy hint, for one crypto perpetual futures. Composite verdict blends trend ranging and cross-venue funding rate sentiment. For a US equity use get_equity_regime. Read-only, live exchange APIs. Verified track record, on-chain verified merkle anchor.",
+    "description": "Returns the market regime — TRENDING_UP TRENDING_DOWN RANGING VOLATILE — with confidence and a strategy hint, for one crypto perpetual futures. Composite verdict blends trend ranging and cross-venue funding rate sentiment. Read-only, live exchange APIs. Verified track record via performance://signal-performance; on-chain verified merkle anchor.",
     "arguments": []
   },
   {


### PR DESCRIPTION
## MCP Server Information

**Server Name:** algovault-remote
**Repository URL:** https://github.com/AlgoVaultLabs/crypto-quant-signal-mcp
**Brief Description:** AI trading signal intelligence for AI agents — composite BUY/SELL/HOLD verdicts with confidence scores, market-regime classification, cross-venue funding-rate analysis, and a top-N market scanner across 5 crypto perpetual-futures venues (Binance, Bybit, OKX, Bitget, Hyperliquid). Track record Merkle-verified on Base L2. Free tier available.

This is a **remote** MCP server (`type: remote`, Streamable HTTP at `https://api.algovault.com/mcp`), added following the `notion-remote` / `dappier-remote` template (no OAuth; free tier needs no credentials).

## Basic Requirements

- [x] **Open Source**: Source is MIT-licensed (`crypto-quant-signal-mcp`, `package.json` → `"license": "MIT"`).
- [x] **MCP Compliant**: Implements the MCP spec; live `tools/list` over Streamable HTTP (3-step handshake) verified.
- [x] **Active Development**: Source repo actively maintained (latest push 2026-06-04).
- [ ] **Docker Artifact**: N/A — `type: remote` (hosted endpoint), no Dockerfile required per the remote flow in `add_mcp_server.md` (cf. `notion-remote`, `dappier-remote`).
- [x] **Documentation**: README + docs at https://algovault.com/docs.html
- [x] **Security Contact**: GitHub private vulnerability reporting on the source repo.

## Submitter Checklist

- [x] This server meets the basic requirements listed above (remote-server adaptations noted).
- [x] I understand this will undergo automated and manual review.
- [ ] `task validate -- --name algovault-remote` — `task`/`go` unavailable in the submitter environment; relying on registry CI. The entry mirrors the validated `notion-remote` / `dappier-remote` schema.
- [ ] `task build -- --tools algovault-remote` — same note as above.
- [ ] Test credentials — N/A; the free tier needs no credentials (e.g. `get_trade_call` is callable anonymously).
