### PR TITLE
catalog: add Kinocut video editing server

### DIFF
--- a/servers/kinocut/server.yaml
+++ b/servers/kinocut/server.yaml
@@ -1,0 +1,35 @@
+name: kinocut
+image: mcp/kinocut
+type: server
+meta:
+  category: video
+  tags:
+    - video
+    - audio
+    - ffmpeg
+    - media
+    - editing
+    - local-first
+about:
+  title: Kinocut
+  description: Guarded, local-first video editing for AI agents with 135 tools for editing, captions, audio, effects, quality gates, resumable workflows, and provenance receipts.
+  icon: https://www.google.com/s2/favicons?domain=kinocut.dev&sz=64
+source:
+  project: https://github.com/KyaniteLabs/kinocut
+  branch: master
+  commit: 96de09d48f38afbd10d15f792a297c73d05c5b92
+run:
+  volumes:
+    - "{{kinocut.workspace_path}}:/workspace"
+  disableNetwork: true
+config:
+  description: Choose the host directory Kinocut may read from and write to. Inside the container, use /workspace for files in this directory.
+  parameters:
+    type: object
+    properties:
+      workspace_path:
+        type: string
+        description: Host directory containing the video project and media files.
+        default: /Users/demo/Videos
+    required:
+      - workspace_path

--- a/servers/kinocut/server.yaml
+++ b/servers/kinocut/server.yaml
@@ -12,12 +12,12 @@ meta:
     - local-first
 about:
   title: Kinocut
-  description: Guarded, local-first video editing for AI agents with 135 tools for editing, captions, audio, effects, quality gates, resumable workflows, and provenance receipts.
+  description: Guarded, local-first video editing for AI agents with FFmpeg, captions, audio, effects, repurposing, quality gates, resumable workflows, and provenance receipts.
   icon: https://www.google.com/s2/favicons?domain=kinocut.dev&sz=64
 source:
   project: https://github.com/KyaniteLabs/kinocut
   branch: master
-  commit: 96de09d48f38afbd10d15f792a297c73d05c5b92
+  commit: b2498333acc8c0e29cba7e6ceca19603cc8bedaf
 run:
   volumes:
     - "{{kinocut.workspace_path}}:/workspace"


### PR DESCRIPTION
## What

Adds Kinocut, a guarded local-first video execution layer for AI agents, to the Docker MCP Registry. This update pins the entry to the published v1.15.1 source commit and replaces the stale fixed tool-count claim with capability-based wording.

## Runtime

- Local stdio MCP server
- Source repository includes a Dockerfile and defaults to MCP mode
- FFmpeg is installed in the image
- Network is disabled at runtime
- A single configurable workspace mount scopes media access
- No API keys or hosted services are required

## Verification

- `task validate -- --name kinocut` passed
- `task build -- --tools kinocut` passed locally on Docker Engine for Linux arm64
- The built `check:latest` and `mcp/kinocut:latest` tags resolved to the same image with OCI revision `b2498333acc8c0e29cba7e6ceca19603cc8bedaf`
- A sequential MCP initialize and tools/list exchange returned 196 unique tools, exactly matching the expected public tool inventory from the pinned source
- YAML parsing, the exact two-field metadata delta, and `git diff --check` passed

Hosted checks, other architectures, and Docker maintainer review remain upstream acceptance gates.

Canonical project: https://github.com/KyaniteLabs/kinocut
