### PR TITLE
Add AgenticEmail remote MCP server

### DIFF
--- a/servers/agenticemail/readme.md
+++ b/servers/agenticemail/readme.md
@@ -1,0 +1,1 @@
+Docs: https://agenticemail.dev/docs/mcp

--- a/servers/agenticemail/server.yaml
+++ b/servers/agenticemail/server.yaml
@@ -1,0 +1,23 @@
+name: agenticemail
+type: remote
+meta:
+  category: communication
+  tags:
+    - communication
+    - email
+    - automation
+    - remote
+about:
+  title: AgenticEmail
+  description: Email infrastructure for AI agents - create inboxes on the fly, then send, receive, and reply to real email with scoped API keys.
+  icon: https://raw.githubusercontent.com/AgenticEmail/.github/main/profile/logo.svg
+remote:
+  transport_type: streamable-http
+  url: https://api.agenticemail.dev/mcp
+  headers:
+    Authorization: "Bearer ${AGENTICEMAIL_API_KEY}"
+config:
+  secrets:
+    - name: agenticemail.api_key
+      env: AGENTICEMAIL_API_KEY
+      example: <YOUR_API_KEY>

--- a/servers/agenticemail/tools.json
+++ b/servers/agenticemail/tools.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "create_inbox",
+    "description": "Provision a new email inbox on the fly.",
+    "arguments": []
+  },
+  {
+    "name": "list_inboxes",
+    "description": "List the inboxes available to your API key.",
+    "arguments": []
+  },
+  {
+    "name": "list_threads",
+    "description": "List email threads in an inbox.",
+    "arguments": []
+  },
+  {
+    "name": "get_thread",
+    "description": "Get a single email thread and its messages.",
+    "arguments": []
+  },
+  {
+    "name": "list_messages",
+    "description": "List messages in an inbox or thread.",
+    "arguments": []
+  },
+  {
+    "name": "get_message",
+    "description": "Get the full content of a single email message.",
+    "arguments": []
+  },
+  {
+    "name": "send_message",
+    "description": "Send a new email message from an inbox.",
+    "arguments": []
+  },
+  {
+    "name": "reply_to_message",
+    "description": "Reply to an existing email message.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
Adds AgenticEmail, a hosted remote MCP server (streamable HTTP) that gives AI agents real email: create inboxes on the fly, then send, receive, and reply with scoped API keys.

- Endpoint: `https://api.agenticemail.dev/mcp` (Authorization: Bearer API key; keys at https://agenticemail.dev)
- Published in the official MCP Registry as `dev.agenticemail/mcp`
- Docs: https://agenticemail.dev/docs/mcp
- 8 tools: create_inbox, list_inboxes, list_threads, get_thread, list_messages, get_message, send_message, reply_to_message

Files follow the remote-server convention: `servers/agenticemail/server.yaml`, `tools.json`, `readme.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)