### PR TITLE
Add vr-org: VR.org VR / AR / XR news and data server

### DIFF
--- a/servers/vr-org/readme.md
+++ b/servers/vr-org/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/evanatpizzarobot/vr-org-mcp#readme

--- a/servers/vr-org/server.yaml
+++ b/servers/vr-org/server.yaml
@@ -1,0 +1,19 @@
+name: vr-org
+type: remote
+meta:
+  category: news
+  tags:
+    - vr
+    - ar
+    - xr
+    - news
+    - remote
+about:
+  title: VR.org VR / AR / XR Reader
+  description: Live VR, AR, and XR news, full-text original articles, events, curated headset deals, comparisons, and buyer-guide answers from VR.org.
+  icon: https://vr.org/favicon-512.png
+source:
+  project: https://github.com/evanatpizzarobot/vr-org-mcp
+remote:
+  transport_type: streamable-http
+  url: https://vr.org/mcp

--- a/servers/vr-org/tools.json
+++ b/servers/vr-org/tools.json
@@ -1,0 +1,124 @@
+[
+  {
+    "name": "search_vr_news",
+    "description": "Returns the latest VR, AR, and XR headlines from VR.org's live aggregated feed plus VR.org originals. Optionally filter by category and match a keyword.",
+    "arguments": [
+      {
+        "name": "category",
+        "type": "string",
+        "desc": "Optional category filter: hardware, gaming, software, enterprise, ar, or xr. Omit for all."
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "Max results, 1-50 (default 20)."
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Optional keyword to match in the title or snippet."
+      }
+    ]
+  },
+  {
+    "name": "get_vr_trending",
+    "description": "Returns the topics currently trending across VR.org's aggregated VR / AR / XR feed.",
+    "arguments": []
+  },
+  {
+    "name": "list_vr_originals",
+    "description": "Returns summaries of VR.org's own editorial articles (reporting, opinion, retrospectives, guides), newest first. Optionally filter by category.",
+    "arguments": [
+      {
+        "name": "category",
+        "type": "string",
+        "desc": "Optional category filter: hardware, gaming, software, enterprise, ar, or xr. Omit for all."
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "Max results, 1-50 (default 15)."
+      }
+    ]
+  },
+  {
+    "name": "get_vr_article",
+    "description": "Returns the full content (title, author, date, tags, and the article body HTML) of one VR.org original article identified by its slug.",
+    "arguments": [
+      {
+        "name": "slug",
+        "type": "string",
+        "desc": "The article slug, e.g. 'why-vr-is-the-perfect-horror-machine'."
+      }
+    ]
+  },
+  {
+    "name": "get_vr_events",
+    "description": "Returns upcoming VR, AR, and XR industry events (conferences, expos, launches) from VR.org's events calendar, soonest first. Set include_past to also include events that have already ended.",
+    "arguments": [
+      {
+        "name": "include_past",
+        "type": "boolean",
+        "desc": "Include events that have already ended (default false)."
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "Max results, 1-50 (default 10)."
+      }
+    ]
+  },
+  {
+    "name": "get_vr_deals",
+    "description": "Returns VR.org's current curated product picks (headsets, accessories, AR glasses) with prices, badges, and retailer links. Optionally filter to one section.",
+    "arguments": [
+      {
+        "name": "section",
+        "type": "string",
+        "desc": "Optional section filter, e.g. 'headsets'."
+      }
+    ]
+  },
+  {
+    "name": "compare_vr_headsets",
+    "description": "Returns a side-by-side of two headsets (price, badge, description, retailer links) from VR.org's curated catalog. Accepts partial names like 'Quest 3' or 'PSVR2'.",
+    "arguments": [
+      {
+        "name": "a",
+        "type": "string",
+        "desc": "First headset name (partial match allowed)."
+      },
+      {
+        "name": "b",
+        "type": "string",
+        "desc": "Second headset name (partial match allowed)."
+      }
+    ]
+  },
+  {
+    "name": "get_top_vr_games",
+    "description": "Returns VR.org's current ranked list of the top VR games.",
+    "arguments": []
+  },
+  {
+    "name": "get_top_vr_apps",
+    "description": "Returns VR.org's current ranked list of the top VR apps and utilities.",
+    "arguments": []
+  },
+  {
+    "name": "list_vr_sources",
+    "description": "Returns the news sources VR.org aggregates, with per-source article counts and status.",
+    "arguments": []
+  },
+  {
+    "name": "vr_explain",
+    "description": "Returns a canonical VR.org answer and the authoritative pillar-page link for a common VR / AR / XR question (for example 'what is vr', 'best headset').",
+    "arguments": [
+      {
+        "name": "topic",
+        "type": "string",
+        "desc": "The topic or question, e.g. 'what is vr' or 'best vr headset'."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds a catalog entry for vr-org, VR.org's read-only MCP server. It gives agents live VR, AR, and XR news, full-text original articles, events, curated headset deals, comparisons, and buyer-guide answers from VR.org.

This is a remote server (streamable-http, stateless, no auth, no secrets required). The npm package (vr-org-mcp) is also published for local stdio use via npx.

- npm package: https://www.npmjs.com/package/vr-org-mcp
- Official MCP registry entry (org.vr/vr-mcp): https://registry.modelcontextprotocol.io/v0/servers?search=org.vr/vr-mcp
- Live endpoint: https://vr.org/mcp
- GitHub repo: https://github.com/evanatpizzarobot/vr-org-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)