### PR TITLE
Add ProposalCraft — MCP server for freelance proposal drafting

### DIFF
--- a/servers/proposalcraft/server.yaml
+++ b/servers/proposalcraft/server.yaml
@@ -1,0 +1,22 @@
+name: proposalcraft
+image: mcp/proposalcraft
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - freelance
+    - business-writing
+    - proposal
+about:
+  title: ProposalCraft
+  description: MCP server for freelancers and consultants. Paste a client brief and get a proposal drafted in your voice from your past winning work. Analyzes briefs for budget signals, red flags, and scope risks before you commit. Free tier includes 5 drafts/month; all 8 tools available with no API key required.
+  icon: https://www.google.com/s2/favicons?domain=jabbawocky.github.io&sz=64
+source:
+  project: https://github.com/jabbawocky/proposalcraft
+  branch: main
+  commit: 7baf27de5d3985547a7ff6e25f879ac4d22e3b06
+run:
+  disableNetwork: false
+  allowHosts:
+    - api.anthropic.com:443


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ProposalCraft
**Repository URL:** https://github.com/jabbawocky/proposalcraft
**Brief Description:** MCP server for freelancers and consultants. Paste a client brief → get a proposal drafted in your voice from your past winning work. No API key required.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (8 tools: draft_proposal, analyze_brief, save_proposal, list_proposals, get_proposal, delete_proposal, load_examples, usage_status)
- [x] **Active Development**: Recent commits (June 2026), actively maintained
- [x] **Docker Artifact**: Dockerfile present at repo root — `FROM node:22-alpine`, copies pre-built `dist/`, entrypoint `node dist/index.js`
- [x] **Documentation**: Full README with demo, install instructions for Claude Desktop + Claude Code, tool reference table
- [x] **Security Contact**: GitHub Issues at https://github.com/jabbawocky/proposalcraft/issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME` *(local Docker toolchain not available in CI environment — happy to retest if needed)*
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [x] No credentials required to test — ProposalCraft is fully local, no API key needed

## Notes

- ProposalCraft uses **stdio transport** (local MCP server), no network endpoints required
- The `run.allowHosts` entry for `api.anthropic.com:443` covers the user's Claude session forwarding — the server itself does not call Anthropic directly
- Free tier: 5 `draft_proposal` calls/month. Pro plan coming at launch (Jun 10 2026 Product Hunt launch)
- Install via Claude Desktop/Code: `npx -y github:jabbawocky/proposalcraft`