### PR TITLE
okta-mcp-server: refresh source.commit and title

### DIFF
--- a/servers/okta-mcp-server/server.yaml
+++ b/servers/okta-mcp-server/server.yaml
@@ -14,12 +14,12 @@ meta:
     - compliance
     - enterprise
 about:
-  title: Okta MCP Server
+  title: Okta
   description: Okta MCP Server
   icon: https://avatars.githubusercontent.com/u/362460?v=4
 source:
   project: https://github.com/okta/okta-mcp-server
-  commit: 9a7e9092063d776dffd86ebd7529c957ca439380
+  commit: 05121c937c92a5990ff563cfc493ce7693dad704
 run:
   volumes:
     - "okta-mcp-server-keyring:/root/.local/share/python_keyring"


### PR DESCRIPTION
## MCP Server Information

**Server Name:**
**Repository URL:**
**Brief Description:**

## Basic Requirements

- [X] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [X] **MCP Compliant**: Implements MCP API specification
- [X] **Active Development**: Recent commits and maintained
- [X] **Docker Artifact**: Dockerfile
- [X] **Documentation**: Basic README and setup instructions
- [X] **Security Contact**: Method for reporting security issues

### Summary

Refresh the `okta-mcp-server` registry entry so the catalog can publish it.

- Bump `source.commit` to the latest `okta/okta-mcp-server` `main` (`05121c937c92a5990ff563cfc493ce7693dad704`). The previously pinned commit (`9a7e9092…`, Jan 2025) no longer builds because it depends on `okta>=2.9.13`, which pulls in `flatdict==4.0.1` — that release of `flatdict` doesn't declare `pkg_resources` as a build dependency and fails under modern `setuptools`/`uv`. The new commit pins `okta==3.4.1` and `flatdict>=4.1.0` (wheel-only, no build step).
- Rename `about.title` from `Okta MCP Server` to `Okta` to comply with the registry rule that titles must not contain `MCP`.

### Why

The original add-server PR (#1014) was merged but the entry never appeared in the Docker MCP catalog. Re-running the registry tasks against the current `server.yaml` reproduces two failures:

1. `task validate -- --name okta-mcp-server`
   → `title should not contain 'MCP': Okta MCP Server`
2. `task build -- --tools okta-mcp-server`
   → `uv sync` fails building `flatdict==4.0.1`
   (`ModuleNotFoundError: No module named 'pkg_resources'`)

Both are addressed by this PR.

### Validation

Ran the registry's own commands locally against this branch:

## Submitter Checklist

- [X] This server meets the basic requirements listed above
- [X] I understand this will undergo automated and manual review.
- [X] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [X] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
