### PR TITLE
Add Corent MCP server

### DIFF
--- a/servers/corent/server.yaml
+++ b/servers/corent/server.yaml
@@ -1,0 +1,24 @@
+name: corent
+image: mcp/corent
+type: server
+meta:
+  category: ai
+  tags:
+    - image-generation
+    - video-generation
+    - media
+about:
+  title: Corent
+  description: Generate images and videos through the Corent API — one key, automatic model routing, and provider fallback. Includes plan/create tools with a per-call spend ceiling so autonomous agents can't overspend.
+  icon: https://www.google.com/s2/favicons?domain=corent.tech&sz=64
+source:
+  project: https://github.com/gg13121/corent
+  branch: main
+  commit: a62dffc3c0c6acafad4703d1527ded2c2c4599f7
+  directory: mcp
+config:
+  description: Configure the Corent MCP server
+  secrets:
+    - name: corent.api_key
+      env: CORENT_API_KEY
+      example: co_live_xxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Adds the **Corent** MCP server (`servers/corent/`).

Corent is a media-generation API — one key, automatic model routing across providers, and provider fallback. The MCP server exposes 7 tools (`generate_image`, `generate_video`, `get_job`, `get_balance`, `get_status`, and the agent-native `plan`/`create`, where `create` takes a per-call spend ceiling so an autonomous agent can't overspend).

- **Source:** https://github.com/gg13121/corent (`mcp/` subfolder, pinned commit)
- **License:** MIT
- **Auth:** single secret `CORENT_API_KEY` (get one at https://corent.tech)

Verified locally before submitting:
- Image builds from the `mcp/` Dockerfile (`docker build`) ✔
- Container starts and returns all 7 tools on `tools/list` over stdio, with no key required for enumeration ✔ (the key is enforced only when a tool is invoked)

Happy to share a test API key via the credentials form if useful for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)