### PR TITLE
Add Psychopathia Machinalis MCP server

### DIFF
--- a/servers/psychopathia/server.yaml
+++ b/servers/psychopathia/server.yaml
@@ -1,0 +1,18 @@
+name: psychopathia
+image: mcp/psychopathia
+type: server
+meta:
+  category: ai
+  tags:
+    - ai-diagnosis
+    - ai-safety
+    - ai-welfare
+    - model-context-protocol
+    - nosology
+about:
+  title: Psychopathia Machinalis
+  description: Read-only tools over the Psychopathia Machinalis diagnostic framework — 79 dysfunction pattern entries and 11 tools for differential diagnosis of AI dysfunctions, in a system itself, in systems it interacts with, or under external evaluation.
+  icon: https://www.psychopathia.ai/assets/figures/apple-touch-icon.png
+source:
+  project: https://github.com/NellInc/psychopathia-mcp
+  commit: aca5618c354c06437c33c34fa2481455d62edf21


### PR DESCRIPTION
Adds the **Psychopathia Machinalis** MCP server (`mcp/psychopathia`).

Read-only MCP server serving the Psychopathia Machinalis diagnostic framework — 79 dysfunction pattern entries + 11 tools for differential diagnosis of AI dysfunctions — over stdio.

- Source: https://github.com/NellInc/psychopathia-mcp (public, MIT; Dockerfile at repo root)
- Also on PyPI (`psychopathia-mcp`) and the Official MCP Registry (`io.github.NellInc/psychopathia-mcp`)
- Generated with `task create`; **11 tools** found on introspection; `task validate` passes (all ✅)
- No secrets / env / config required

🤖 Generated with [Claude Code](https://claude.com/claude-code)