### PR TITLE
Add memo (local-first memory for AI agents)

### DIFF
--- a/servers/memo/server.yaml
+++ b/servers/memo/server.yaml
@@ -1,0 +1,21 @@
+name: memo
+image: ghcr.io/jagoff/memo
+type: server
+meta:
+  category: ai
+  tags:
+    - mcp
+    - ai
+    - memory
+about:
+  title: Memo
+  description: Local-first long-term memory for AI agents — hybrid vector + BM25 search over markdown files, contradiction detection, time-machine queries. Runs 100% locally, no cloud API, no keys.
+  icon: https://raw.githubusercontent.com/jagoff/memo/master/docs/logo.png
+source:
+  project: https://github.com/jagoff/memo
+  commit: b622d662aafab0b351b4f1e67dedad658accc5ad
+run:
+  command:
+    - memo-mcp
+  volumes:
+    - memo-data:/data


### PR DESCRIPTION
## MCP Server Information

**Server Name:** memo
**Repository URL:** https://github.com/jagoff/memo
**Brief Description:** Local-first long-term memory for AI agents — hybrid vector + BM25 search over markdown files, contradiction detection, time-machine queries. Runs 100% locally, no cloud API, no keys.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification (stdio; also in the official MCP registry as `io.github.jagoff/memo`)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile at repo root; self-provided image `ghcr.io/jagoff/memo` (linux/amd64) with the embedding model pre-baked
- [x] **Documentation**: README with setup instructions
- [x] **Security Contact**: GitHub issues / security advisories on the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name memo` (all checks pass)
- [ ] I have built the MCP Server using `task build` — not needed: self-provided image (`ghcr.io/jagoff/memo`)
- [ ] Test credentials — not needed: no secrets or env vars required for default operation

## Notes

- Default image CMD is `memo doctor` (self-check); the entry overrides `run.command` to `memo-mcp` (stdio MCP server).
- Persistent state lives under `/data` (single `memo-data` volume).
- Smoke test: `docker run --rm ghcr.io/jagoff/memo:latest memo doctor`