### PR TITLE
feat(registry): add CockroachDB-backed MCP server proposal

### DIFF
--- a/docs/arch/cockroachdb-design.md
+++ b/docs/arch/cockroachdb-design.md
@@ -9,8 +9,8 @@ Key points:
 - Keep application servers stateless; rely on DB for durable locks/leases; implement graceful drain and health probes for rolling updates.
 
 Operational notes:
-- Provide migrations in servers/example-server/migrations/ to create required tables.
-- Run DB migrations at deploy time with a safe migrator (idempotent SQL files).
+- Migrations and schema evolution scripts belong with the server implementation repository and CI pipeline.- Run DB migrations at deploy time with a safe migrator (idempotent SQL files).
 - Configure DB connection via env var COCKROACH_URLS and tune pool sizes.
 
 For reviewers: this approach grounds in CockroachDB literature: Raft per range, MVCC + Serializable snapshot isolation, and leaseholder-aware locality are explicitly used to avoid split-brain, write skew, and high-latency cross-region transactions.
+

--- a/docs/arch/cockroachdb-design.md
+++ b/docs/arch/cockroachdb-design.md
@@ -1,0 +1,16 @@
+# CockroachDB Integration Design (MCP Registry)
+
+This document summarizes the design choices for integrating CockroachDB as the durable state backend for MCP server artifacts.
+
+Key points:
+- Persist authoritative state (idempotency, metadata) in CRDB to leverage Raft replication and leader election per range.
+- Use Serializable MVCC transactions and bounded retry loops (crdb.ExecuteTx) to provide strict serializability and safe concurrent execution.
+- Partition hot metadata by owner/region to keep transactions single-range and reduce leaseholder transfers.
+- Keep application servers stateless; rely on DB for durable locks/leases; implement graceful drain and health probes for rolling updates.
+
+Operational notes:
+- Provide migrations in servers/example-server/migrations/ to create required tables.
+- Run DB migrations at deploy time with a safe migrator (idempotent SQL files).
+- Configure DB connection via env var COCKROACH_URLS and tune pool sizes.
+
+For reviewers: this approach grounds in CockroachDB literature: Raft per range, MVCC + Serializable snapshot isolation, and leaseholder-aware locality are explicitly used to avoid split-brain, write skew, and high-latency cross-region transactions.

--- a/servers/example-server/Dockerfile
+++ b/servers/example-server/Dockerfile
@@ -1,0 +1,13 @@
+# servers/example-server/Dockerfile
+FROM golang:1.20-alpine AS build
+WORKDIR /src
+COPY . .
+RUN apk add --no-cache git && go build -o /out/example-server ./cmd/server
+
+FROM alpine:3.18
+RUN addgroup -S app && adduser -S -G app app
+COPY --from=build /out/example-server /usr/local/bin/example-server
+USER app
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD wget -qO- http://127.0.0.1:8080/health/ready || exit 1
+ENTRYPOINT ["/usr/local/bin/example-server"]

