### PR TITLE
Add TokenLab MCP server

### DIFF
--- a/servers/tokenlab/server.yaml
+++ b/servers/tokenlab/server.yaml
@@ -1,0 +1,26 @@
+name: tokenlab
+image: mcp/tokenlab
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - llm
+    - model-catalog
+    - pricing
+    - api-gateway
+about:
+  title: TokenLab
+  description: Discover and compare AI models and pricing, then call OpenAI-compatible Chat Completions or native Responses, Anthropic Messages, and Gemini endpoints.
+  icon: https://tokenlab.sh/favicon.ico
+source:
+  project: https://github.com/hedging8563/tokenlab-mcp-server
+  branch: main
+  commit: 7fc1f10c0de568aa54c49e6be43c43ef910a1765
+config:
+  description: Configure TokenLab inference. The API key is optional for public model catalog and pricing tools.
+  secrets:
+    - name: tokenlab.api_key
+      env: TOKENLAB_API_KEY
+      example: tl_your_api_key
+      required: false


### PR DESCRIPTION
## Summary

Add TokenLab to the Docker MCP Catalog. The server provides public model discovery and pricing tools plus optional authenticated OpenAI-compatible Chat Completions, Responses, Anthropic Messages, and Gemini generateContent calls.

## Validation

- `go run ./cmd/validate -name tokenlab`
- Upstream `npm test` (9-tool MCP handshake, native payload forwarding, and auth coverage)
- Upstream `npm pack --dry-run`
- Upstream Dockerfile lint
- Live smoke against TokenLab Responses, Anthropic Messages, and Gemini endpoints

The API key is optional. Public catalog and pricing tools can be tested without credentials.