### PR TITLE
Add FourA MCP server (web scraping for AI agents)

### DIFF
--- a/servers/foura/server.yaml
+++ b/servers/foura/server.yaml
@@ -1,0 +1,29 @@
+name: foura
+image: mcp/foura
+type: server
+meta:
+  category: web-scraping
+  tags:
+    - web-scraping
+    - proxy
+    - browser
+    - anti-bot
+    - data
+about:
+  title: FourA
+  description: |-
+    Web scraping for AI agents. One smart tool fetches any public page and picks the right method automatically - a direct request, a rotating proxy, or a full headless browser - getting past anti-bot challenges so your agent receives the content instead of a block page.
+
+    Four tools (smart auto-fetch, plain HTTP request, rotating-proxy request, full browser render) and six ready-made prompts, all from a single API key.
+  icon: https://www.google.com/s2/favicons?domain=foura.ai&sz=128
+source:
+  project: https://github.com/fouradata/mcp
+  branch: main
+  commit: 382241b6e0f6b069a12e8aa7e5ff95218bdb0f67
+  dockerfile: Dockerfile.stdio
+config:
+  description: Configure your FourA API access
+  secrets:
+    - name: foura.api_key
+      env: FOURA_API_KEY
+      example: pk_live_xxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Adds the **FourA** MCP server - web scraping for AI agents.

- Repo: https://github.com/fouradata/mcp
- npm: https://www.npmjs.com/package/@fouradata/mcp (published from GitHub Actions with provenance)
- Official MCP Registry: `ai.foura/mcp`

Docker-built (`type: server`) from `Dockerfile.stdio` (stdio transport), image `mcp/foura`.

Four read-only tools (smart auto-fetch, plain HTTP request, rotating-proxy request, full headless
browser) plus six prompts. One secret: `FOURA_API_KEY`.

Verified locally: the image builds and `tools/list` returns all four tools.
