### PR TITLE
Add bgblur MCP server

### DIFF
--- a/servers/bgblur/server.yaml
+++ b/servers/bgblur/server.yaml
@@ -14,7 +14,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=bgblur.com&sz=64
 source:
   project: https://github.com/whyashthakker/bgblur-mcp
-  commit: 3684d8c0e7249c7c1bdc905b3538442dfe3bf442
+  commit: 192b11bf284bed0af25cb40dbe2812d53d4fc4fb
   dockerfile: registry/Dockerfile
 config:
   secrets:

--- a/servers/bgblur/server.yaml
+++ b/servers/bgblur/server.yaml
@@ -1,0 +1,23 @@
+name: bgblur
+image: mcp/bgblur-mcp
+type: server
+meta:
+  category: media
+  tags:
+    - image
+    - video
+    - blur
+    - privacy
+about:
+  title: BGBlur
+  description: Blur or remove image backgrounds, enhance portraits, blur faces and license plates in images and videos, remove objects from videos, and detect NSFW content via the BGBlur API.
+  icon: https://www.google.com/s2/favicons?domain=bgblur.com&sz=64
+source:
+  project: https://github.com/whyashthakker/bgblur-mcp
+  commit: 3684d8c0e7249c7c1bdc905b3538442dfe3bf442
+  dockerfile: registry/Dockerfile
+config:
+  secrets:
+    - name: bgblur.api_key
+      env: BGBLUR_API_KEY
+      example: vba_****


### PR DESCRIPTION
## MCP Server Information

**Server Name:** bgblur
**Repository URL:** https://github.com/whyashthakker/bgblur-mcp
**Brief Description:** Blur or remove image backgrounds, enhance portraits, blur faces and license plates in images and videos, remove objects from videos, anonymize faces, detect NSFW content, and check job status/credits against the BGBlur public API.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues — see [SECURITY.md](https://github.com/whyashthakker/bgblur-mcp/blob/main/SECURITY.md) (support@explainx.ai)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name bgblur`
- [x] I have built the MCP Server using `task build -- --tools bgblur`
- [ ] If the server requires credentials to test it, I have shared test credentials using this form