### PR TITLE
Add odoo-pulse

### DIFF
--- a/servers/odoo-pulse/server.yaml
+++ b/servers/odoo-pulse/server.yaml
@@ -1,0 +1,54 @@
+name: odoo-pulse
+image: mcp/odoo-pulse
+type: server
+meta:
+  category: productivity
+  tags:
+    - ai
+    - analytics
+    - anthropic
+    - business-intelligence
+    - claude
+    - claude-mcp
+    - erp
+    - llm
+    - model-context-protocol
+    - odoo
+    - xml-rpc
+about:
+  title: odoo-pulse
+  description: An AI business analyst for your Odoo ERP. One MCP call returns a full report (numbers, highlights, risks, and a verdict) spanning sales, CRM, receivables, inventory, project health, and absence. Read-only by default; works with Odoo 18+ via XML-RPC.
+  icon: https://avatars.githubusercontent.com/u/169115789?v=4
+source:
+  project: https://github.com/minhhq-a1/odoo-pulse
+  commit: 82abfa691e48da98c026c4021a57dc98e9255519
+config:
+  description: Configure the connection to your Odoo ERP instance.
+  secrets:
+    - name: odoo-pulse.odoo_api_key
+      env: ODOO_API_KEY
+      example: <ODOO_API_KEY>
+  env:
+    - name: ODOO_URL
+      example: https://acme.odoo.com
+      value: '{{odoo-pulse.odoo_url}}'
+    - name: ODOO_DB
+      example: acme
+      value: '{{odoo-pulse.odoo_db}}'
+    - name: ODOO_USERNAME
+      example: you@example.com
+      value: '{{odoo-pulse.odoo_username}}'
+    - name: ODOO_READ_ONLY
+      example: "true"
+      value: '{{odoo-pulse.odoo_read_only}}'
+  parameters:
+    type: object
+    properties:
+      odoo_url:
+        type: string
+      odoo_db:
+        type: string
+      odoo_username:
+        type: string
+      odoo_read_only:
+        type: string


### PR DESCRIPTION
AI business analyst for Odoo ERP (18+) — one-call reports with verdicts (business_pulse, pipeline_review, receivables_health, inventory_risk, sales_snapshot, absence_overview) over the XML-RPC external API. Read-only by default; writes require four independent opt-ins, and system models are never writable. MIT. PyPI: [odoo-pulse](https://pypi.org/project/odoo-pulse/) (also on the official MCP registry as io.github.minhhq-a1/odoo-pulse). Docker builds from the repo Dockerfile; a seeded docker-compose playground is available for testing without an Odoo account.