### PR TITLE
Add supplement-advisor-mcp server

### DIFF
--- a/servers/supplement-advisor-mcp/server.yaml
+++ b/servers/supplement-advisor-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: supplement-advisor-mcp
+image: mcp/supplement-advisor-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - supplements
+    - health
+    - nutrition
+    - evidence-based
+about:
+  title: Supplement Advisor
+  description: Evidence-based supplement guidance — ranked recommendations by cost-per-effective-dose, supplement form comparisons with absorption data, medication-nutrient interaction checks, and clinical dosing with PubMed citations. Covers 19 supplement categories with data from NIH DSLD, PubMed, NSF, and USP. No API key required.
+  icon: https://raw.githubusercontent.com/erinheit451/supplement-advisor-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/erinheit451/supplement-advisor-mcp
+  branch: main
+  commit: 2775c1c862e981cf72d0cc13cd887c19e5f9533c


### PR DESCRIPTION
Adds **Supplement Advisor** — evidence-based supplement guidance MCP server.

- **Repo:** https://github.com/erinheit451/supplement-advisor-mcp (MIT license)
- **Dockerfile:** at repo root, multi-stage node:20-alpine — **build verified locally** and the container answers `tools/list` over stdio with its 5 tools (recommend_supplement, compare_forms, check_interactions, get_dosage, classify_form).
- **No secrets/env required** — data is bundled (NIH DSLD product data, PubMed-cited evidence, medication-nutrient interactions).
- **npm:** https://www.npmjs.com/package/supplement-advisor-mcp
- Commit pinned to current main; icon is a 400×400 PNG in the source repo.

Happy to have Docker build and host the image in the `mcp/` namespace.