### PR TITLE
Add Savvly MCP server

### DIFF
--- a/servers/savvly/server.yaml
+++ b/servers/savvly/server.yaml
@@ -1,0 +1,19 @@
+name: savvly
+image: mcp/savvly
+type: server
+meta:
+  category: finance
+  tags:
+    - mcp
+    - model-context-protocol
+    - savvly
+    - retirement
+    - longevity
+    - ai-agent
+about:
+  title: Savvly
+  description: MCP server for Savvly's Longevity Benefit Fund. Exposes product information, eligibility checks, Savvly-vs-alternative comparisons, an audience-tagged Q&A content library, and retirement/lump-sum/monthly projections (with inline MCP Apps chart widgets). Bundled as a single self-contained Node file — no install step.
+  icon: https://github.com/Savvly/savvly-mcp/raw/main/media/logo-400.png
+source:
+  project: https://github.com/Savvly/savvly-mcp
+  branch: main


### PR DESCRIPTION
Adds the **Savvly** MCP server (`com.savvly/savvly`) under **finance**.

- **Source repo (Docker-built):** https://github.com/Savvly/savvly-mcp — `Dockerfile` at the root `npm install -g @savvly/mcp-server` and runs the stdio server (`ENTRYPOINT ["savvly-mcp"]`).
- **What it does:** read-only (8 tools, all `readOnlyHint: true`) — Savvly Longevity Benefit Fund product info, Savvly-vs-alternative comparisons, eligibility checks, an audience-tagged Q&A library, and retirement / lump-sum / monthly projections (projection tools render inline MCP Apps chart widgets).
- **Also published:** Official MCP Registry (`com.savvly/savvly`), npm, PyPI, NuGet, ghcr.io, MCPB; hosted remote at https://api.savvly.com/mcp.
- No configuration, no secrets, no auth required.

Letting Docker build the image into the `mcp/` namespace (no `image:` override) for signatures + SBOM + provenance.
