### PR TITLE
Add dftracer-agents MCP server

### DIFF
--- a/servers/dftracer-agents/server.yaml
+++ b/servers/dftracer-agents/server.yaml
@@ -1,0 +1,23 @@
+name: dftracer-agents
+image: dftracer/agents-mcp
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - profiling
+    - observability
+    - hpc
+    - io
+about:
+  title: DFTracer Agents
+  description: >-
+    Exposes the dftracer I/O tracing toolkit as MCP tools: trace summarizing,
+    querying, analysis, and plot generation, plus dftracer_utils CLI wrappers
+    (info, stats, merge, split, index, reader, pgzip, tar, organize, replay).
+    Built for diagnosing I/O performance in HPC and AI/ML (DLIO) workloads.
+  icon: https://avatars.githubusercontent.com/u/5921419?v=4
+source:
+  project: https://github.com/llnl/dftracer-agents
+  branch: develop
+  commit: fa303f0a9c98a2fecd7330b5b12cb74cfe8309f2

--- a/servers/dftracer-agents/server.yaml
+++ b/servers/dftracer-agents/server.yaml
@@ -20,4 +20,4 @@ about:
 source:
   project: https://github.com/llnl/dftracer-agents
   branch: develop
-  commit: fa303f0a9c98a2fecd7330b5b12cb74cfe8309f2
+  commit: dc4415507db78e54c75f32766602037eb2cc2be3

