### PR TITLE
Add OptionsAhoy (remote MCP server)

### DIFF
--- a/servers/optionsahoy/readme.md
+++ b/servers/optionsahoy/readme.md
@@ -1,0 +1,27 @@
+# OptionsAhoy
+
+OptionsAhoy is an equity-compensation tax optimizer exposed as a remote MCP server. It computes optimal schedules for ISO/AMT exercise, NSO exercise, RSU sell-vs-hold, QSBS eligibility, single-stock concentration risk, and protective puts/collars against the full federal tax code plus all 50 states and DC. Each tool returns a globally-optimal, deterministic result over the candidate space rather than an approximation.
+
+## Tools
+
+- `amt_iso_optimize` — Multi-year ISO exercise schedule maximizing after-tax Net Final Value, modeling AMT credit recovery and grant timing.
+- `nso_calculate` — After-tax NSO exercise payout (federal, state, FICA) comparing sell-at-exercise vs hold-for-LTCG.
+- `rsu_sell_vs_hold` — After-tax RSU vest payout, including the 22% supplemental withholding gap, comparing sell-at-vest vs hold.
+- `concentration_analyze` — Single-stock concentration risk analysis on an existing position.
+- `protective_put_price` — Black-Scholes pricing of a protective put or zero-cost collar.
+- `qsbs_check` — Section 1202 Qualified Small Business Stock qualification check.
+- `equity_funding_plan` — Multi-year, multi-stack optimizer to fund a cash goal from equity at minimum after-tax cost.
+
+## Usage
+
+Remote streamable-http endpoint, no authentication required (open endpoint, no OAuth, no API key):
+
+```
+https://optionsahoy.com/mcp
+```
+
+Docs: https://optionsahoy.com/for-agents
+
+## License
+
+MIT

--- a/servers/optionsahoy/server.yaml
+++ b/servers/optionsahoy/server.yaml
@@ -1,0 +1,19 @@
+name: optionsahoy
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: finance
+  tags:
+    - finance
+    - tax
+    - equity-compensation
+    - optimization
+    - remote
+about:
+  title: OptionsAhoy
+  description: Equity-compensation tax optimizer. ISO/AMT exercise scheduling, NSO, RSU sell-vs-hold, QSBS eligibility, single-stock concentration, and protective puts/collars across federal, 50-state, and DC tax code.
+  icon: https://raw.githubusercontent.com/AlvisoOculus/optionsahoy-mcp/main/assets/logo-400.png
+remote:
+  transport_type: streamable-http
+  url: https://optionsahoy.com/mcp

--- a/servers/optionsahoy/tools.json
+++ b/servers/optionsahoy/tools.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "amt_iso_optimize",
+    "description": "Multi-year Incentive Stock Option (ISO) exercise schedule that maximizes after-tax Net Final Value (NFV) at the planning horizon, modeling AMT credit recovery, grant expiration, and the post-termination exercise window across federal and 50-state tax tables."
+  },
+  {
+    "name": "nso_calculate",
+    "description": "After-tax payout on a non-qualified stock option (NSO) exercise: federal, state, and FICA (Social Security + Medicare + Additional Medicare), comparing sell-at-exercise vs hold-for-long-term-capital-gains over the chosen horizon."
+  },
+  {
+    "name": "rsu_sell_vs_hold",
+    "description": "After-tax payout on a Restricted Stock Unit (RSU) vest: federal ordinary income tax, state income tax, FICA, and the gap between mandatory 22% federal supplemental withholding and the user's marginal bracket, comparing selling at vest against holding for long-term capital gains."
+  },
+  {
+    "name": "concentration_analyze",
+    "description": "Single-stock concentration risk analysis on an existing position, quantifying exposure and after-tax diversification trade-offs."
+  },
+  {
+    "name": "protective_put_price",
+    "description": "Black-Scholes pricing of a protective put or zero-cost collar to hedge a single-stock concentrated position."
+  },
+  {
+    "name": "qsbs_check",
+    "description": "Section 1202 Qualified Small Business Stock (QSBS) qualification check, evaluating the federal capital-gains exclusion eligibility for a holding."
+  },
+  {
+    "name": "equity_funding_plan",
+    "description": "Multi-year, multi-stack equity-funding optimizer that schedules sales across ISO, NSO, RSU, and held shares to fund a cash goal at minimum after-tax cost."
+  }
+]


### PR DESCRIPTION
Adds OptionsAhoy as a remote (hosted) MCP server.

OptionsAhoy is an equity-compensation tax optimizer covering ISO/AMT exercise scheduling, NSO exercise, RSU sell-vs-hold, QSBS (Section 1202) eligibility, single-stock concentration risk, protective puts/collars, and multi-year equity funding plans. All calculations run against the full federal tax code plus all 50 states and DC.

Details:
- Type: remote, transport_type streamable-http
- Endpoint: https://optionsahoy.com/mcp (publicly accessible)
- Authentication: none required (open endpoint, no OAuth, no API key)
- Category: finance
- License: MIT

Files added under servers/optionsahoy/: server.yaml, tools.json, readme.md.

The seven tools (amt_iso_optimize, nso_calculate, rsu_sell_vs_hold, concentration_analyze, protective_put_price, qsbs_check, equity_funding_plan) were verified live against the endpoint via tools/list. Dynamic tool discovery is enabled.

Test credentials form: N/A. The server requires no credentials or OAuth, so there is nothing to share; the endpoint can be exercised directly with no authentication.
