### PR TITLE
Add InfraNode (keyless remote MCP server for German open data)

### DIFF
--- a/servers/infranode/readme.md
+++ b/servers/infranode/readme.md
@@ -1,0 +1,30 @@
+# InfraNode
+
+Keyless remote MCP server unifying German public-infrastructure open data:
+weather, air quality, traffic, public transit (incl. live departures), parking
+and roadworks for 84+ German cities. Data is sourced and normalized from official
+German providers (DWD, Umweltbundesamt, Mobilithek, GovData and others).
+
+- **Endpoint:** `https://mcp.infranode.dev/mcp` (remote, streamable HTTP, no API key)
+- **Tools:** 38, all read-only
+- **License:** Apache-2.0
+- **Docs:** https://infranode.dev/mcp
+- **Source:** https://github.com/street1983nk/infranode
+
+## Connect
+
+```bash
+claude mcp add --transport http infranode https://mcp.infranode.dev/mcp
+```
+
+No installation, no key, no account. Tools return a canonical JSON envelope with
+`data` and `meta` (including per-source status and attribution).
+
+## Example tools
+
+- `list_cities` — all covered cities with slug, state, population, coverage
+- `weather` — current DWD observations for a city
+- `air_quality` — Umweltbundesamt air quality (PM10/NO2, ...)
+- `transit_departures` — live public-transit departures with real-time delay
+- `compare` — compare one resource (weather/air) across multiple cities
+- `sources` — overview of all data sources with license and attribution

--- a/servers/infranode/readme.md
+++ b/servers/infranode/readme.md
@@ -1,12 +1,14 @@
 # InfraNode
 
 Keyless remote MCP server unifying German public-infrastructure open data:
-weather, air quality, traffic, public transit (incl. live departures), parking
-and roadworks for 84+ German cities. Data is sourced and normalized from official
-German providers (DWD, Umweltbundesamt, Mobilithek, GovData and others).
+weather, air quality, traffic, public transit (incl. live departures),
+electricity prices, land values, station departures, parking and roadworks for
+84+ German cities. Data is sourced and normalized from official German providers
+(DWD, Umweltbundesamt, SMARD, BORIS, Deutsche Bahn, Mobilithek, GovData and
+others).
 
 - **Endpoint:** `https://mcp.infranode.dev/mcp` (remote, streamable HTTP, no API key)
-- **Tools:** 38, all read-only
+- **Tools:** 42, all read-only
 - **License:** Apache-2.0
 - **Docs:** https://infranode.dev/mcp
 - **Source:** https://github.com/street1983nk/infranode
@@ -22,9 +24,12 @@ No installation, no key, no account. Tools return a canonical JSON envelope with
 
 ## Example tools
 
-- `list_cities` — all covered cities with slug, state, population, coverage
-- `weather` — current DWD observations for a city
-- `air_quality` — Umweltbundesamt air quality (PM10/NO2, ...)
-- `transit_departures` — live public-transit departures with real-time delay
-- `compare` — compare one resource (weather/air) across multiple cities
-- `sources` — overview of all data sources with license and attribution
+- `list_cities`: all covered cities with slug, state, population, coverage
+- `weather`: current DWD observations for a city
+- `air_quality`: Umweltbundesamt air quality (PM10/NO2, ...)
+- `power_price`: SMARD day-ahead electricity prices
+- `land_values`: official BORIS land values per city
+- `station_departures`: live Deutsche Bahn departures at a city's main station
+- `transit_departures`: live public-transit departures with real-time delay
+- `compare`: compare one resource (weather/air) across multiple cities
+- `sources`: overview of all data sources with license and attribution

--- a/servers/infranode/server.yaml
+++ b/servers/infranode/server.yaml
@@ -1,0 +1,17 @@
+name: infranode
+type: remote
+meta:
+  category: data
+  tags:
+    - germany
+    - open-data
+    - transit
+    - weather
+    - remote
+about:
+  title: InfraNode
+  description: "Keyless open data for 84 German cities: weather, air, transit, traffic. 38 read-only MCP tools."
+  icon: https://www.google.com/s2/favicons?domain=infranode.dev&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://mcp.infranode.dev/mcp

--- a/servers/infranode/server.yaml
+++ b/servers/infranode/server.yaml
@@ -7,10 +7,11 @@ meta:
     - open-data
     - transit
     - weather
+    - air-quality
     - remote
 about:
   title: InfraNode
-  description: "Keyless open data for 84 German cities: weather, air, transit, traffic. 38 read-only MCP tools."
+  description: "Keyless open-data API for 84 German cities: weather, air quality, public transit, electricity prices, land values and live station departures. 42 read-only MCP tools, no signup, no API key."
   icon: https://www.google.com/s2/favicons?domain=infranode.dev&sz=64
 remote:
   transport_type: streamable-http


### PR DESCRIPTION
## What

Adds **InfraNode**, a keyless remote MCP server for German public-infrastructure open data.

- **Type:** remote (streamable-http), no API key, no OAuth
- **Endpoint:** https://mcp.infranode.dev/mcp
- **Tools:** 38, all read-only (annotated `readOnlyHint`/`idempotentHint`)
- **Data:** weather, air quality, traffic, public transit (incl. live departures), parking, roadworks for 84+ German cities, sourced from official providers (DWD, Umweltbundesamt, Mobilithek, GovData)
- **License:** Apache-2.0
- **Source:** https://github.com/street1983nk/infranode
- **Also listed:** Official MCP Registry as `dev.infranode/infranode`

## Notes

Remote server, so no Docker image is built. Added `server.yaml` and `readme.md` under `servers/infranode/` following the keyless-remote pattern (e.g. `cloudflare-docs`). The endpoint is public and requires no credentials, so no test credentials are needed.