### PR TITLE
Add a new MCP server

### DIFF
--- a/servers/kiln/server.yaml
+++ b/servers/kiln/server.yaml
@@ -1,0 +1,50 @@
+name: kiln
+image: mcp/kiln
+type: server
+meta:
+  category: devops
+  tags:
+    - 3d-printing
+    - manufacturing
+    - hardware
+about:
+  title: Kiln
+  description: AI agent control of real 3D printers — design, slice, print, monitor, and recover across Bambu Lab, Creality, Prusa, Elegoo, and more.
+  icon: https://www.google.com/s2/favicons?domain=kiln3d.com&sz=64
+source:
+  project: https://github.com/codeofaxel/Kiln
+  commit: f2c47944dc67e1577483dcbf7d10b40aa3132e5d
+run:
+  env:
+    KILN_ACCEPT_TERMS: "1"
+config:
+  description: Optionally connect Kiln to a printer on your local network. Not required to start — printers can also be registered dynamically from inside the chat.
+  secrets:
+    - name: kiln.printer_api_key
+      env: KILN_PRINTER_API_KEY
+      example: <PRINTER_API_KEY>
+  env:
+    - name: KILN_PRINTER_HOST
+      example: 192.168.1.50
+      value: '{{kiln.printer_host}}'
+    - name: KILN_PRINTER_TYPE
+      example: octoprint
+      value: '{{kiln.printer_type}}'
+  parameters:
+    type: object
+    properties:
+      printer_host:
+        type: string
+        description: URL or IP of your 3D printer (OctoPrint, Moonraker, Creality, or Prusa Link)
+      printer_type:
+        type: string
+        description: Printer connection type
+        enum:
+          - octoprint
+          - moonraker
+          - creality
+          - bambu
+          - prusalink
+          - elegoo
+          - serial
+    required: []


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Kiln
**Repository URL:** https://github.com/codeofaxel/Kiln
**Brief Description:** MCP server that lets AI agents drive real 3D printers end to end — design, slice, print, monitor via camera, and recover from failures — across Bambu Lab, Creality, Prusa, Elegoo, and more, over OctoPrint, Moonraker/Klipper, PrusaLink, and USB.

## Basic Requirements

- [x] **Open Source**: AGPL-3.0-or-later — copyleft, not in the Apache/MIT/BSD list above. Flagging this explicitly since the image gets rebuilt and redistributed under `mcp/kiln`; happy to answer any licensing questions or adjust if this needs a different path.
- [x] **MCP Compliant**: Implements MCP API specification (stdio transport)
- [x] **Active Development**: Recent commits, actively maintained
- [x] **Docker Artifact**: Dockerfile already in the repo root (`kiln serve` entrypoint, requires `KILN_ACCEPT_TERMS=1` for non-interactive boot — set in `run.env`)
- [x] **Documentation**: README with full setup instructions
- [x] **Security Contact**: `.well-known/security.txt` in the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above (see the license note)
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name kiln` — **not run**: Docker/Go/task weren't available in the environment this was prepared in. The manifest was hand-verified against the `notion` and `filesystem`/`fetch` reference entries and parses cleanly as YAML; happy to fix anything CI flags.
- [ ] I have built the MCP Server using `task build -- --tools kiln` — same reason, not run locally.
- [ ] N/A — no credentials required to run; printer connection is optional and user-configurable at runtime.