### PR TITLE
Add flatten-mcp server

### DIFF
--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: ecd1b73d6d3ce3c8b00172e076a6734f4529cf32
+  commit: 6f2e6bc5d243974a89759b2bad182ee9b8c2dbe6
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 7d98a1bcee734758b1eb2e9f734f6d74d3974395
+  commit: 6fca843d04884660721fcc517142b91539ad0aee
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 7db9e635f0da0c0bbbb7e61bfe86665bff3c7775
+  commit: bd3f31d4b4d491272f1707665336c51f11dfacd5
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -1,0 +1,37 @@
+name: flatten-mcp
+image: mcp/flatten-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - claude-code
+    - context-window
+    - tokens
+    - session
+    - productivity
+about:
+  title: Flatten for Claude Code
+  description: >-
+    Losslessly cut a Claude Code session's context tokens: bulky tool output
+    moves to a local backup, every prompt stays verbatim, and the session
+    resumes lighter — the reversible alternative to /compact.
+  icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/shayaShav/flatten-mcp
+  commit: 49140149b06655f68da4240317cf9d849822e994
+run:
+  volumes:
+    - "{{flatten-mcp.claude_dir|volume-target}}:/claude"
+  disableNetwork: true
+config:
+  description: flatten-mcp reads and writes Claude Code sessions in this directory (your ~/.claude)
+  parameters:
+    type: object
+    properties:
+      claude_dir:
+        type: string
+        title: Claude Config Directory
+        description: Absolute path to your Claude Code config directory (the one holding projects/)
+        default: /Users/username/.claude
+    required:
+      - claude_dir

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 0da016dbca20d9dbe947a3674d04826f8f10cd06
+  commit: 7db9e635f0da0c0bbbb7e61bfe86665bff3c7775
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 6fad2a6204155fc5999d1cbabb13b85a2e05af0c
+  commit: ba1c5e0893173263d1984fb8ea149b5d401ad84a
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -24,7 +24,14 @@ run:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"
   disableNetwork: true
 config:
-  description: flatten-mcp reads and writes Claude Code sessions in this directory (your ~/.claude)
+  description: >-
+    flatten-mcp reads and writes Claude Code sessions in this directory (your
+    ~/.claude). Inside the container, "current" resolves to the most recent
+    session in the store.
+  env:
+    - name: FLATTEN_INMEMORY_TOOLS
+      example: "1"
+      value: "{{flatten-mcp.inmemory_tools}}"
   parameters:
     type: object
     properties:
@@ -33,5 +40,9 @@ config:
         title: Claude Config Directory
         description: Absolute path to your Claude Code config directory (the one holding projects/)
         default: /Users/username/.claude
+      inmemory_tools:
+        type: string
+        title: In-Memory Tools
+        description: Set to 1 to also register the flatten_messages/unflatten_messages in-memory tools (no disk or network involved)
     required:
       - claude_dir

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: ba1c5e0893173263d1984fb8ea149b5d401ad84a
+  commit: 7d98a1bcee734758b1eb2e9f734f6d74d3974395
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 49140149b06655f68da4240317cf9d849822e994
+  commit: ecd1b73d6d3ce3c8b00172e076a6734f4529cf32
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 6fca843d04884660721fcc517142b91539ad0aee
+  commit: 0da016dbca20d9dbe947a3674d04826f8f10cd06
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"

--- a/servers/flatten-mcp/server.yaml
+++ b/servers/flatten-mcp/server.yaml
@@ -12,13 +12,13 @@ meta:
 about:
   title: Flatten for Claude Code
   description: >-
-    Losslessly cut a Claude Code session's context tokens: bulky tool output
+    Cut a Claude Code session's context tokens losslessly: bulky tool output
     moves to a local backup, every prompt stays verbatim, and the session
     resumes lighter — the reversible alternative to /compact.
   icon: https://raw.githubusercontent.com/shayaShav/flatten-mcp/main/assets/logo-400.png
 source:
   project: https://github.com/shayaShav/flatten-mcp
-  commit: 6f2e6bc5d243974a89759b2bad182ee9b8c2dbe6
+  commit: 6fad2a6204155fc5999d1cbabb13b85a2e05af0c
 run:
   volumes:
     - "{{flatten-mcp.claude_dir|volume-target}}:/claude"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** flatten-mcp
**Repository URL:** https://github.com/shayaShav/flatten-mcp
**Brief Description:** Losslessly cut a Claude Code session's context tokens: bulky tool output moves to a local backup, every prompt stays verbatim, and the session resumes lighter — the reversible alternative to /compact.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

No credentials are required: the server is fully offline (`disableNetwork: true`) and lists its 3 tools unconfigured. It operates on Claude Code session files in a host directory mounted via the `run.volumes` config (`claude_dir`, the user's `~/.claude`). License is MIT; security reporting is via GitHub Security Advisories (SECURITY.md).