### PR TITLE
Add mcp-sports-hub MCP server

### DIFF
--- a/servers/mcp-sports-hub/server.yaml
+++ b/servers/mcp-sports-hub/server.yaml
@@ -1,0 +1,30 @@
+name: mcp-sports-hub
+image: mcp/mcp-sports-hub
+type: server
+meta:
+  category: data-analytics
+  tags:
+    - sports
+    - scores
+    - statistics
+    - odds
+    - nfl
+    - nba
+    - soccer
+    - formula-1
+    - esports
+    - chess
+about:
+  title: Sports Hub
+  description: |
+    Unified sports-data MCP server aggregating 41 providers (~396 tools) in a single process. With no configuration it loads the keyless "free" preset — 19 providers, ~165 tools — covering live scores, standings, schedules, and player/team stats across NFL, NBA, MLB, NHL, soccer, F1/MotoGP/NASCAR, tennis, cricket, golf, MMA/boxing, esports, and chess.
+
+    Highlights:
+    • 41 providers, 396 tools — ESPN, NHL, MLB Stats API, Jolpica F1, OpenF1, OpenLigaDB, TheSportsDB, EuroLeague, Lichess, Chess.com, and more.
+    • Works out of the box — most providers need no API key.
+    • Optional keyed providers add betting odds, video highlights, fantasy, and historical data.
+    • Also exposes MCP resources (provider/preset catalogs) and prompts (curated workflows).
+  icon: https://raw.githubusercontent.com/lacausecrypto/mcp-sports-hub/main/assets/logo.png
+source:
+  project: https://github.com/lacausecrypto/mcp-sports-hub
+  commit: 58cf7e736463e808510e25fdf5779b804540d8fa


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcp-sports-hub (Sports Hub)
**Repository URL:** https://github.com/lacausecrypto/mcp-sports-hub
**Brief Description:** Unified sports-data MCP server aggregating **41 providers (~396 tools)** in one process. With no configuration it loads the keyless **`free` preset** (19 providers, ~165 tools): live scores, standings, schedules, and player/team stats across NFL, NBA, MLB, NHL, soccer, F1/MotoGP/NASCAR, tennis, cricket, golf, MMA/boxing, esports, and chess. Also exposes MCP resources (provider/preset catalogs) and prompts.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (verified `initialize`, `tools/list`, resources, prompts)
- [x] **Active Development**: Recent commits, published on npm and the official MCP Registry (`io.github.lacausecrypto/sports-hub`)
- [x] **Docker Artifact**: `Dockerfile` at the repo root (multi-stage `node:20-alpine`; defaults to stdio, ideal for the MCP gateway)
- [x] **Documentation**: README + wiki with full provider/tool reference
- [x] **Security Contact**: via GitHub issues; privacy policy at `PRIVACY.md`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name mcp-sports-hub` *(see note)*
- [ ] I have built the MCP Server using `task build -- --tools mcp-sports-hub` *(see note)*
- [x] If the server requires credentials to test it, I have shared test credentials — **N/A: the default `free` preset needs no API keys to run or list tools.**

> **Note on validation:** I don't have the Go/Task toolchain locally, so I couldn't run the exact `task` wrappers — but I verified the equivalents and am happy to iterate on CI:
> - The `Dockerfile` builds cleanly (`node:20-alpine`, ~226 MB).
> - Running the image / binary over **stdio** with zero config returns a valid `initialize` (`serverInfo: sports-hub 1.3.0`) and **`tools/list` lists 165 tools** — so the build's tool-listing step should pass without a `tools.json`.
> - `server.yaml` conforms to the documented schema (no `run`/`config` block needed — it works out of the box).
> - `source.commit` is pinned to `58cf7e7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
