### PR TITLE
Add rustok-wallet (self-custody Ethereum agent wallet)

### DIFF
--- a/servers/rustok-wallet/server.yaml
+++ b/servers/rustok-wallet/server.yaml
@@ -1,0 +1,48 @@
+name: rustok-wallet
+image: ghcr.io/rustok-org/rustok-wallet
+type: server
+meta:
+  category: finance
+  tags:
+    - ethereum
+    - wallet
+    - crypto
+    - defi
+    - self-custody
+about:
+  title: Rustok Ethereum Wallet
+  description: >-
+    Self-custody Ethereum agent wallet that runs entirely locally — private
+    keys live in a local Docker volume and never leave it. Read wallet context,
+    balances and DeFi positions (Aave v3, ERC-4626), preview any transaction
+    with a pre-sign simulation (decoded call, revert check, gas, risk level),
+    and sign EIP-191 messages. Transaction execution is intentionally not
+    exposed as an MCP tool. One-time onboarding required: run create-wallet
+    (see the project README) to create the keystore and back up the recovery
+    phrase before enabling this server.
+  icon: https://avatars.githubusercontent.com/u/288316369?s=200&v=4
+source:
+  project: https://github.com/rustok-org/mcp
+  commit: a0fef13d397bb3582895a353183a878a5de4b526
+run:
+  volumes:
+    - rustok-wallet:/data
+config:
+  description: Configure your Ethereum RPC endpoint and the keystore password chosen during create-wallet onboarding
+  secrets:
+    - name: rustok-wallet.keyring_password
+      env: RUSTOK_KEYRING_PASSWORD
+      example: <YOUR_KEYRING_PASSWORD>
+      description: Password that unlocks your local keystore (the one set at create-wallet)
+  env:
+    - name: RUSTOK_RPC_URLS_1
+      example: https://eth-mainnet.g.alchemy.com/v2/<key>
+      value: "{{rustok-wallet.rpc_url}}"
+  parameters:
+    type: object
+    properties:
+      rpc_url:
+        type: string
+        description: Ethereum mainnet RPC URL (an Alchemy key URL, or a public RPC)
+    required:
+      - rpc_url

--- a/servers/rustok-wallet/tools.json
+++ b/servers/rustok-wallet/tools.json
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "get_wallet_context",
+    "description": "Get the active wallet address, per-chain balances and allowed chains.",
+    "arguments": []
+  },
+  {
+    "name": "get_balances",
+    "description": "Token balances for the active wallet, or for an explicit address. Balance is returned in wei and ETH.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "Optional address to query instead of the active wallet (requires chain_id)"
+      },
+      {
+        "name": "chain_id",
+        "type": "number",
+        "desc": "Chain ID: optional filter for the active wallet, required with address"
+      }
+    ]
+  },
+  {
+    "name": "get_positions",
+    "description": "Get on-chain DeFi positions (Aave v3 collateral/debt/health factor/LTV, ERC-4626 vaults) for the active wallet, or for an explicit address.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "Optional address to query instead of the active wallet"
+      }
+    ]
+  },
+  {
+    "name": "preview_transaction",
+    "description": "Preview any transaction: decoded call (who/what is authorized), pre-sign simulation (revert check), gas estimate and txguard risk level. Execution is not exposed as an MCP tool.",
+    "arguments": [
+      {
+        "name": "to",
+        "type": "string",
+        "desc": "Recipient or contract address"
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": "Value in wei"
+      },
+      {
+        "name": "chain_id",
+        "type": "number",
+        "desc": "Chain ID"
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": "Optional calldata (hex)"
+      }
+    ]
+  },
+  {
+    "name": "sign_message",
+    "description": "Sign a message with the active wallet key (EIP-191).",
+    "arguments": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "Message to sign"
+      },
+      {
+        "name": "sign_type",
+        "type": "string",
+        "desc": "Signature type (default eip191)"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## What

Adds **rustok-wallet** — a self-custody Ethereum agent wallet that runs entirely locally as one container (MCP over stdio). Private keys are created and stored in a local Docker volume (`rustok-wallet:/data`) and never leave it.

- Read-only tools: wallet context, token balances, DeFi positions (Aave v3, ERC-4626)
- `preview_transaction`: decoded call, pre-sign simulation (revert check), gas, risk level
- `sign_message` (EIP-191)
- Transaction execution is intentionally **not** exposed as an MCP tool

## Notes for review

- **Own pre-built image** (Option B): `ghcr.io/rustok-org/rustok-wallet` — the image ships compiled wallet-core binaries whose source is proprietary; the MCP layer and this catalog entry come from the MIT-0 repo [rustok-org/mcp](https://github.com/rustok-org/mcp). The image is public and free to pull. Also published in the official MCP registry as `io.github.rustok-org/rustok-wallet` (ownership label `io.modelcontextprotocol.server.name` present in the image config).
- **`tools.json` provided**: the server needs a configured RPC URL and keystore password before it can list tools, so the tools list is supplied statically (verified against the tool definitions in `src/rustok_mcp/handlers.py`).
- **One-time onboarding**: users must run `create-wallet` once in their own terminal (prints the recovery phrase locally) before enabling the server — called out in the entry description; docs in the repo README/INSTALL.
- **User-configured RPC endpoint** (any Ethereum RPC), so no static `allowHosts` list — same pattern as the `prometheus` entry.

Validated locally: name/directory/title checks pass, YAML formatted with prettier.