### PR TITLE
feat: Add Zdravo AI memory server

### DIFF
--- a/servers/zdravo-ai/server.yaml
+++ b/servers/zdravo-ai/server.yaml
@@ -1,0 +1,31 @@
+name: zdravo-ai
+image: zdravoai/zdravo-mcp:latest
+type: server
+meta:
+  category: productivity
+  tags:
+    - memory
+    - ai
+    - productivity
+    - knowledge-management
+about:
+  title: Zdravo AI
+  description: Unified memory layer for AI conversations. Save, search, and recall conversations from ChatGPT, Claude, Gemini, and Perplexity using semantic search and AI-powered insights.
+  icon: https://www.zdravo.ai/favicon.ico
+source:
+  project: https://github.com/zdravoai/zdravo
+config:
+  description: Configure the connection to Zdravo AI
+  secrets:
+    - name: zdravo-ai.api_key
+      env: ZDRAVO_API_KEY
+      example: zdravo_abc123def456ghi789jkl012mno345pqr678stu901vwx
+  env:
+    - name: ZDRAVO_API_URL
+      example: https://www.zdravo.ai
+      value: "{{zdravo-ai.api_url}}"
+  parameters:
+    type: object
+    properties:
+      api_url:
+        type: string


### PR DESCRIPTION
Adds Zdravo AI to the MCP server registry.

Zdravo AI is a unified memory layer for AI conversations that allows users to:
- Save conversations from ChatGPT, Claude, Gemini, and Perplexity
- Search memories using semantic search
- Get AI-powered insights from saved conversations

## Features
- Cross-platform memory storage
- Semantic search across all memories
- AI-powered insights and analysis
- Privacy controls (private/shared/public)
- Memory types (semantic, procedural, episodic, working, emotional)

## Configuration
Requires ZDRAVO_API_KEY environment variable. Get your key at https://www.zdravo.ai