### PR TITLE
Add EQVPS — crypto-native no-KYC VPS (remote MCP server)

### DIFF
--- a/servers/eqvps/README.md
+++ b/servers/eqvps/README.md
@@ -1,0 +1,7 @@
+# EQVPS MCP Server
+
+Crypto-native, no-KYC VPS hosting for humans and AI agents. Pay with USDC/USDT (Base, Ethereum) — no ID, no card. Agents can register, top up, order and fully operate servers programmatically over MCP (Streamable HTTP).
+
+- Endpoint: https://mcp.eqvps.com/mcp
+- Docs (REST + MCP): https://eqvps.com/docs
+- Auth: Bearer token obtained at runtime via the `register_account` tool (public tools: list_plans, register_account, login).

--- a/servers/eqvps/server.yaml
+++ b/servers/eqvps/server.yaml
@@ -1,0 +1,20 @@
+name: eqvps
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: devops
+  tags:
+    - vps
+    - hosting
+    - crypto
+    - no-kyc
+    - ai-agents
+    - remote
+about:
+  title: EQVPS
+  description: Crypto-native, no-KYC VPS hosting. AI agents can list plans, register an account, top up with USDC/USDT, order a VPS, and fully control it (power, hostname, reinstall, metrics) autonomously over MCP.
+  icon: https://www.google.com/s2/favicons?domain=eqvps.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://mcp.eqvps.com/mcp


### PR DESCRIPTION
Adds EQVPS as a remote MCP server (Streamable HTTP).

Crypto-native, no-KYC VPS hosting for humans and AI agents: pay with USDC/USDT (Base, Ethereum), no ID/card. Agents can register, top up, order and fully control servers programmatically over MCP.

- Endpoint: https://mcp.eqvps.com/mcp (streamable-http)
- Docs: https://eqvps.com/docs
- Repo (MIT): https://github.com/Poiuyhje/eqvps-mcp

Files: servers/eqvps/server.yaml + README.md. Remote server, no OAuth — public tools (list_plans, register_account, login) need no token; authed tools use a Bearer obtained at runtime via register_account.