### PR TITLE
Add FileToPDF server (convert files/HTML/Markdown to PDF)

### DIFF
--- a/servers/filetopdf/server.yaml
+++ b/servers/filetopdf/server.yaml
@@ -1,0 +1,31 @@
+name: filetopdf
+image: mcp/filetopdf
+type: server
+meta:
+  category: productivity
+  tags:
+    - filetopdf
+    - pdf
+    - conversion
+    - documents
+    - productivity
+about:
+  title: FileToPDF
+  description: Convert files, URLs, raw HTML, and Markdown into pixel-perfect PDFs with the FileToPDF API.
+  icon: https://raw.githubusercontent.com/FileToPDF/filetopdf-mcp/master/assets/icon.png
+source:
+  project: https://github.com/FileToPDF/filetopdf-mcp
+  commit: 1008c3dfc0eb6a72bc208b8f241b042fa5a3e5d4
+run:
+  command:
+    - node
+    - dist/stdio.js
+  allowHosts:
+    - api.filetopdf.dev:443
+config:
+  description: Get a free FileToPDF API key in one click at https://filetopdf.dev (10 free conversions, no signup).
+  secrets:
+    - name: filetopdf.api_key
+      env: FILETOPDF_API_KEY
+      example: <FILETOPDF_API_KEY>
+      description: Your FileToPDF API key from https://filetopdf.dev


### PR DESCRIPTION
## What

Adds **FileToPDF** — convert documents at a URL (DOCX, XLSX, PPTX, images…), raw HTML, and Markdown into PDFs via the FileToPDF API. 4 tools: `convert_file`, `convert_html`, `convert_markdown`, plus a free `get_account` credits check.

- Source: https://github.com/FileToPDF/filetopdf-mcp (MIT, TypeScript, official MCP SDK; commit pinned)
- Also published: npm `filetopdf-mcp@0.1.1`, official MCP registry `dev.filetopdf/filetopdf-mcp`
- `run.command` overrides the image default CMD (the Dockerfile defaults to the Streamable-HTTP entry for hosted use; `dist/stdio.js` is the stdio entry for the Toolkit)
- The server boots and answers `tools/list` without any secret set; `FILETOPDF_API_KEY` is only read per tool call
- Network: only `api.filetopdf.dev:443` (conversions happen server-side)

## Testing for reviewers

No credential sharing needed — free API keys are self-serve in one click at https://filetopdf.dev (10 free conversions, no signup). `get_account` verifies the key for free; a quick `convert_markdown` with `markdown: "# Hello"` returns a real PDF.