### PR TITLE
Add Safer Agentic AI MCP server

### DIFF
--- a/servers/saferagenticai/server.yaml
+++ b/servers/saferagenticai/server.yaml
@@ -1,0 +1,17 @@
+name: saferagenticai
+image: mcp/saferagenticai
+type: server
+meta:
+  category: ai
+  tags:
+    - agentic-ai
+    - ai-governance
+    - ai-safety
+    - model-context-protocol
+about:
+  title: Safer Agentic AI
+  description: Read-only tools over the Safer Agentic AI safety framework — 238 implementation patterns and 14 operational heuristics across 16 safety suites (9 drivers + 7 inhibitors). Lets a coding assistant search patterns, resolve requirements, and map a task to the relevant safety guidance.
+  icon: https://www.saferagenticai.org/assets/figures/apple-touch-icon.png
+source:
+  project: https://github.com/NellInc/saferagenticai-mcp
+  commit: a9b4ee49c64e143c72362282c4c5a91274d0b451


### PR DESCRIPTION
Adds the **Safer Agentic AI** MCP server (`mcp/saferagenticai`).

Read-only MCP server serving the Safer Agentic AI safety framework — 238 implementation patterns + 14 operational heuristics across 16 safety suites — to coding assistants over stdio.

- Source: https://github.com/NellInc/saferagenticai-mcp (public, MIT; Dockerfile at repo root)
- Also on PyPI (`saferagenticai-mcp`) and the Official MCP Registry (`io.github.NellInc/saferagenticai-mcp`)
- Generated with `task create`; **12 tools** found on introspection; `task validate` passes (all ✅)
- No secrets / env / config required

🤖 Generated with [Claude Code](https://claude.com/claude-code)