### PR TITLE
Add A2E (Agent to Execution) MCP server

### DIFF
--- a/servers/a2e/server.yaml
+++ b/servers/a2e/server.yaml
@@ -1,0 +1,37 @@
+---
+name: a2e
+image: mauricioperera/a2e-mcp-server
+type: server
+meta:
+  category: productivity
+  tags:
+    - workflows
+    - automation
+    - activepieces
+    - agents
+about:
+  title: A2E (Agent to Execution)
+  description: Discover validated pieces, compose declarative JSON workflows over them, and execute them. The agent composes workflows from already-validated pieces — it never writes code. Point it at your A2E engine (mauricioperera/a2e-engine).
+  icon: https://avatars.githubusercontent.com/u/6507438?v=4
+source:
+  project: https://github.com/MauricioPerera/a2e-engine
+  branch: main
+  commit: a45f6348ff10a9fcbdc0a492fee91f3740ce696e
+  directory: packages/a2e-mcp-server
+config:
+  description: Connect the MCP server to your A2E engine (product-api).
+  secrets:
+    - name: a2e.api_key
+      env: A2E_API_KEY
+      example: <your A2E API key>
+  env:
+    - name: A2E_API_BASE
+      example: http://localhost:8088
+      value: "{{a2e.api_base}}"
+  parameters:
+    type: object
+    properties:
+      api_base:
+        type: string
+    required:
+      - api_base


### PR DESCRIPTION
Adds the A2E MCP server (image: mauricioperera/a2e-mcp-server) to the catalog. A2E is an agent-first workflow engine: the agent discovers validated pieces, composes declarative JSON workflows, and executes them — it never writes code. The MCP server is an adapter that connects to a user-run A2E engine (mauricioperera/a2e-engine on Docker Hub) via A2E_API_BASE + A2E_API_KEY. Repo: https://github.com/MauricioPerera/a2e-engine