### PR TITLE
Add Ag-Bash and MindForge MCP servers

### DIFF
--- a/servers/ag-bash/server.yaml
+++ b/servers/ag-bash/server.yaml
@@ -1,0 +1,19 @@
+name: ag-bash
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - bash
+    - shell
+    - sandbox
+    - code-execution
+    - ai-agents
+    - wasm
+about:
+  title: Ag-Bash
+  description: Sandboxed AI-native bash environment with 70 agentic tools — run_bash with a full unix toolkit (grep/sed/awk/jq), surgical code edit/diff/analyze, WASM Python & JavaScript runtimes, semantic search, and agent task/worktree management. Defense-in-depth sandbox on by default; no host access required.
+  icon: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+source:
+  project: https://github.com/sairam0424/ag-bash
+  commit: e7d0aef7a4f21928e9d8e11a6b9f14026999c819
+  directory: packages/mcp-server

--- a/servers/ag-bash/tools.json
+++ b/servers/ag-bash/tools.json
@@ -1,0 +1,282 @@
+[
+  {
+    "name": "run_bash",
+    "description": "Run a bash script in a persistent sandboxed environment. State (cwd, variables, functions) persists between calls."
+  },
+  {
+    "name": "get_state",
+    "description": "Retrieve the current state of the shell (CWD and Environment Variables)."
+  },
+  {
+    "name": "snapshot",
+    "description": "Capture a complete binary snapshot of the current shell state (filesystem + environment)."
+  },
+  {
+    "name": "restore",
+    "description": "Restore the shell to a previously captured state via a snapshot."
+  },
+  {
+    "name": "create_delta",
+    "description": "Create a differential delta between a base snapshot and current state for efficient sync."
+  },
+  {
+    "name": "apply_delta",
+    "description": "Apply a differential delta to the current shell state."
+  },
+  {
+    "name": "fork_speculate",
+    "description": "Fork-speculation: copy-on-write branch the sandbox into N isolated children, run a candidate script sequence in each branch in parallel, and report each branch's output + exit code so you can pick a winner. Branch mutations (env, cwd, files) are invisible to the persistent shell and to each other. Optionally pass keepWinner to commit exactly one winning branch's scripts onto the persistent shell; otherwise the persistent shell is left untouched (all branches discarded)."
+  },
+  {
+    "name": "search_tools",
+    "description": "Discover which agentic tools are available for a free-text task description (Code Mode). Returns the best-matching tools by relevance so an agent can pick a tool without pre-loading the full catalog."
+  },
+  {
+    "name": "add_todo",
+    "description": "Add a new todo item."
+  },
+  {
+    "name": "ag_convert",
+    "description": "Convert documents (PDF, Docx, Xlsx) and images to Markdown with AI-powered visual intelligence and OCR."
+  },
+  {
+    "name": "ag_edit",
+    "description": "Advanced line-based file editor. Supports multiple non-contiguous edits in a single call and protects against stale writes using content hashes."
+  },
+  {
+    "name": "ag_explain",
+    "description": "Parse and explain a shell command string, showing its structure and components."
+  },
+  {
+    "name": "ag_find_files",
+    "description": "Find files by name or glob pattern recursively."
+  },
+  {
+    "name": "ag_find_symbol",
+    "description": "Search for symbols (functions, variables, classes) by name or pattern across the workspace."
+  },
+  {
+    "name": "ag_grep",
+    "description": "High-performance recursive pattern search within files."
+  },
+  {
+    "name": "ag_hover",
+    "description": "Get semantic information about a symbol at a specific line and character position."
+  },
+  {
+    "name": "ag_lsp",
+    "description": "Advanced code intelligence: goToDefinition, findReferences, hover, etc."
+  },
+  {
+    "name": "ag_multi_edit",
+    "description": "Apply multiple non-contiguous text replacements to a file in a single operation."
+  },
+  {
+    "name": "ag_todo",
+    "description": "Manage project tasks and todos. Support for listing, adding, updating, and removing tasks."
+  },
+  {
+    "name": "ag_web_fetch",
+    "description": "Fetch the content of a web page and convert it to clean markdown. Results are cached for 15 minutes."
+  },
+  {
+    "name": "ag_web_search",
+    "description": "Search the web for current information, documentation, and answers."
+  },
+  {
+    "name": "agent_memory_read",
+    "description": "Read a memory entry for an agent type."
+  },
+  {
+    "name": "agent_memory_write",
+    "description": "Write a memory entry for an agent type."
+  },
+  {
+    "name": "analyze_code",
+    "description": "Perform semantic analysis on a source file."
+  },
+  {
+    "name": "check_destructive",
+    "description": "Check if a command contains destructive patterns (rm -rf, DROP TABLE, git reset --hard, etc.). Returns warning or null."
+  },
+  {
+    "name": "check_environment",
+    "description": "Get diagnostics about the sandboxed environment."
+  },
+  {
+    "name": "close_session",
+    "description": "Terminate a persistent session and release its resources."
+  },
+  {
+    "name": "cron_create",
+    "description": "Schedule a recurring or one-shot prompt using a cron expression."
+  },
+  {
+    "name": "cron_delete",
+    "description": "Delete a scheduled cron job."
+  },
+  {
+    "name": "cron_list",
+    "description": "List all scheduled cron jobs."
+  },
+  {
+    "name": "diff_files",
+    "description": "Generate a unified diff between two files."
+  },
+  {
+    "name": "edit_file",
+    "description": "Apply a text patch to a file (simple find and replace)."
+  },
+  {
+    "name": "enter_worktree",
+    "description": "Create and enter an isolated virtual worktree for independent development."
+  },
+  {
+    "name": "exit_worktree",
+    "description": "Exit the active worktree and restore the original working directory."
+  },
+  {
+    "name": "explain_command",
+    "description": "Parse and explain a shell command."
+  },
+  {
+    "name": "find_files",
+    "description": "Search for files by name or glob pattern."
+  },
+  {
+    "name": "find_symbols",
+    "description": "Search for symbols (functions, variables) across the workspace."
+  },
+  {
+    "name": "get_definition",
+    "description": "Find the definition of a symbol."
+  },
+  {
+    "name": "get_references",
+    "description": "Find all references to a function or variable."
+  },
+  {
+    "name": "git_audit_log",
+    "description": "Get the git operations audit log, optionally filtered to destructive operations only."
+  },
+  {
+    "name": "git_track",
+    "description": "Record and classify a git operation. Returns classification (safe/mutating/destructive) and audit entry."
+  },
+  {
+    "name": "glob_files",
+    "description": "Fast glob pattern matching over the filesystem. Returns matching file paths sorted by name or mtime."
+  },
+  {
+    "name": "grep_search",
+    "description": "Search for a text pattern across multiple files."
+  },
+  {
+    "name": "help_builtin",
+    "description": "Get detailed help for a shell builtin command."
+  },
+  {
+    "name": "hover_info",
+    "description": "Get information about a symbol at a specific position."
+  },
+  {
+    "name": "index_workspace",
+    "description": "Trigger a full scan and indexing of all supported files in the workspace."
+  },
+  {
+    "name": "list_dir",
+    "description": "List contents of a directory."
+  },
+  {
+    "name": "list_mcp_tools",
+    "description": "List all tools available via connected MCP servers."
+  },
+  {
+    "name": "list_todos",
+    "description": "List all todo items."
+  },
+  {
+    "name": "plan_enter",
+    "description": "Enter plan mode to design an approach before making changes."
+  },
+  {
+    "name": "plan_exit",
+    "description": "Exit plan mode and return to execution mode."
+  },
+  {
+    "name": "query_json",
+    "description": "Run a jq query against a JSON file or string."
+  },
+  {
+    "name": "read_file",
+    "description": "Read the contents of a file from the virtual filesystem."
+  },
+  {
+    "name": "run_command",
+    "description": "Execute a shell command in the sandbox."
+  },
+  {
+    "name": "run_js",
+    "description": "Execute JavaScript code in the sandbox. For persistent state, use run_js_session."
+  },
+  {
+    "name": "run_js_session",
+    "description": "Execute JavaScript code in a persistent session (stateful REPL). Maintains variables and modules between calls."
+  },
+  {
+    "name": "run_python",
+    "description": "Execute Python code in the sandbox. For persistent state, use run_python_session."
+  },
+  {
+    "name": "run_python_session",
+    "description": "Execute Python code in a persistent session (stateful REPL). Maintains variables and imports between calls."
+  },
+  {
+    "name": "search_tools",
+    "description": "Search for available tools by keyword, or select by exact name with 'select:Name1,Name2'."
+  },
+  {
+    "name": "send_message",
+    "description": "Send a message from one agent to another."
+  },
+  {
+    "name": "sync_mcp_tools",
+    "description": "Synchronize and register all MCP tools into the central toolbox."
+  },
+  {
+    "name": "task_create",
+    "description": "Create a new tracked task with subject, description, owner, and progress text."
+  },
+  {
+    "name": "task_get",
+    "description": "Get full details of a specific task by ID."
+  },
+  {
+    "name": "task_list",
+    "description": "List all tracked tasks, optionally filtered by status or owner."
+  },
+  {
+    "name": "task_stop",
+    "description": "Stop (fail) a running task."
+  },
+  {
+    "name": "task_update",
+    "description": "Update a task's status, subject, description, owner, or dependencies."
+  },
+  {
+    "name": "team_create",
+    "description": "Create a new agent team for coordinated multi-agent work."
+  },
+  {
+    "name": "team_delete",
+    "description": "Delete an agent team."
+  },
+  {
+    "name": "update_todo",
+    "description": "Update the status of a todo item."
+  },
+  {
+    "name": "write_file",
+    "description": "Create or overwrite a file in the virtual filesystem."
+  }
+]

