### PR TITLE
Add observe-mcp server

### DIFF
--- a/servers/observe-mcp/server.yaml
+++ b/servers/observe-mcp/server.yaml
@@ -1,0 +1,31 @@
+name: observe-mcp
+image: staffdill/observe-mcp
+type: server
+meta:
+  category: monitoring
+  tags:
+    - observe
+    - observability
+    - logs
+    - opal
+about:
+  title: Observe
+  description: Query and search logs in Observe.com using OPAL. Supports raw queries, dataset discovery, field schema inspection, and convenience search tools for service logs and entity correlation.
+  icon: https://avatars.githubusercontent.com/u/46697965?s=200&v=4
+source:
+  project: https://github.com/staffdill/observe-mcp
+  branch: main
+  dockerfile: Dockerfile
+config:
+  secrets:
+    - name: observe.customer_id
+      env: OBSERVE_CUSTOMER_ID
+      example: "171322433722"
+    - name: observe.token
+      env: OBSERVE_TOKEN
+      example: <YOUR_TOKEN>
+  params:
+    - name: observe.default_dataset
+      env: OBSERVE_DEFAULT_DATASET
+      example: "Default.Logs"
+      required: false

--- a/servers/observe-mcp/server.yaml
+++ b/servers/observe-mcp/server.yaml
@@ -20,7 +20,7 @@ config:
   secrets:
     - name: observe.customer_id
       env: OBSERVE_CUSTOMER_ID
-      example: "171322433722"
+      example: "123456789012"
     - name: observe.token
       env: OBSERVE_TOKEN
       example: <YOUR_TOKEN>

--- a/servers/observe-mcp/server.yaml
+++ b/servers/observe-mcp/server.yaml
@@ -24,8 +24,12 @@ config:
     - name: observe.token
       env: OBSERVE_TOKEN
       example: <YOUR_TOKEN>
-  params:
-    - name: observe.default_dataset
-      env: OBSERVE_DEFAULT_DATASET
+  env:
+    - name: OBSERVE_DEFAULT_DATASET
       example: "Default.Logs"
-      required: false
+      value: "{{observe.default_dataset}}"
+  parameters:
+    type: object
+    properties:
+      default_dataset:
+        type: string


### PR DESCRIPTION
Adds a generic Observe.com MCP server for querying logs with OPAL. Source: https://github.com/staffdill/observe-mcp