### PR TITLE
Add Savvly MCP server

### DIFF
--- a/servers/savvly/server.yaml
+++ b/servers/savvly/server.yaml
@@ -1,0 +1,19 @@
+name: savvly
+image: mcp/savvly
+type: server
+meta:
+  category: productivity
+  tags:
+    - mcp
+    - model-context-protocol
+    - savvly
+    - retirement
+    - longevity
+    - ai-agent
+about:
+  title: Savvly
+  description: MCP server for Savvly's Longevity Benefit Fund. Exposes product information, eligibility checks, Savvly-vs-alternative comparisons, an audience-tagged Q&A content library, and retirement/lump-sum/monthly projections (with inline MCP Apps chart widgets). Bundled as a single self-contained Node file — no install step.
+  icon: https://github.com/Savvly/savvly-mcp/raw/main/media/logo-400.png
+source:
+  project: https://github.com/Savvly/savvly-mcp
+  branch: main


### PR DESCRIPTION
Adds the **Savvly** MCP server to the Docker MCP Catalog under **`mcp/savvly`** (Docker-built).

- **Source:** https://github.com/Savvly/savvly-mcp (`main` branch, Dockerfile at the root — already present, version-pinned)
- **What it does:** read-only (all 8 tools `readOnlyHint: true`) — product info on the Savvly Longevity Benefit Fund, Savvly-vs-alternative comparisons, eligibility checks, an audience-tagged Q&A content library, and retirement / lump-sum / monthly projections (with inline MCP Apps chart widgets).
- **Identity:** `com.savvly/savvly` on the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=com.savvly/savvly). Also published to npm (`@savvly/mcp-server`), PyPI (`savvly-mcp-server`), NuGet (`Savvly.McpServer`), OCI (`ghcr.io/savvly/savvly-mcp-server`), and MCPB.
- **Auth / config:** none required. The Dockerfile carries `LABEL io.modelcontextprotocol.server.name="com.savvly/savvly"` and `npm install -g @savvly/mcp-server@<pinned>` so the catalog image is reproducible from the published npm package.

Happy to adjust per maintainer feedback.
