### PR TITLE
Add HeadlessTracker (read-only crypto portfolio MCP server)

### DIFF
--- a/servers/headless-tracker/server.yaml
+++ b/servers/headless-tracker/server.yaml
@@ -1,0 +1,18 @@
+name: headless-tracker
+image: mcp/headless-tracker
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - crypto
+    - portfolio
+    - read-only
+about:
+  title: HeadlessTracker
+  description: Read-only MCP server that gives an AI assistant a view of your whole crypto portfolio across exchanges (Bybit, Binance), on-chain wallets (EVM, Solana), and Polymarket. It can read every balance but cannot trade, cannot withdraw, and your API keys never reach the model. Try it with no credentials by pointing it at any public Solana, EVM, or Polymarket address. Local-first and open-source. Not financial advice; data aggregation only.
+  icon: https://headlesstracker.dev/hex-mark.png
+source:
+  project: https://github.com/tamasPetki/HeadlessTracker
+  branch: main
+  commit: 9a6af403dc37bf3e8390deaada90cb6851b3b81e


### PR DESCRIPTION
### What

Adds **HeadlessTracker** — an open-source, read-only MCP server that gives an AI host a view of a crypto portfolio across exchanges (Bybit, Binance), on-chain wallets (EVM, Solana), and Polymarket.

### Why it fits the catalog

- **Read-only by design.** It reads balances; it cannot trade, cannot withdraw, and API keys never enter the model's context (connectors sign requests below the MCP boundary; tool output is a constructed whitelist, never upstream passthrough). Threat model in [SECURITY.md](https://github.com/tamasPetki/HeadlessTracker/blob/main/SECURITY.md).
- **Zero-credential trial.** Point it at any public Solana / EVM / Polymarket address, or run the bundled `demo` — no accounts or keys needed to see it work. Great fit for the Docker Desktop MCP Toolkit "try before you connect" flow.
- **MIT licensed**, published on npm as [`headless-tracker`](https://www.npmjs.com/package/headless-tracker), 377-test suite, CI-published with provenance. A root `Dockerfile` already exists (installs the published package, starts the stdio server on `ENTRYPOINT`).
- Already listed on the official MCP Registry, Glama, PulseMCP, and awesome-mcp-servers.

### Notes

- `server.yaml` follows the existing schema (e.g. `servers/airtable-mcp-server`). The server starts and lists its 15 tools with no configuration, so I've omitted a `config` block; credentialed exchange connectors are configured at runtime per the README.
- Compliance: the tool is for data aggregation only and is **not financial advice** — this is stated on every surface (README, package, tool descriptions, landing page).

Happy to adjust the entry to match any conventions I've missed.
