### PR TITLE
Add VulnFeed MCP server

### DIFF
--- a/servers/vulnfeed/server.yaml
+++ b/servers/vulnfeed/server.yaml
@@ -1,0 +1,30 @@
+name: vulnfeed
+image: mcp/vulnfeed
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - vulnerability-scanner
+    - cve
+    - epss
+    - dependencies
+about:
+  title: VulnFeed
+  description: |
+    Dependency vulnerability scanner with EPSS-based prioritization. Scans lockfiles
+    (package-lock.json, requirements.txt, go.sum, Cargo.lock, Gemfile.lock, composer.lock)
+    across npm, PyPI, Go, crates.io, RubyGems, and Packagist; enriches findings with EPSS
+    exploit-probability scores so the noisy low-risk CVEs are suppressed by default; and
+    recommends minimal fix versions. Can monitor projects and alert on new CVEs between runs.
+    Free tier works with zero configuration — no signup or API key required (10 scans/day).
+  icon: https://vulnfeed.novadyne.ai/favicon.svg
+source:
+  project: https://github.com/novadyne-hq/vulnfeed-mcp
+  commit: 349ecd3eed5d31ebc7177b1d1aa521c8bb756de5
+config:
+  description: Optional — the free tier works with no configuration. A license key unlocks the paid tier.
+  secrets:
+    - name: vulnfeed.api_key
+      env: VULNFEED_API_KEY
+      example: <your-license-key>


### PR DESCRIPTION
## What
Adds **VulnFeed** — a dependency vulnerability scanner MCP server (local, containerized, stdio).

- Scans lockfiles across six ecosystems (npm, PyPI, Go, crates.io, RubyGems, Packagist)
- Prioritizes by EPSS exploit probability (low-risk noise suppressed by default), recommends minimal fix versions
- Project monitoring + new-CVE alerts between runs
- **Zero-config free tier** — no signup or API key needed to list tools or run scans (10 scans/day); optional license key for the paid tier

## Source
- Repo: https://github.com/novadyne-hq/vulnfeed-mcp (MIT), pinned to `349ecd3`
- Dockerfile builds from source at the repo root
- Also published as `vulnfeed-mcp` on PyPI and `io.github.novadyne-hq/vulnfeed` in the official MCP registry

## Verification done locally
Built the image from the pinned commit and drove it over stdio: `initialize` + `tools/list` return 9 tools with no configuration, and a live `check_package` call returns real scan results.
