### PR TITLE
Add LBC Reference Node MCP server

### DIFF
--- a/servers/lbc-reference-node-mcp/server.yaml
+++ b/servers/lbc-reference-node-mcp/server.yaml
@@ -1,0 +1,17 @@
+name: lbc-reference-node-mcp
+image: djpjronline/lbc-reference-node-mcp:1.0.0
+type: server
+meta:
+  category: devops
+  tags:
+    - docker
+    - mcp
+    - reference
+    - developer-tools
+about:
+  title: LBC Reference Node
+  description: Minimal stdio MCP server used as the dogfood reference image for the Lonely Brew Club Dockerized MCP Server Pack.
+  icon: https://avatars.githubusercontent.com/u/276112803?v=4
+source:
+  project: https://github.com/djpjronline-netizen/lbc-reference-node-mcp
+  commit: 0d9dc1b2c6a4eaa79cf4c014ac12597b265f33ee

--- a/servers/lbc-reference-node-mcp/tools.json
+++ b/servers/lbc-reference-node-mcp/tools.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "health_check",
+    "description": "Return reference Node MCP server health.",
+    "arguments": []
+  },
+  {
+    "name": "echo",
+    "description": "Echo a message for MCP smoke tests.",
+    "arguments": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "Message to echo."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** lbc-reference-node-mcp
**Repository URL:** https://github.com/djpjronline-netizen/lbc-reference-node-mcp
**Brief Description:** Minimal stdio MCP server used as the dogfood reference image for the Lonely Brew Club Dockerized MCP Server Pack.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have shared test credentials using the form.

## Validation

Validated locally with the registry commands using direct `go run` equivalents because `task` is not installed on the build host:

```bash
GOTOOLCHAIN=auto go run ./cmd/validate --name lbc-reference-node-mcp
GOTOOLCHAIN=auto go run ./cmd/build --pull-community --tools lbc-reference-node-mcp
```

The published image is:

```text
docker.io/djpjronline/lbc-reference-node-mcp:1.0.0
```

No runtime credentials are required.
