### PR TITLE
Add stackql MCP server

### DIFF
--- a/servers/stackql/server.yaml
+++ b/servers/stackql/server.yaml
@@ -1,0 +1,19 @@
+name: stackql
+image: stackql/stackql-mcp:0.10.500
+type: server
+meta:
+  category: devops
+  tags:
+    - cloud
+    - sql
+    - infrastructure
+    - multicloud
+    - iac
+    - devops
+about:
+  title: StackQL
+  description: SQL-native query and provisioning engine for cloud infrastructure, served over MCP.
+  icon: https://stackql.io/apple-touch-icon.png
+source:
+  project: https://github.com/stackql/stackql
+  commit: 55ff2daa14b79a734d334888c42ba96b4de6ed19


### PR DESCRIPTION
Community-image submission pointing at the public multi-arch `stackql/stackql-mcp` image (linux/amd64 + linux/arm64), MIT licensed. Starts and introspects with no credentials (github provider runs in null_auth for public data); tools/list returns 13 tools.

---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Add stackql MCP server"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** stackql
**Repository URL:** https://github.com/stackql/stackql
**Brief Description:** SQL-native query and provisioning engine for cloud infrastructure, served over MCP. Community-image submission referencing the existing public multi-arch image `stackql/stackql-mcp:0.10.500` (linux/amd64 + linux/arm64), pinned to stackql/stackql @ v0.10.500 (commit 55ff2daa14b79a734d334888c42ba96b4de6ed19).

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: verified `initialize` + `tools/list` over stdio; returns 13 tools (incl. `pull_provider`, `list_services`, `list_providers`)
- [x] **Active Development**: maintained; latest release v0.10.500, not archived
- [x] **Docker Artifact**: public Dockerfile in stackql/stackql; this is a community-image submission that provides the prebuilt public image `stackql/stackql-mcp`, so Docker references the image rather than building it
- [x] **Documentation**: README and setup instructions at https://github.com/stackql/stackql and https://stackql.io
- [x] **Security Contact**: security policy at https://github.com/stackql/stackql/blob/main/SECURITY.md

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name stackql` (ran the underlying `go run ./cmd/validate -name stackql`; all checks pass)
- [ ] I have built the MCP Server using `task build -- --tools stackql` (N/A - community-image submission; image is prebuilt, tools verified via `docker run -i --rm stackql/stackql-mcp:0.10.500` MCP introspection returning 13 tools)
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6) (N/A - no credentials required; github provider runs in null_auth for public data)
