### PR TITLE
Add image2svg-mcp server

### DIFF
--- a/servers/image2svg-mcp/server.yaml
+++ b/servers/image2svg-mcp/server.yaml
@@ -1,0 +1,22 @@
+name: image2svg-mcp
+image: mcp/image2svg-mcp
+type: server
+meta:
+  category: tools
+  tags:
+    - image
+    - svg
+    - vector
+    - conversion
+    - graphics
+about:
+  title: Image2SVG
+  description: |
+    MCP server that converts raster images (PNG/JPG/WEBP/TIFF) to SVG vector format. Exposes a single tool that accepts an image as base64 or a URL and returns the traced SVG. Runs locally over stdio, with an HTTP transport also available.
+  icon: https://www.google.com/s2/favicons?domain=botmonster.com&sz=64
+source:
+  project: https://github.com/botmonster/image2svg-mcp
+  branch: main
+  commit: 2ce7ef50beb3c241f3c1a3843151c5b9d6dea3c7
+config:
+  description: Image2SVG - No additional configuration required


### PR DESCRIPTION
## MCP Server Information

**Server Name:** image2svg-mcp
**Repository URL:** https://github.com/botmonster/image2svg-mcp
**Brief Description:** MCP server that converts raster images (PNG/JPG/WEBP/TIFF) to SVG vector format via a single tool (base64 or URL input).

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP; published to the Official MCP Registry as `io.github.botmonster/image2svg-mcp`
- [x] **Active Development**: Maintained (PyPI `image2svg-mcp`, ghcr image, CI)
- [x] **Docker Artifact**: Dockerfile present in repo
- [x] **Documentation**: README with install/setup instructions
- [x] **Security Contact**: Via repository issues / SECURITY

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name image2svg-mcp`
- [ ] I have built the MCP Server using `task build -- --tools image2svg-mcp`
- [ ] If the server requires credentials to test it, I have shared test credentials

> Note: `task`/Docker were not available in my environment, so I could not run `task validate`/`task build` locally; relying on CI to validate and build. The server needs no credentials. Image built by Docker from `source` (repo Dockerfile), pinned to commit `2ce7ef5`.