### PR TITLE
Add Memkeeper MCP server

### DIFF
--- a/servers/memkeeper/server.yaml
+++ b/servers/memkeeper/server.yaml
@@ -1,0 +1,22 @@
+name: memkeeper
+image: mcp/memkeeper
+type: server
+meta:
+  category: ai
+  tags:
+    - ai-agents
+    - local-first
+    - mcp
+    - memory
+    - semantic-search
+    - sqlite
+about:
+  title: Memkeeper
+  description: Local-first memory for AI agents with durable SQLite storage and optional local semantic retrieval.
+  icon: https://avatars.githubusercontent.com/u/261611586?s=200&v=4
+source:
+  project: https://github.com/teflon07/memkeeper
+  commit: a903000a6cac2416553769eb0934665888da6eed
+run:
+  volumes:
+    - memkeeper-data:/root/.memkeeper


### PR DESCRIPTION
## Summary
- add Memkeeper as a local/containerized MCP server
- use Docker-built image name `mcp/memkeeper`
- mount `memkeeper-data:/root/.memkeeper` so the local SQLite store and pulled semantic models persist
- keep network enabled so users can pull local semantic model assets

## Verification
- `go run ./cmd/validate --name memkeeper` via a disposable Go/Node container: passed
- `go run ./cmd/catalog memkeeper` via a disposable Go container: generated catalog successfully
- built the pinned source commit with Docker as `mcp/memkeeper:catalog-pr`
- verified MCP `initialize` + `tools/list` against the image with the catalog-style volume mounted: 16 tools