### PR TITLE
Add notion-mcp-awkoy (community Notion server, token auth)

### DIFF
--- a/servers/notion-mcp-awkoy/server.yaml
+++ b/servers/notion-mcp-awkoy/server.yaml
@@ -1,0 +1,42 @@
+name: notion-mcp-awkoy
+image: mcp/notion-mcp-awkoy
+type: server
+meta:
+  category: productivity
+  tags:
+    - notion
+    - productivity
+about:
+  title: Notion Community (Token Auth)
+  description: |
+    Community Notion MCP server that authenticates with a token, so it runs
+    headless — CI, cron jobs, and background agents — where OAuth-only servers
+    can't. 43 operations (pages, databases, blocks, comments, users, files,
+    templates) behind 2 context-efficient tools, with batched mutations and
+    atomic rollback, idempotency keys, automatic retry on rate limits, and
+    full markdown round-trip.
+  icon: https://avatars.githubusercontent.com/u/4792552?s=200&v=4
+source:
+  project: https://github.com/awkoy/notion-mcp-server
+  commit: c855bd586283a6c244a6f48786fbe963ddfea8e2
+config:
+  description: |
+    Set NOTION_TOKEN to a Notion Personal Access Token (ntn_...) created at
+    https://app.notion.com/developers/tokens, or an Internal Integration
+    Secret. Optionally set a default parent page ID used by create_page /
+    create_database when no parent is passed.
+  secrets:
+    - name: notion-mcp-awkoy.notion_token
+      env: NOTION_TOKEN
+      example: ntn_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      description: Notion Personal Access Token or Internal Integration Secret.
+  env:
+    - name: NOTION_PAGE_ID
+      example: 8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d
+      value: "{{notion-mcp-awkoy.notion_page_id}}"
+  parameters:
+    type: object
+    properties:
+      notion_page_id:
+        type: string
+        description: Default parent page ID used when none is passed at call time.

--- a/servers/notion-mcp-awkoy/server.yaml
+++ b/servers/notion-mcp-awkoy/server.yaml
@@ -15,7 +15,7 @@ about:
     templates) behind 2 context-efficient tools, with batched mutations and
     atomic rollback, idempotency keys, automatic retry on rate limits, and
     full markdown round-trip.
-  icon: https://avatars.githubusercontent.com/u/4792552?s=200&v=4
+  icon: https://raw.githubusercontent.com/awkoy/notion-mcp-server/main/assets/logo.png
 source:
   project: https://github.com/awkoy/notion-mcp-server
   commit: c855bd586283a6c244a6f48786fbe963ddfea8e2


### PR DESCRIPTION
Adds [awkoy/notion-mcp-server](https://github.com/awkoy/notion-mcp-server) as a local (Docker-built) server.

## Why alongside the existing `notion` entry

This is a community alternative that authenticates with a **token** (Notion PAT or internal integration secret), so it runs **headless** — CI, cron jobs, background agents — where the OAuth flow of the official server can't. It also dispatches 43 operations (pages, databases, blocks, comments, users, files, templates) behind 2 context-efficient tools, with batched mutations + atomic rollback, idempotency keys, and automatic retry on rate limits.

## Details

- MIT licensed, TypeScript, Dockerfile at repo root (`node:24-alpine`, stdio entrypoint), commit pinned
- On npm as [`notion-mcp-server`](https://www.npmjs.com/package/notion-mcp-server) (~7k downloads/month)
- `go run ./cmd/validate --name notion-mcp-awkoy` passes all checks locally
- Config: `NOTION_TOKEN` secret (required), optional `notion_page_id` parameter mapped to `NOTION_PAGE_ID`