### PR TITLE
Add Orbit Sentinel (space regulatory filings search)

### DIFF
--- a/servers/orbit-sentinel/server.yaml
+++ b/servers/orbit-sentinel/server.yaml
@@ -1,0 +1,35 @@
+name: orbit-sentinel
+image: mcp/orbit-sentinel
+type: server
+meta:
+  category: search
+  tags:
+    - fcc
+    - golang
+    - model-context-protocol
+    - regulatory-data
+    - satellite
+    - space
+about:
+  title: Orbit Sentinel
+  description: Search 419,000+ LLM-extracted space regulatory filings from the FCC, ITU, UNOOSA, and FAA-AST. 20 tools covering semantic search, entity dossiers (filings + SEC + sanctions screening), spectrum-band holdings, launch licenses, filing trends and distributions, and email alerts. A thin open-source stdio client of the Orbit Sentinel REST API by Viventine Space Systems.
+  icon: https://avatars.githubusercontent.com/u/301902482?v=4
+source:
+  project: https://github.com/Viventine-Space/orbit-sentinel-mcp
+  commit: ecd95f6ab9128e692f8c9d6fce454b4d2329364e
+config:
+  description: Configure your Orbit Sentinel API access. Get a free beta API key via magic-link signup at https://console.viventine.com.
+  secrets:
+    - name: orbit-sentinel.mcp_api_key
+      env: MCP_API_KEY
+      example: <MCP_API_KEY>
+  env:
+    - name: MCP_API_URL
+      example: https://orbit-sentinel.viventine.com
+      value: '{{orbit-sentinel.mcp_api_url}}'
+  parameters:
+    type: object
+    properties:
+      mcp_api_url:
+        type: string
+        default: https://orbit-sentinel.viventine.com

--- a/servers/orbit-sentinel/server.yaml
+++ b/servers/orbit-sentinel/server.yaml
@@ -12,11 +12,11 @@ meta:
     - space
 about:
   title: Orbit Sentinel
-  description: Search 419,000+ LLM-extracted space regulatory filings from the FCC, ITU, UNOOSA, and FAA-AST. 20 tools covering semantic search, entity dossiers (filings + SEC + sanctions screening), spectrum-band holdings, launch licenses, filing trends and distributions, and email alerts. A thin open-source stdio client of the Orbit Sentinel REST API by Viventine Space Systems.
+  description: Search 950K+ space regulatory filings from the FCC, ITU, UNOOSA, and FAA-AST. 21 tools covering semantic search, entity dossiers (filings + SEC + sanctions screening), spectrum-band holdings, launch licenses, filing trends and distributions, and email alerts. A thin open-source stdio client of the Orbit Sentinel REST API by Viventine Space Systems.
   icon: https://avatars.githubusercontent.com/u/301902482?v=4
 source:
   project: https://github.com/Viventine-Space/orbit-sentinel-mcp
-  commit: ecd95f6ab9128e692f8c9d6fce454b4d2329364e
+  commit: 6dee7f5f9764eecbe93587036c5557bdb6bf3909
 config:
   description: Configure your Orbit Sentinel API access. Get a free beta API key via magic-link signup at https://console.viventine.com.
   secrets:
@@ -26,7 +26,7 @@ config:
   env:
     - name: MCP_API_URL
       example: https://orbit-sentinel.viventine.com
-      value: '{{orbit-sentinel.mcp_api_url}}'
+      value: "{{orbit-sentinel.mcp_api_url}}"
   parameters:
     type: object
     properties:


### PR DESCRIPTION
Adds Orbit Sentinel — search over 419,000+ LLM-extracted space regulatory filings from the FCC, ITU, UNOOSA, and FAA-AST: semantic search, entity dossiers, spectrum-band holdings, launch licenses, trends, and alerts. Go stdio server, MIT, in the official MCP registry (`io.github.Viventine-Space/orbit-sentinel-mcp`). Requesting Docker-built image. `task build`/`task catalog` pass locally with all 20 tools discovered.