### PR TITLE
Add Scholar Feed MCP server

### DIFF
--- a/servers/scholar-feed/server.yaml
+++ b/servers/scholar-feed/server.yaml
@@ -1,0 +1,40 @@
+name: scholar-feed
+image: mcp/scholar-feed
+type: server
+meta:
+  category: productivity
+  tags:
+    - research
+    - papers
+    - arxiv
+    - search
+    - citations
+    - ai
+    - machine-learning
+about:
+  title: Scholar Feed
+  description: >-
+    A research copilot over 600,000+ CS/AI/ML papers: semantic search,
+    citation-graph traversal, co-author graphs, full-text extraction,
+    foundational-lineage lookup, text embeddings, and saved libraries,
+    collections, and standing watches. Works anonymously at 100 calls/day,
+    or 1,000/day with a free API key.
+  icon: https://raw.githubusercontent.com/YGao2005/scholar-feed-mcp/main/assets/icon-marketplace.png
+source:
+  project: https://github.com/YGao2005/scholar-feed-mcp
+  commit: dbba3955aa9c74c20a19ba3f62299105602a2df3
+run:
+  allowHosts:
+    - api.scholarfeed.org:443
+config:
+  description: >-
+    Optional. Scholar Feed runs anonymously (100 calls/day) with no
+    configuration. To raise limits to 1,000 calls/day, supply a free API key
+    from https://www.scholarfeed.org/settings as the SF_API_KEY secret.
+  secrets:
+    - name: scholar-feed.api_key
+      env: SF_API_KEY
+      example: sf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      description: >-
+        Optional Scholar Feed API key (sf_...). Leave unset for anonymous mode.
+        Get a free key at https://www.scholarfeed.org/settings.


### PR DESCRIPTION
## Scholar Feed

Adds `servers/scholar-feed/server.yaml` for **Scholar Feed** — a research copilot over 600,000+ CS/AI/ML papers: semantic search, citation-graph traversal, co-author graphs, full-text extraction, foundational-lineage lookup, text embeddings, and saved libraries/collections/standing watches.

- **Source:** https://github.com/YGao2005/scholar-feed-mcp (MIT licensed)
- **Transport:** stdio (containerized; valid `Dockerfile` at repo root)
- **Network:** the server calls one backend host — `run.allowHosts: api.scholarfeed.org:443`
- **Auth:** **optional.** Runs anonymously at 100 calls/day with no configuration. An optional free API key (`SF_API_KEY`, `sf_...`) from https://www.scholarfeed.org/settings raises limits to 1,000/day. **No test credentials are required to review** — it works out of the box anonymously.
- npm: https://www.npmjs.com/package/scholar-feed-mcp · also in the official MCP registry as `io.github.YGao2005/scholar-feed-mcp`.

Pinned to source commit `dbba395` (default branch `main`), which carries the Dockerfile.