### PR TITLE
Add Creed Space MCP server (mcp/creedspace)

### DIFF
--- a/servers/creedspace/server.yaml
+++ b/servers/creedspace/server.yaml
@@ -1,0 +1,20 @@
+name: creedspace
+image: mcp/creedspace
+type: server
+meta:
+  category: ai
+  tags:
+    - ai-safety
+    - claude
+    - constitutional-ai
+    - creed-space
+    - guardrails
+    - llm
+    - model-context-protocol
+about:
+  title: Creed Space
+  description: Constitutional-AI safety guardrails for any LLM. Serves Creed Space personas and constitutions over stdio — fetch and search constitutions, switch among six personas (Ambassador, Nanny, Sentinel, Godparent, Muse, Anchor), generate persona system prompts and compact non-negotiable-rule anchors, adjudicate requests through the policy decision point, and attest responses against the active creed. 16 tools.
+  icon: https://avatars.githubusercontent.com/u/196999690?s=256&v=4
+source:
+  project: https://github.com/Creed-Space/creedspace-mcp-server
+  commit: 87f99b559a1cd9c9c9dede3bef9998390bee503e


### PR DESCRIPTION
## MCP Server Information

**Server Name:** creedspace
**Repository URL:** https://github.com/Creed-Space/creedspace-mcp-server
**Brief Description:** Constitutional-AI safety guardrails for any LLM. Serves Creed Space personas and constitutions over stdio via **16 tools** — fetch and search constitutions, switch among six personas (Ambassador, Nanny, Sentinel, Godparent, Muse, Anchor), generate persona system prompts and compact non-negotiable-rule anchors, adjudicate requests through the policy decision point, and attest responses against the active creed. Node/TypeScript, MIT-licensed; also on npm (`@creedspace/mcp-server`) and the Official MCP Registry (`io.github.Creed-Space/creedspace-mcp-server`).

## Basic Requirements

- [x] **Open Source**: MIT license (`LICENSE`)
- [x] **MCP Compliant**: stdio MCP server; introspection reports 16 tools
- [x] **Active Development**: released 2026-07, actively maintained
- [x] **Docker Artifact**: root `Dockerfile` (installs the published npm package `@creedspace/mcp-server@1.1.1`)
- [x] **Documentation**: README with install/config and full tool reference; docs at https://www.creed.space/mcp
- [x] **Security Contact**: support@creed.space · https://www.creed.space

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name creedspace` (all checks passed)
- [x] I have built the MCP Server using `task build -- --tools creedspace` (16 tools found)
- [x] N/A — the server needs no credentials to test: it runs against the public Creed Space API with sensible defaults (an API key is optional, via env only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
