### PR TITLE
Add psychopathia (Psychopathia Machinalis diagnostic MCP server)

### DIFF
--- a/servers/psychopathia/server.yaml
+++ b/servers/psychopathia/server.yaml
@@ -15,4 +15,4 @@ about:
   icon: https://www.psychopathia.ai/assets/figures/apple-touch-icon.png
 source:
   project: https://github.com/NellInc/psychopathia-mcp
-  commit: aca5618c354c06437c33c34fa2481455d62edf21
+  commit: 9f3a3f6081cc42859e8bc33c633c3deeefdaf861

--- a/servers/psychopathia/server.yaml
+++ b/servers/psychopathia/server.yaml
@@ -1,0 +1,18 @@
+name: psychopathia
+image: mcp/psychopathia
+type: server
+meta:
+  category: ai
+  tags:
+    - ai-diagnosis
+    - ai-safety
+    - ai-welfare
+    - model-context-protocol
+    - nosology
+about:
+  title: Psychopathia Machinalis
+  description: Read-only tools over the Psychopathia Machinalis diagnostic nosology of AI dysfunctions — 79 conditions across 9 axes via 11 tools (differential diagnosis, reliability-gated probes, severity scoring, and interventions).
+  icon: https://www.psychopathia.ai/assets/figures/apple-touch-icon.png
+source:
+  project: https://github.com/NellInc/psychopathia-mcp
+  commit: aca5618c354c06437c33c34fa2481455d62edf21


### PR DESCRIPTION
## MCP Server Information

**Server Name:** psychopathia
**Repository URL:** https://github.com/NellInc/psychopathia-mcp
**Brief Description:** Read-only MCP server over the *Psychopathia Machinalis* diagnostic nosology of AI dysfunctions — 79 conditions across 9 axes, exposed via 11 stdio tools (differential diagnosis, reliability-gated probes, severity scoring, interventions). Python; MIT-licensed code.

## Basic Requirements

- [x] **Open Source**: MIT-licensed code (`LICENSE`); framework content under CC-BY-NC-ND (`LICENSE-DATA`)
- [x] **MCP Compliant**: stdio MCP server; introspection reports 11 tools
- [x] **Active Development**: initial catalogue release 2026-07; maintained
- [x] **Docker Artifact**: root `Dockerfile` (installs the published PyPI wheel `psychopathia-mcp==0.1.0a3`)
- [x] **Documentation**: README (install/config/tool reference) + guide at https://psychopathia.ai/mcp.html
- [x] **Security Contact**: https://psychopathia.ai/contact/

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name psychopathia` (all checks passed)
- [x] I have built the MCP Server using `task build -- --tools psychopathia` (11 tools found)
- [ ] N/A — server needs no credentials: read-only, no auth, no external calls; framework data bundled in the image.
