### PR TITLE
Add Omnicord

### DIFF
--- a/servers/omnicord/server.yaml
+++ b/servers/omnicord/server.yaml
@@ -1,0 +1,35 @@
+name: omnicord
+image: mcp/omnicord
+type: server
+meta:
+  category: communication
+  tags:
+    - communication
+    - discord
+    - moderation
+about:
+  title: Omnicord
+  description: Hands an AI assistant complete operational control of a Discord server through your own bot. 148 tools for chat, moderation, automod, events, and administration, up to building out a full community server from a one paragraph brief. Setup is a single guided command, and destructive actions never execute on the first call. They return a preview and wait for explicit confirmation, enforced by the server itself rather than the model's judgment.
+  icon: https://avatars.githubusercontent.com/OrygnsCode
+source:
+  project: https://github.com/OrygnsCode/Omnicord
+  branch: main
+run:
+  command:
+    - node
+    - dist/index.js
+config:
+  description: Connect Omnicord to your Discord bot
+  secrets:
+    - name: omnicord.discord_token
+      env: DISCORD_TOKEN
+      example: your-bot-token-from-the-developer-portal
+  env:
+    - name: OMNICORD_GUILD
+      example: "123456789012345678"
+      value: "{{omnicord.guild}}"
+  parameters:
+    type: object
+    properties:
+      guild:
+        type: string

--- a/servers/omnicord/server.yaml
+++ b/servers/omnicord/server.yaml
@@ -9,7 +9,7 @@ meta:
     - moderation
 about:
   title: Omnicord
-  description: Hands an AI assistant complete operational control of a Discord server through your own bot. 148 tools for chat, moderation, automod, events, and administration, up to building out a full community server from a one paragraph brief. Setup is a single guided command, and destructive actions never execute on the first call. They return a preview and wait for explicit confirmation, enforced by the server itself rather than the model's judgment.
+  description: Hands an AI assistant complete operational control of a Discord server through your own bot. More than 150 tools for chat, moderation, automod, events, and administration, up to building out a full community server from a one paragraph brief, and it can run several bots from one install. Setup is a single guided command, and destructive actions never execute on the first call. They return a preview and wait for explicit confirmation, enforced by the server itself rather than the model's judgment.
   icon: https://avatars.githubusercontent.com/OrygnsCode
 source:
   project: https://github.com/OrygnsCode/Omnicord


### PR DESCRIPTION
Adds Omnicord, a Discord MCP server by Orygn LLC. More than 150 tools covering chat, moderation, automod, events, administration, and building out complete servers from a plain language brief, and it can run several bots from a single install. Destructive actions return a preview and require confirmation before executing. The image builds from the Dockerfile at the repository root. The run command override starts the stdio transport for the gateway; the image's default CMD is the HTTP transport for standalone self-hosting. Source: https://github.com/OrygnsCode/Omnicord. Also on npm as @orygn/omnicord and Docker Hub as orygn/omnicord.
