### PR TITLE
Add Sequenzy remote MCP server

### DIFF
--- a/servers/sequenzy/server.yaml
+++ b/servers/sequenzy/server.yaml
@@ -1,0 +1,30 @@
+name: sequenzy
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: marketing
+  tags:
+    - marketing
+    - email-marketing
+    - automation
+    - remote
+about:
+  title: Sequenzy
+  description: >-
+    Official hosted MCP endpoint for Sequenzy email marketing automation: manage
+    subscribers, lists, segments, templates, campaigns, sequences, transactional
+    email, analytics, and AI-generated email content.
+  icon: https://www.google.com/s2/favicons?domain=sequenzy.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://api.sequenzy.com/v1/mcp
+  headers:
+    Authorization: "Bearer ${SEQUENZY_API_KEY}"
+source:
+  project: https://github.com/Sequenzy/mcp
+config:
+  secrets:
+    - name: sequenzy.api_key
+      env: SEQUENZY_API_KEY
+      example: seq_user_your_key_here


### PR DESCRIPTION
Adds Sequenzy's official hosted Streamable HTTP MCP endpoint to the Docker MCP registry.\n\n- Endpoint: https://api.sequenzy.com/v1/mcp\n- Source: https://github.com/Sequenzy/mcp\n- npm package: @sequenzy/mcp\n\nValidation:\n- go run ./cmd/validate servers/sequenzy/server.yaml