### PR TITLE
Add Savvly MCP server

### DIFF
--- a/servers/savvly/server.yaml
+++ b/servers/savvly/server.yaml
@@ -12,7 +12,7 @@ meta:
     - remote
 about:
   title: Savvly
-  description: "Savvly Longevity Benefit — retirement projections, product comparisons, eligibility, and FAQs for an SEC-registered fund offering market upside plus longevity protection."
+  description: "Explore Savvly MCP: retirement projections, eligibility, comparisons, and FAQs for an SEC-registered fund that pairs full market upside with later-life longevity payouts."
   icon: https://raw.githubusercontent.com/Savvly/savvly-mcp/main/logo.png
 remote:
   transport_type: streamable-http

--- a/servers/savvly/server.yaml
+++ b/servers/savvly/server.yaml
@@ -1,0 +1,19 @@
+name: savvly
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: finance
+  tags:
+    - finance
+    - retirement
+    - longevity
+    - investment
+    - remote
+about:
+  title: Savvly
+  description: "Savvly Longevity Benefit Fund: retirement projections, product comparisons, eligibility, and FAQs."
+  icon: https://raw.githubusercontent.com/Savvly/savvly-mcp/main/logo.png
+remote:
+  transport_type: streamable-http
+  url: https://api.savvly.com/mcp

--- a/servers/savvly/server.yaml
+++ b/servers/savvly/server.yaml
@@ -12,7 +12,7 @@ meta:
     - remote
 about:
   title: Savvly
-  description: "Savvly Longevity Benefit Fund: retirement projections, product comparisons, eligibility, and FAQs."
+  description: "Savvly Longevity Benefit — retirement projections, product comparisons, eligibility, and FAQs for an SEC-registered fund offering market upside plus longevity protection."
   icon: https://raw.githubusercontent.com/Savvly/savvly-mcp/main/logo.png
 remote:
   transport_type: streamable-http


### PR DESCRIPTION
Adds the **Savvly** MCP server to the catalog.

- **Type:** remote (streamable-http), hosted at `https://api.savvly.com/mcp`
- **Category:** finance
- **Auth:** none — public server, so **no test credentials needed**
- **About:** Savvly Longevity Benefit Fund — retirement projections (lump-sum, monthly, full trajectory), product comparisons, eligibility checks, and FAQ/content search. SEC-registered fund offering market upside plus longevity protection.

The server is published to the official MCP Registry (`com.savvly/savvly`) and exposes 8 read-only tools with `title` + `readOnlyHint` annotations. Tools are discovered dynamically over streamable-http. Source/public face: https://github.com/Savvly/savvly-mcp