### PR TITLE
Add AISentinel — security/policy/audit layer for AI agents

### DIFF
--- a/servers/aisentinel/server.yaml
+++ b/servers/aisentinel/server.yaml
@@ -17,4 +17,4 @@ about:
   icon: https://raw.githubusercontent.com/Kabzhanov/AISentinel/main/assets/aisentinel-logo-400.png
 source:
   project: https://github.com/Kabzhanov/AISentinel
-  commit: b93e50e1c22c99354cdea977dd3290d5aa012a09
+  commit: c60326064e2fef822bf744db9c9a0c706ce4b9ec

--- a/servers/aisentinel/server.yaml
+++ b/servers/aisentinel/server.yaml
@@ -1,0 +1,20 @@
+name: aisentinel
+image: mcp/aisentinel
+type: server
+meta:
+  category: devops
+  tags:
+    - agent-security
+    - ai-agents
+    - ai-security
+    - llm-security
+    - observability
+    - prompt-injection-defense
+    - security
+about:
+  title: AISentinel
+  description: Security, control and observability layer for AI agents. Enforces a YAML policy on tool calls (allow / block / require_human_approval) and keeps an append-only JSONL audit log. Exposes MCP tools to check a proposed tool call against the active policy, append audit events, validate a policy, and read an audit snapshot for the AI Trust Index. By BizDNAi.
+  icon: https://raw.githubusercontent.com/Kabzhanov/AISentinel/main/assets/aisentinel-logo-400.png
+source:
+  project: https://github.com/Kabzhanov/AISentinel
+  commit: b93e50e1c22c99354cdea977dd3290d5aa012a09


### PR DESCRIPTION
Adds AISentinel to the Docker MCP Registry (local/containerized server).

AISentinel is an open-source (Apache-2.0) security, control & observability layer for AI agents. As an MCP server it exposes tools to evaluate a proposed tool call against a YAML policy (allow / block / require_human_approval), append events to an append-only JSONL audit log, validate a policy, and read an audit snapshot for the AI Trust Index.

- Repo: https://github.com/Kabzhanov/AISentinel
- License: Apache-2.0
- Category: devops
- Validated locally: `task build`, `task catalog`, `task validate` all pass; `docker run mcp/aisentinel` answers MCP initialize + tools/list (4 tools).
- By BizDNAi (team behind the AI Trust Index).