### PR TITLE
Add Nora MCP server

### DIFF
--- a/servers/nora/server.yaml
+++ b/servers/nora/server.yaml
@@ -13,10 +13,10 @@ meta:
 about:
   title: Nora
   description: Deploy, monitor, and operate self-hosted OpenClaw and Hermes agent fleets.
-  icon: https://raw.githubusercontent.com/solomon2773/nora/b61cd2b4dc7b6ca0cdec1d1adeb4f1ce808a9e2c/.github/press-kit/logos/logo-mark.png
+  icon: https://raw.githubusercontent.com/solomon2773/nora/e1c497ca49a123faa90054e816c9ad11f76f0048/.github/press-kit/logos/logo-mark.png
 source:
   project: https://github.com/solomon2773/nora
-  commit: b61cd2b4dc7b6ca0cdec1d1adeb4f1ce808a9e2c
+  commit: e1c497ca49a123faa90054e816c9ad11f76f0048
   directory: mcp-server
 config:
   description: Configure the connection to your self-hosted Nora control plane.

--- a/servers/nora/server.yaml
+++ b/servers/nora/server.yaml
@@ -1,0 +1,38 @@
+name: nora
+image: mcp/nora
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - agent-management
+    - llmops
+    - docker
+    - kubernetes
+    - self-hosted
+about:
+  title: Nora
+  description: Deploy, monitor, and operate self-hosted OpenClaw and Hermes agent fleets.
+  icon: https://raw.githubusercontent.com/solomon2773/nora/b61cd2b4dc7b6ca0cdec1d1adeb4f1ce808a9e2c/.github/press-kit/logos/logo-mark.png
+source:
+  project: https://github.com/solomon2773/nora
+  commit: b61cd2b4dc7b6ca0cdec1d1adeb4f1ce808a9e2c
+  directory: mcp-server
+config:
+  description: Configure the connection to your self-hosted Nora control plane.
+  secrets:
+    - name: nora.api_key
+      env: NORA_API_KEY
+      example: nora_xxxxxxxx
+  env:
+    - name: NORA_API_URL
+      example: https://nora.example.com
+      value: "{{nora.api_url}}"
+  parameters:
+    type: object
+    properties:
+      api_url:
+        type: string
+        description: The public base URL of your Nora deployment.
+    required:
+      - api_url


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Nora
**Repository URL:** https://github.com/solomon2773/nora
**Brief Description:** Operate a self-hosted Nora control plane from MCP clients: deploy and control OpenClaw/Hermes agents, inspect fleet state, and read metrics, events, and cost.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Published as `@noraai/mcp-server` and in the official MCP Registry
- [x] **Active Development**: Actively maintained; latest Nora release is v1.16.4
- [x] **Docker Artifact**: Non-root image at `mcp-server/Dockerfile`
- [x] **Documentation**: `mcp-server/README.md` includes npx, client JSON, and Docker setup
- [x] **Security Contact**: GitHub private vulnerability reporting is documented in `SECURITY.md`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I tested the MCP Server using the registry validator (`task validate -- --name nora` equivalent).
- [x] I built and inspected the MCP Server using the registry build helper (`task build -- --tools nora` equivalent): 15 tools discovered.
- [ ] Test credentials shared. MCP initialization and tool discovery work with placeholder configuration and do not call the Nora API; functional tool calls require a reviewer-accessible Nora deployment and can be arranged if needed.

## Verification

- Source pinned to `e1c497ca49a123faa90054e816c9ad11f76f0048`.
- Registry validator passed name, directory, title, YAML, commit pin, secrets, config env, license, icon, remote, and OAuth checks.
- Registry build helper built `mcp/nora` from the pinned Git context and discovered 15 tools.
- The container runs as the non-root `node` user. Destructive deletion remains disabled unless a user explicitly opts in; this catalog entry does not enable it.
- Nora local CI passed before the source commit was pushed.