--- a/servers/dftracer-agents/tools.json
+++ b/servers/dftracer-agents/tools.json
@@ -1,0 +1,4422 @@
+[
+  {
+    "name": "reader",
+    "description": "Read bytes / lines from a GZIP or TAR.GZ compressed file.",
+    "arguments": [
+      {
+        "name": "file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "force_rebuild",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "check",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "read_buffer_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "info",
+    "description": "Display metadata / index info for .pfw.gz files.",
+    "arguments": [
+      {
+        "name": "files",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "force_rebuild",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "merge",
+    "description": "Merge .pfw/.pfw.gz files into a single JSON-array output.",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "compress",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "gzip_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "split",
+    "description": "Split traces into equal-size chunks.",
+    "arguments": [
+      {
+        "name": "app_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "chunk_size_mb",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "compress",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "event_count",
+    "description": "Count valid events in .pfw/.pfw.gz files.",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pgzip",
+    "description": "Parallel-gzip .pfw \u2192 .pfw.gz in a directory.",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "tar",
+    "description": "Inspect / list files in a TAR.GZ archive with DFTracer data.",
+    "arguments": [
+      {
+        "name": "file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "force_rebuild",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "list_files",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "show_info",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "stats",
+    "description": "Compute event statistics (summary / categories / names / pid_tids \u2026).",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "files",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "report",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_n",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "top_n_pid_tid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group_by_dims",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "json_output",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "no_auto_index",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "aggregator",
+    "description": "Aggregate DFTracer events into time-series counters.",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "time_interval_ms",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "group_keys",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "metric_fields",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "compress",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "compression_level",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "event_format",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "boundary_events",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "no_track_process_parents",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "chunk_size_mb",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "read_batch_size_mb",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "compute_percentiles",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "percentiles",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "relative_accuracy",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "format_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "call_tree",
+    "description": "Build and analyze a hierarchical call tree from trace files.",
+    "arguments": [
+      {
+        "name": "inputs",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "recursive",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pattern",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "save_json",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "text_export",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "analyze",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "stats_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "no_save",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "fix_c_app_names",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "comparator",
+    "description": "Compare trace metrics between a baseline and variant run.",
+    "arguments": [
+      {
+        "name": "baseline",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "variant",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "config_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group_by_dims",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_format",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "time_interval_ms",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "threshold_pct",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "no_color",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "view",
+    "description": "Extract a filtered subset of trace events with chunk-level pruning.",
+    "arguments": [
+      {
+        "name": "files",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "preset",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "recipe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "save_recipe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "time_range",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "min_duration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_duration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "output_file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "stream",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "no_metadata",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "no_auto_index",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "index",
+    "description": "Build bloom-filter per-chunk indices (and optional manifest).",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dimensions",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expected_entries",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "false_positive_rate",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "read_batch_size_mb",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "manifest",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "rebuild_summaries",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "organize",
+    "description": "Reorganize traces into query-based groups with provenance tracking.",
+    "arguments": [
+      {
+        "name": "files",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "groups",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "chunk_size_mb",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "no_compress",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "reconstruct",
+    "description": "Reconstruct original traces from reorganized files via provenance sidecars.",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "no_compress",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "replay",
+    "description": "Replay I/O operations from trace files with timing / filtering.",
+    "arguments": [
+      {
+        "name": "inputs",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "no_timing",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "dftracer_mode",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "no_sleep",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "recursive",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "use_call_tree",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "hierarchical_replay",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "respect_call_hierarchy",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "filter_pid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude_pid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter_tid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude_tid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter_function",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude_function",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter_category",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude_category",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start_timestamp",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end_timestamp",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "min_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "sample_rate",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "sample_seed",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_events",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "gen_fake_trace",
+    "description": "Generate realistic synthetic DFTracer traces for testing bloom-filter indexing.",
+    "arguments": [
+      {
+        "name": "output_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "num_processes",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "num_hosts",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "num_epochs",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "steps_per_epoch",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_every",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "validation_every",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "num_train_files",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "num_val_files",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "step_duration_ms",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size_mb",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "server",
+    "description": "Start the HTTP REST server for DFTracer trace data.",
+    "arguments": [
+      {
+        "name": "bind_address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "gen_dlio_config",
+    "description": "Generate a DLIO YAML config from raw DFTracer traces.",
+    "arguments": [
+      {
+        "name": "output",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_bound_percentile",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "simulation_iterations",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "target_e2e_error",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "target_cdf_similarity",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "patience",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "epsilon",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "momentum",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "min_percentile",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "num_workers",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "prefetch_factor",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "seed",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_samples_per_entry",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "time_interval_ms",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "aggregator_mpi",
+    "description": "Distributed-SST aggregator driven via ``mpirun``.",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "time_interval_ms",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "staging_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "shared_staging",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "keep_staging",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "checkpoint_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "executor_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "call_tree_mpi",
+    "description": "Distributed call-tree aggregation across MPI ranks.",
+    "arguments": [
+      {
+        "name": "input_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "staging_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "gzip_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "keep_staging",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "analyze",
+    "description": "Run dfanalyzer on the provided trace path.",
+    "arguments": [
+      {
+        "name": "trace_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "view_types",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "debug",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "analyzer",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_preset",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_checkpoint",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_checkpoint_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_time_approximate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_time_granularity",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_time_resolution",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "output_format",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_compact",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "output_root_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "output_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_run_db_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cluster_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cluster_n_workers",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "cluster_memory_limit",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cluster_processes",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "cluster_cores",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "cluster_memory",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "list_presets",
+    "description": "List common presets and supported modes from the docs.",
+    "arguments": []
+  },
+  {
+    "name": "plot",
+    "description": "Generate a plot from a dftracer I/O trace directory.",
+    "arguments": [
+      {
+        "name": "trace_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "plot_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter_expr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_preset",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_n",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "n_buckets",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_format",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_files",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "plot_all",
+    "description": "Generate all five standard plots for a trace in one call.",
+    "arguments": [
+      {
+        "name": "trace_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_format",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter_expr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "analyzer_preset",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_n",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_files",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "diagnose",
+    "description": "Diagnose I/O bottlenecks from a DFAnalyzer checkpoint directory.",
+    "arguments": [
+      {
+        "name": "checkpoint_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "output_format",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "metric_boundaries",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_create",
+    "description": "Clone a Git repository into a new, isolated session workspace.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ref",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dataset_path",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_init_structure",
+    "description": "Build (or repair) the canonical session directory skeleton.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dataset_path",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_detect",
+    "description": "Detect the programming language, build tool, and dftracer feature flags.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hdf5_prefix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mpi_prefix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mpicc",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mpicxx",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_list_files",
+    "description": "List files inside a workspace sub-folder using a glob pattern.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subfolder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pattern",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_read_file",
+    "description": "Read a file from the workspace for inspection or annotation.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subfolder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_bytes",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_write_file",
+    "description": "Write (create or overwrite) a file inside the workspace.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subfolder",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_remove_path",
+    "description": "Remove a file, directory, or symlink inside the session workspace.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "relpath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "recursive",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_configure",
+    "description": "Configure the build system for the *original* cloned source.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "extra_cmake_flags",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "extra_configure_flags",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "extra_pip_flags",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_build_install",
+    "description": "Compile and install the original project after ``session_configure``.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "jobs",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_run_smoke_test",
+    "description": "Run a smoke test command inside the workspace as a single process.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subfolder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "env_extra",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_wait_flux_job",
+    "description": "Wait for a Flux job (inside an allocation) to complete, polling until done.",
+    "arguments": [
+      {
+        "name": "alloc_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "poll_interval",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "log_file",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_copy_annotated",
+    "description": "Copy the original source tree to ``annotated/`` ready for instrumentation.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_patch_build",
+    "description": "Patch the build system in ``annotated/`` to link dftracer.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_annotation_report",
+    "description": "Show a coverage report comparing ``source/`` against ``annotated/``.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_install_dftracer",
+    "description": "Install dftracer via pip for all project types, then locate dirs in site-packages.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dftracer_ref",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "jobs",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_install_dftracer_utils",
+    "description": "Install ``dftracer-utils`` from the ``develop`` branch into the session environment.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_build_annotated",
+    "description": "Configure and build the annotated source with dftracer linked.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "jobs",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "extra_cmake_flags",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "custom_build_cmd",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "build_subdir",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_init_run",
+    "description": "Create the directory structure for a named profiling/optimization run.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_get_run_paths",
+    "description": "Return the canonical paths for a named run without creating anything.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_list_runs",
+    "description": "List all named runs (baseline, opt1, opt2, \u2026) in the session workspace.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_validate_structure",
+    "description": "Validate that the session workspace matches the canonical directory structure.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_reorganize_structure",
+    "description": "Repair the session workspace to match the canonical directory structure.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_snapshot_run_source",
+    "description": "Snapshot the current source tree into ``<run_name>/source/`` and generate a patch.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prev_run_name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_run_with_dftracer",
+    "description": "Run a command with dftracer environment variables set to capture traces.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subfolder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "env_extra",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "allocation_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "nnodes",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ntasks",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_analyze_traces",
+    "description": "Summarise dftracer traces using ``dftracer_info`` (dfanalyzer).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "extra_flags",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_search_papers_for_config",
+    "description": "Search academic literature AND GitHub repos for application-specific run configuration.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "app_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "problem_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results_each",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_status",
+    "description": "Return the current persisted state of a session.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_collect_system_info",
+    "description": "Collect a system configuration snapshot for the current node.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_generate_dftracer_pc",
+    "description": "Generate a pkg-config ``.pc`` file for dftracer and save it under install_ann/.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_identify_smoke_test_files",
+    "description": "Identify the minimal set of source files a smoke test actually exercises.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "smoke_cmd",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "use_strace",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_capture_run_record",
+    "description": "Capture everything needed to reconstruct a run, before it is overwritten.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prev_run_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_script",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_log",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "param_files",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_final_report",
+    "description": "Assemble a self-contained ``final_report/`` folder for a session.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "report_md",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "conversation_md",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "readme_md",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "alloc_hint",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "graph_ensure",
+    "description": "Ensure the knowledge graph (or a session's app graph) is fresh.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "graph_query",
+    "description": "Locate code and docs without reading them. Ensures graph freshness first.",
+    "arguments": [
+      {
+        "name": "question",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "symbol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "budget",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "context",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "graph_get_node",
+    "description": "Return the text a graph node owns \u2014 the retriever half of the graph.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_lines",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "profile_bind",
+    "description": "Attach the pipeline profile to a dftracer session. Call once, right",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "app",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "system",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "profile_step_begin",
+    "description": "Open a pipeline step, starting its execution clock.",
+    "arguments": [
+      {
+        "name": "step",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "agent",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "profile_step_end",
+    "description": "Close a step's current attempt and stop its execution clock.",
+    "arguments": [
+      {
+        "name": "status",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "step",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "error",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "profile_status",
+    "description": "Running totals: cost, tokens, per-step timing, tries and retries.",
+    "arguments": []
+  },
+  {
+    "name": "profile_report",
+    "description": "Write the final performance report and return it.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "flush",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "privacy_scan",
+    "description": "Report identifying content in the persisted (git-tracked) trees.",
+    "arguments": [
+      {
+        "name": "paths",
+        "type": "array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "privacy_redact",
+    "description": "Redact identifying content from the persisted trees, in place.",
+    "arguments": [
+      {
+        "name": "paths",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "privacy_suspects",
+    "description": "Hunt for corner cases the current redaction rules do not yet cover.",
+    "arguments": [
+      {
+        "name": "paths",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "privacy_add_pattern",
+    "description": "Persist a new redaction rule, after proving it works and breaks nothing.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "replacement",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "must_redact",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "must_not_change",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "structure_safe",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "note",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_run_pipeline",
+    "description": "Full dftracer annotation + smoke-test pipeline.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ref",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "smoke_test_command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "extra_cmake_flags",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "jobs",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "skip_annotation",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "annotation_confirmed",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "dftracer_ref",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pipeline_create_run",
+    "description": "Create a deterministic run directory for a pipeline and remember the",
+    "arguments": [
+      {
+        "name": "app",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pipeline_get_run_id",
+    "description": "Return the active run ID for the given application.",
+    "arguments": [
+      {
+        "name": "app",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pipeline_list_runs",
+    "description": "List all run directories that exist for the given application.",
+    "arguments": [
+      {
+        "name": "app",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_service_start",
+    "description": "Start the ``dftracer_service`` background daemon for this session.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "trace_interval_ms",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "libuv_threads",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_service_stop",
+    "description": "Stop the ``dftracer_service`` background daemon for this session.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_add_braces",
+    "description": "Add ``{`` / ``}`` around braceless ``if`` / ``for`` / ``while`` bodies.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_extract_functions",
+    "description": "Extract function definitions with exact line numbers from a source file.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_insert_line",
+    "description": "Insert a single line of code at an exact line number in an annotated file.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "line_number",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "position",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_annotate_file",
+    "description": "Annotate a C/C++ source file with dftracer macros in a single in-memory pass.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "is_entry",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "init_args",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comp_overrides",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude_functions",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_annotate_project",
+    "description": "Annotate every C/C++ source file in the ``annotated/`` workspace in one call.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "init_args",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude_patterns",
+        "type": "array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_write_annotated_file",
+    "description": "Flush the in-memory annotated file buffer to disk.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_estimate_function_cost",
+    "description": "Estimate the instrumentation value of a C/C++/Python function.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "function_name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_syntax_check",
+    "description": "Check the syntax of an annotated source file using the real compiler front-end.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "extra_include_dirs",
+        "type": "array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_fix_header_tentative_defs",
+    "description": "Detect and fix bare global variable declarations in C/C++ header files.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_lint_annotations",
+    "description": "Lint an annotated C file for dftracer macro ordering violations.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "clang_regression_test",
+    "description": "Strip annotations from a file, re-annotate, and compare with current state.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "is_entry",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "init_args",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_extract_functions",
+    "description": "Extract function definitions with exact line numbers from a Python file.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_annotate_file",
+    "description": "Annotate a Python file with generic dftracer decorators.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "category",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "is_entry",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "logfile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "process_id",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "annotate_nested",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "only_functions",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_write_annotated_file",
+    "description": "Flush the in-memory annotated Python file buffer to disk.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_estimate_function_cost",
+    "description": "Estimate the instrumentation value of ONE Python function (AI/ML aware).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "function_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "threshold",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_estimate_file_costs",
+    "description": "Score EVERY function in a Python file and return annotate/skip lists.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "threshold",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ml_categorize_files",
+    "description": "Bucket every Python file into entry/train/data/ckpt/comm/other.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "annotated_dir",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ml_annotate_plan",
+    "description": "Compute the full ML annotation plan WITHOUT writing anything.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "threshold",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "exclude",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "annotated_dir",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ml_annotate_project",
+    "description": "Annotate an entire ML project in ONE call (fast path).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "threshold",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "exclude",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "logfile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "annotated_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "validate",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "annotate_add_app_metadata",
+    "description": "Emit the app's run parameters as dftracer metadata events.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "params_json",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "anchor_regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expressions",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "validate_annotations",
+    "description": "Verify the annotated tree is complete and correct for a language.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subdir",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "find_source_files",
+    "description": "Recursively list source files of the given language in a folder.",
+    "arguments": [
+      {
+        "name": "folder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "recursive",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "exclude_patterns",
+        "type": "array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_annotate_ai_file",
+    "description": "Annotate a Python file with dftracer AI/ML region decorators.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "category",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "is_entry",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "logfile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "process_id",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "annotate_loops",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "annotate_nested",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "python_write_ai_file",
+    "description": "Flush the in-memory AI-annotated Python file buffer to disk.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "dftracer_get_ai_annotation",
+    "description": "Look up the correct dftracer AI/ML annotation for a given function or code pattern.",
+    "arguments": [
+      {
+        "name": "function_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "code_snippet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "context",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "phase",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_detect_ml_workload",
+    "description": "Detect ML/AI workload characteristics from a source tree.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source_folder",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_search_local_papers",
+    "description": "Search the local ML/AI optimization paper library for relevant citations.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bottleneck",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "framework",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_k",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_ml_append_lesson",
+    "description": "Append a new lesson to the shared annotation lessons file.",
+    "arguments": [
+      {
+        "name": "app",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "context",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "error",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "root_cause",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "phase",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "framework",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "annotation_rule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tags",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_lessons_sync_preview",
+    "description": "Preview the lessons that would be synced back to the source repo.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_lessons_sync_pr",
+    "description": "Open a PR against llnl/dftracer-agents with new staged lesson entries.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "dftracer_get_init_fini",
+    "description": "Return the correct dftracer init/fini macros and API doc URL for a language.",
+    "arguments": [
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "dftracer_get_function_annotations",
+    "description": "Return the correct function-level annotation macros for a language.",
+    "arguments": [
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "dftracer_get_metadata_api",
+    "description": "Return the dftracer per-process metadata macro for a language.",
+    "arguments": [
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "dftracer_get_function_update_api",
+    "description": "Return the dftracer per-function metadata update macros for a language.",
+    "arguments": [
+      {
+        "name": "language",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_annotate_c_file",
+    "description": "Annotate a single .c source file with dftracer C macros.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "build_errors",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_annotate_cpp_file",
+    "description": "Annotate a single .cpp/.cxx/.cc source file with dftracer C++ RAII macros.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "build_errors",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_annotate_python_file",
+    "description": "Annotate a single .py source file with dftracer Python decorators.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "build_errors",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_search_optimization_papers",
+    "description": "Search arXiv for optimization papers relevant to the diagnosed bottlenecks.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results_per_topic",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "extra_query",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_optimization_iteration",
+    "description": "Run one iteration of the build \u2192 profile \u2192 diagnose \u2192 search optimization loop.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "app_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "env_extra",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "optimization_applied",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rebuild",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_search_attempts",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "papers_per_query",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_generate_optimization_proposals",
+    "description": "Generate concrete, citation-backed optimization proposals from bottleneck diagnosis.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "levels",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_proposals_per_level",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "bottlenecks_json",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_optimize_l1_app",
+    "description": "Generate citation-backed application-code optimization proposals (Level 1).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_proposals",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_optimize_l2_software",
+    "description": "Generate citation-backed software/middleware optimization proposals (Level 2).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_proposals",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_optimize_l3_filesystem",
+    "description": "Generate citation-backed filesystem/OS optimization proposals (Level 3).",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_proposals",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_snapshot_l1_source",
+    "description": "Snapshot the current annotated source tree before or after an L1 optimization pass.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "label",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_run_l1_iteration",
+    "description": "Run the benchmark with dftracer and collect iteration-specific L1 traces.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subfolder",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data_dir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "env_extra",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "app_name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_memory_retrieve",
+    "description": "Read Tier-2 project memory for citations/strategies already",
+    "arguments": [
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sys_context",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "category",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_memory_write",
+    "description": "Write path: record that *strategy_title* (backed by *citation_json*)",
+    "arguments": [
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sys_context",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "strategy_title",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "citation_json",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "outcome",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_memory_reflect",
+    "description": "Agentic reflection: convert one iteration's observed bottleneck",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_memory_stats",
+    "description": "Summarize the Tier-2 project memory store \u2014 counts, top strategies",
+    "arguments": []
+  },
+  {
+    "name": "session_optimization_plan",
+    "description": "Build a Layer x Component x Scale trial matrix from the latest diagnosed bottlenecks.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "session_optimization_apply_trial",
+    "description": "Record the measured impact of one isolated trial and update the greedy-best config.",
+    "arguments": [
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "trial_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iteration",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "result_metric_delta",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "opt_kb_lookup",
+    "description": "STEP 1 of the optimization loop \u2014 what has already been tried here?",
+    "arguments": [
+      {
+        "name": "system",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "workload",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "software",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bottleneck",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "opt_kb_record",
+    "description": "Record ONE measured optimization result into the cross-session KB.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "change",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "metric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "before",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "after",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "citation",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "system",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "workload",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "software",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bottleneck",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lower_is_better",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "run_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "citation_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "opt_kb_render",
+    "description": "Render the KB into the ``dftracer-optimization-kb`` skill (one file per scope).",
+    "arguments": []
+  },
+  {
+    "name": "opt_proposal_table",
+    "description": "Render optimization proposals as a citation-backed markdown table.",
+    "arguments": [
+      {
+        "name": "proposals_json",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "system",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "workload",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "software",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "docs_list_sources",
+    "description": "List all available dftracer documentation sources with their descriptions",
+    "arguments": []
+  },
+  {
+    "name": "docs_search",
+    "description": "Search dftracer documentation and return relevant sections.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "fetch_content",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "docs_fetch_page",
+    "description": "Fetch a specific dftracer documentation page and return its content.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_sections",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "docs_search_key_pages",
+    "description": "Fetch and summarise all key pages for a documentation source.",
+    "arguments": [
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "search_arxiv",
+    "description": "Search arXiv for academic papers.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "sort_by",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "category",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "get_arxiv_paper",
+    "description": "Fetch a single arXiv paper by its ID.",
+    "arguments": [
+      {
+        "name": "arxiv_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "search_semantic_scholar",
+    "description": "Search Semantic Scholar for academic papers.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "year_range",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fields_of_study",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "min_citations",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "get_semantic_scholar_paper",
+    "description": "Fetch full details for a paper from Semantic Scholar.",
+    "arguments": [
+      {
+        "name": "paper_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "get_author_papers",
+    "description": "Search for an author on Semantic Scholar and retrieve their papers.",
+    "arguments": [
+      {
+        "name": "author_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "search_papers_combined",
+    "description": "Search both arXiv and Semantic Scholar simultaneously.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results_each",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "fetch_webpage_article",
+    "description": "Fetch and extract structured content from any webpage, blog post, or article.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_sections",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "rank_papers_by_relevance",
+    "description": "Rank papers and articles by relevance to I/O bottlenecks and system configuration.",
+    "arguments": [
+      {
+        "name": "papers_json",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bottleneck_description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "system_config",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_n",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "system_detect",
+    "description": "Detect the current HPC/container system and return its configuration.",
+    "arguments": [
+      {
+        "name": "hostname",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "system_list",
+    "description": "List all known systems in resources/systems.yaml.",
+    "arguments": []
+  },
+  {
+    "name": "system_save",
+    "description": "Save or update a system's configuration in resources/systems.yaml.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sudo",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "modules",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "env",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "mpi_launcher",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "skill_list",
+    "description": "List every available dftracer skill with its name and description.",
+    "arguments": []
+  },
+  {
+    "name": "skill_search",
+    "description": "Rank skills by relevance to a free-text query.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_results",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "skill_load",
+    "description": "Return Markdown text from one or more skills \u2014 full file, one section, or a sibling file.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "section",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "file",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "agents_sync",
+    "description": "Re-render every harness agent copy from the YAML agent templates.",
+    "arguments": [
+      {
+        "name": "target_root",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "memory_list",
+    "description": "List the project's persistent memories (name + one-line description).",
+    "arguments": []
+  },
+  {
+    "name": "memory_read",
+    "description": "Return the full text of one or more memories (comma-separated names).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "memory_write",
+    "description": "Create or update a persistent memory, and keep the MEMORY.md index current.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "body",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Add dftracer-agents MCP server"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** dftracer-agents
**Repository URL:** https://github.com/llnl/dftracer-agents
**Brief Description:** DFTracer I/O tracing/profiling toolkit for HPC and AI/ML (DLIO) workloads, exposed as MCP tools (trace summarizing, querying, analysis, plotting, plus dftracer_utils CLI wrappers).

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license) — MIT, see [LICENSE](https://github.com/llnl/dftracer-agents/blob/develop/LICENSE)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues — see [SECURITY.md](https://github.com/llnl/dftracer-agents/blob/develop/SECURITY.md)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name dftracer-agents`
- [x] I have built the MCP Server using `task build -- --tools dftracer-agents` — *N/A: submitted with a self-provided image (`--image dftracer/agents-mcp`), which CONTRIBUTING.md says to skip `task build` for. In its place: `task validate -- --name dftracer-agents` passed all 11 checks, and the server was verified live through Docker's own MCP Toolkit gateway (`docker mcp gateway run --catalog ... --servers dftracer-agents`), which listed all 153 tools successfully.*
- [x] If the server requires credentials to test it, I have shared test credentials using this form — *N/A: this server needs no credentials.*