### PR TITLE
Add Token Risk Scanner (ton-jetton-risk-mcp)

### DIFF
--- a/servers/ton-jetton-risk-mcp/server.yaml
+++ b/servers/ton-jetton-risk-mcp/server.yaml
@@ -1,0 +1,17 @@
+name: ton-jetton-risk-mcp
+image: mcp/ton-jetton-risk-mcp
+type: server
+meta:
+  category: blockchain
+  tags:
+    - blockchain
+    - security
+    - finance
+about:
+  title: Token Risk Scanner (EVM / Solana / TON)
+  description: Rug-pull and honeypot risk screening for crypto tokens before you interact with them. Covers EVM (Ethereum, BSC, Base, Arbitrum, Polygon, Optimism, Avalanche — with a live buy/sell simulation), Solana (mint/freeze authority, holder concentration) and TON jettons. Returns a 0-100 risk score with concrete findings (hidden owner, mint authority, sell taxes, blacklists, liquidity). Completely free and keyless — uses public GoPlus, honeypot.is and DexScreener data.
+  icon: https://avatars.githubusercontent.com/u/108728264?v=4
+source:
+  project: https://github.com/mrvlyouknowwho/ton-jetton-risk-mcp
+  branch: main
+  commit: 154cd43ed16460cc8662586f439a1999c4d9485f


### PR DESCRIPTION
Adds **ton-jetton-risk-mcp** — rug-pull/honeypot risk screening for crypto tokens across EVM (7 chains, with live buy/sell simulation via honeypot.is), Solana and TON. Returns a 0-100 risk score with concrete findings.

- Completely **free and keyless**: no API keys, no signup, no secrets to configure — uses public GoPlus / honeypot.is / DexScreener endpoints.
- Local containerized server, Dockerfile at repo root, MIT license.
- Already published in the official MCP Registry as `io.github.mrvlyouknowwho/ton-jetton-risk-mcp` (v0.2.0).
- Verified locally: image builds and `tools/list` returns the 3 tools (`assess_evm_token_risk`, `assess_solana_token_risk`, `assess_ton_jetton_risk`).