--- a/servers/mindforge/server.yaml
+++ b/servers/mindforge/server.yaml
@@ -1,0 +1,24 @@
+name: mindforge
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - claude-code
+    - knowledge-graph
+    - governance
+    - memory
+    - audit
+    - ai-agents
+about:
+  title: MindForge
+  description: Read the MindForge engine over MCP — query the SQLite knowledge graph, find related memory, check project health, and read the tamper-evident audit log, plus a guarded memory write. Scopes all reads to the mounted project directory (CLAUDE_PROJECT_DIR); no shell execution, no network egress.
+  icon: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+source:
+  project: https://github.com/sairam0424/MindForge
+  commit: a9d4b9b5734c5613cead2144570422ece4822a91
+  directory: mcp-server
+config:
+  env:
+    - name: CLAUDE_PROJECT_DIR
+      example: /project
+      value: "{{mindforge.project_dir}}"

--- a/servers/mindforge/tools.json
+++ b/servers/mindforge/tools.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "mindforge_health",
+    "description": "Run a MindForge health check on the current project: verifies required planning/governance files exist, validates HANDOFF.json, and reports the audit-log size. Returns overallStatus (healthy|warning|error) with details."
+  },
+  {
+    "name": "mindforge_status",
+    "description": "Read the current MindForge project status: whether the project is initialized, the raw STATE.md, the HANDOFF.json contents, and the autonomous-run auto-state.json if present. Use to understand where a MindForge project currently stands."
+  },
+  {
+    "name": "mindforge_memory_query",
+    "description": "Search the MindForge knowledge graph (architectural decisions, code/bug patterns, team preferences, domain knowledge) by topic text, tags, and type. Results are relevance-ranked. Use to recall prior decisions and patterns for the current project."
+  },
+  {
+    "name": "mindforge_memory_stats",
+    "description": "Report statistics for the MindForge knowledge graph: total/active/deprecated entries, breakdown by type, average confidence, plus graph metrics (nodes, edges, edges by type, orphan ratio). Use to gauge how much project memory exists."
+  },
+  {
+    "name": "mindforge_memory_find_related",
+    "description": "Given a free-text query, find related knowledge entries via keyword scoring plus graph traversal (multi-hop). Returns ranked entry ids with relevance scores. Use to surface connected decisions/patterns for a task description."
+  },
+  {
+    "name": "mindforge_audit_log",
+    "description": "Read entries from the MindForge audit log (.planning/AUDIT.jsonl), optionally filtered by event type or phase. Use to review what the framework has recorded for this project (task completions, security findings, decisions)."
+  },
+  {
+    "name": "mindforge_memory_remember",
+    "description": "Persist a new knowledge entry (decision, pattern, preference, or domain note) into the project knowledge graph so future sessions can recall it. Append-only and non-destructive \u2014 it never overwrites or deletes existing entries. Returns the new entry id."
+  }
+]


### PR DESCRIPTION
Two AI-native MCP servers, both published on npm and the official MCP Registry:

  - ag-bash (@ag-bash/mcp-server@6.0.3, Apache-2.0) — sandboxed AI-native bash, 70 tools.
  - mindforge (mindforge-mcp-server@11.5.1, MIT) — read the MindForge engine (knowledge graph, health, audit).

  Each ships a root Dockerfile (multi-stage, non-root) and a tools.json.