### PR TITLE
Add marionette-mcp server

### DIFF
--- a/servers/marionette-mcp/server.yaml
+++ b/servers/marionette-mcp/server.yaml
@@ -1,0 +1,27 @@
+name: marionette-mcp
+image: mcp/marionette-mcp
+type: server
+longLived: true
+meta:
+  category: devops
+  tags:
+    - flutter
+    - testing
+    - automation
+    - ai
+about:
+  title: Marionette
+  description: |
+    MCP server that lets AI agents inspect and interact with running Flutter
+    apps — read the widget tree, tap, scroll, type, take screenshots, read
+    logs, and hot reload. Works against any Flutter app started in debug mode.
+
+    Networking note: this server connects to the host's Flutter VM Service.
+    From inside the container, use the connect URI
+    ws://host.docker.internal:<port>/ws (Docker Desktop) instead of the
+    ws://127.0.0.1:<port>/ws address printed by `flutter run`. On native Linux
+    Docker Engine, run with host networking so host.docker.internal resolves.
+  icon: https://avatars.githubusercontent.com/u/33636762?v=4
+source:
+  project: https://github.com/leancodepl/marionette_mcp
+  commit: a8bcfc655bb671b8b34fa6e2a02e8065d90a8c86


### PR DESCRIPTION
## MCP Server Information

**Server Name:** marionette-mcp
**Repository URL:** https://github.com/leancodepl/marionette_mcp
**Brief Description:** MCP server that lets AI agents inspect and interact with running Flutter apps — read the widget tree, tap, scroll, type, take screenshots, read logs, and hot reload.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements the MCP specification (stdio transport)
- [x] **Active Development**: Actively maintained, published on pub.dev
- [x] **Docker Artifact**: Dockerfile at the repo root (Docker-built image, `mcp/marionette_mcp`)
- [x] **Documentation**: README + docs/ in the source repo
- [x] **Security Contact**: GitHub issues / repository security policy

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name marionette-mcp`
- [x] I have built the MCP Server using `task build -- --tools marionette-mcp` (image built, 16 tools discovered)
- [ ] If the server requires credentials to test it, I have shared test credentials — N/A (no credentials required)

## Notes for reviewers

- **No credentials/secrets required.** Marionette attaches to a locally running Flutter app's Dart VM Service.
- **Networking:** the server connects out to the host's VM Service. From inside the container, the `connect` tool must be given `ws://host.docker.internal:<port>/ws` (Docker Desktop) rather than the `ws://127.0.0.1:<port>/ws` URI that `flutter run` prints. This is documented in the server description.