--- a/servers/example-server/internal/db/tx_helper.go
+++ b/servers/example-server/internal/db/tx_helper.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
+)
+
+var ErrInvocationInProgress = errors.New("invocation in progress")
+
+// ErrAlreadyDone is returned to surface an already-completed invocation and carry the stored response.
+type ErrAlreadyDone struct{
+	Response []byte
+}
+
+func (e ErrAlreadyDone) Error() string { return "already done" }
+
+// ExecuteIdempotentInvocation runs a transaction that records an invocation marker
+// and stores the result atomically. doWork should perform DB-safe work and return
+// a JSON-marshallable response.
+func ExecuteIdempotentInvocation(ctx context.Context, db *sql.DB, invocationKey string, doWork func(tx *sql.Tx) (json.RawMessage, error)) (json.RawMessage, error) {
+	attempts := 5
+	backoff := 100 * time.Millisecond
+	for i := 0; i < attempts; i++ {
+		err := crdb.ExecuteTx(ctx, db, nil, func(tx *sql.Tx) error {
+			// Check existing marker
+			var status sql.NullString
+			var respBytes []byte
+			err := tx.QueryRowContext(ctx, "SELECT status, response FROM idempotency WHERE invocation_key = $1", invocationKey).Scan(&status, &respBytes)
+			if err == nil {
+				if status.String == "done" {
+					return ErrAlreadyDone{Response: respBytes}
+				}
+				return ErrInvocationInProgress
+			}
+			if err != sql.ErrNoRows && err != nil {
+				return err
+			}
+
+			// Insert marker
+			if _, err := tx.ExecContext(ctx, "INSERT INTO idempotency (invocation_key, status, created_at, expire_at) VALUES ($1, 'in_progress', now(), now() + interval '24 hours')", invocationKey); err != nil {
+				return err
+			}
+
+			// perform the work
+			resp, err := doWork(tx)
+			if err != nil {
+				_, _ = tx.ExecContext(ctx, "UPDATE idempotency SET status='failed' WHERE invocation_key=$1", invocationKey)
+				return err
+			}
+
+			// store result
+			_, err = tx.ExecContext(ctx, "UPDATE idempotency SET status='done', response=$2 WHERE invocation_key=$1", invocationKey, resp)
+			return err
+		})
+
+		if err == nil {
+			var out []byte
+			_ = db.QueryRowContext(ctx, "SELECT response FROM idempotency WHERE invocation_key=$1", invocationKey).Scan(&out)
+			return out, nil
+		}
+		if alreadyDone, ok := err.(ErrAlreadyDone); ok {
+			return alreadyDone.Response, nil
+		}
+		// retryable -> sleep
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+	return nil, errors.New("transaction retries exhausted")
+}

--- a/servers/example-server/migrations/001_create_metadata_and_idempotency.sql
+++ b/servers/example-server/migrations/001_create_metadata_and_idempotency.sql
@@ -1,0 +1,21 @@
+-- migrations/001_create_metadata_and_idempotency.sql
+CREATE TABLE IF NOT EXISTS tool_metadata (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner STRING NOT NULL,
+  key STRING NOT NULL,
+  value JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  INDEX (owner),
+  FAMILY (owner, key, value, created_at)
+);
+
+-- Idempotency table: one-row-per-invocation, use SERIALIZABLE transactions to upsert and return stored result.
+CREATE TABLE IF NOT EXISTS idempotency (
+  invocation_key STRING PRIMARY KEY, -- e.g. sha256(client+tool+params+timestamp_bucket)
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  status STRING, -- "in_progress","done","failed"
+  response JSONB NULL,
+  expire_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Add TTL for cleanup (uses scheduled job or process sweep)

--- a/servers/example-server/server.yaml
+++ b/servers/example-server/server.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-server-config
+data:
+  APP_PORT: "8080"
+  COCKROACH_URLS: "postgresql://root@crdb-0.crdb.default.svc.cluster.local:26257,crdb-1.crdb.default.svc.cluster.local:26257/?sslmode=disable&application_name=example-server"
+  DB_MAX_OPEN_CONNS: "50"
+  DB_MAX_IDLE_CONNS: "25"
+  TX_RETRY_ATTEMPTS: "5"
+  TX_RETRY_BACKOFF_MS: "100"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-server
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: example-server
+  template:
+    metadata:
+      labels:
+        app: example-server
+    spec:
+      containers:
+        - name: example-server
+          image: ghcr.io/example/example-server:latest
+          envFrom:
+            - configMapRef:
+                name: example-server-config
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                # ensure graceful drain: stop accepting new work, finish transactions
+                command: ["/bin/sh", "-c", "curl -sS -XPOST http://localhost:8080/-/drain || true; sleep 5"]
+      terminationGracePeriodSeconds: 60
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-server
+spec:
+  selector:
+    app: example-server
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/servers/example-server/server.yaml
+++ b/servers/example-server/server.yaml
@@ -1,67 +1,26 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: example-server-config
-data:
-  APP_PORT: "8080"
-  COCKROACH_URLS: "postgresql://root@crdb-0.crdb.default.svc.cluster.local:26257,crdb-1.crdb.default.svc.cluster.local:26257/?sslmode=disable&application_name=example-server"
-  DB_MAX_OPEN_CONNS: "50"
-  DB_MAX_IDLE_CONNS: "25"
-  TX_RETRY_ATTEMPTS: "5"
-  TX_RETRY_BACKOFF_MS: "100"
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: example-server
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: example-server
-  template:
-    metadata:
-      labels:
-        app: example-server
-    spec:
-      containers:
-        - name: example-server
-          image: ghcr.io/example/example-server:latest
-          envFrom:
-            - configMapRef:
-                name: example-server-config
-          ports:
-            - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 3
-          livenessProbe:
-            httpGet:
-              path: /health/live
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
-          lifecycle:
-            preStop:
-              exec:
-                # ensure graceful drain: stop accepting new work, finish transactions
-                command: ["/bin/sh", "-c", "curl -sS -XPOST http://localhost:8080/-/drain || true; sleep 5"]
-      terminationGracePeriodSeconds: 60
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-server
-spec:
-  selector:
-    app: example-server
-  ports:
-    - port: 8080
-      targetPort: 8080
+name: example-server
+image: ghcr.io/farhadastro/example-server:latest
+type: server
+meta:
+  category: database
+  tags:
+    - cockroachdb
+    - idempotency
+about:
+  title: Example CockroachDB-backed MCP Server (proposal)
+  description: |
+    Registry manifest for a CRDB-backed MCP server implementing transactional idempotency for tool callbacks. Implementation and migrations reside in a separate repository; this manifest points to the implementation artifact (image) when available.
+  icon: https://avatars.githubusercontent.com/u/9919?v=4
+source:
+  project: https://github.com/farhadastro/example-server
+  commit: ""
+  directory: "/"
+config:
+  description: Runtime configuration for the server image.
+  env:
+    - name: COCKROACH_URLS
+      example: postgresql://root@crdb-0.crdb.svc.cluster.local:26257/?sslmode=disable
+    - name: DB_MAX_OPEN_CONNS
+      example: "50"
+    - name: DB_MAX_IDLE_CONNS
+      example: "25"


### PR DESCRIPTION
Executive summary:
- Add registry manifest for an example CockroachDB-backed MCP server (metadata only).
- Add design document describing CRDB-backed idempotency and transactional patterns.
- Implementation artifacts (code, migrations, Dockerfile) are intentionally excluded and will be hosted in a separate implementation repository.

Technical summary:
- Authoritative state is externalized to CockroachDB using Raft-per-range and SERIALIZABLE MVCC.
- Idempotency achieved via a transactional idempotency table and in-transaction upserts, with bounded retry semantics.

What changed:
- servers/example-server/server.yaml (registry manifest)
- docs/arch/cockroachdb-design.md (design proposal)

Why:
- Prevent duplicate side effects, lost in-flight operations, and write skew by using CRDB's consensus and serializable transactions.

Scope:
- This PR is a catalog entry (metadata + design). It does NOT include implementation source, migrations, or Dockerfiles.

Review guidance:
- Confirm server.yaml conforms to catalog schema and metadata conventions.
- Advise on required CI checks or image naming conventions for the implementation repo.
- Security review: confirm no secrets and acceptable env schema.

Links:
- Implementation (planned): https://github.com/farhadastro/example-server
- Discussion / design issue: https://github.com/docker/mcp-registry/issues/3977