### PR TITLE
Add Selvedge

### DIFF
--- a/servers/selvedge/server.yaml
+++ b/servers/selvedge/server.yaml
@@ -1,0 +1,23 @@
+name: selvedge
+type: server
+longLived: true
+meta:
+  category: devops
+  tags:
+    - selvedge
+    - devops
+    - version-control
+    - change-tracking
+    - code-history
+    - provenance
+    - ai
+    - agent-trace
+    - sqlite
+    - claude-code
+about:
+  title: Selvedge
+  description: Captures why AI agents change code — live, entity-level history with reasoning; exports Agent Trace v0.1.0.
+  icon: https://raw.githubusercontent.com/masondelan/selvedge/main/docs/icon.png
+source:
+  project: https://github.com/masondelan/selvedge
+  commit: c8e1a6ce0a82cab0eba7ff4d707ad16f850d8a47

--- a/servers/selvedge/server.yaml
+++ b/servers/selvedge/server.yaml
@@ -20,4 +20,4 @@ about:
   icon: https://raw.githubusercontent.com/masondelan/selvedge/main/docs/icon.png
 source:
   project: https://github.com/masondelan/selvedge
-  commit: 6569269cc7d35c555dff92686ade187f17d46b27
+  commit: 3bc7227664138992281a6e29f03ff3e72233a208

--- a/servers/selvedge/server.yaml
+++ b/servers/selvedge/server.yaml
@@ -16,8 +16,8 @@ meta:
     - claude-code
 about:
   title: Selvedge
-  description: Captures why AI agents change code — live, entity-level history with reasoning; exports Agent Trace v0.1.0.
+  description: Decision provenance for AI-coded codebases: know what your agents already tried and rejected. Captures the why behind every change as an append-only, queryable audit trail — a git blame for decisions, with no LLM in the path.
   icon: https://raw.githubusercontent.com/masondelan/selvedge/main/docs/icon.png
 source:
   project: https://github.com/masondelan/selvedge
-  commit: c8e1a6ce0a82cab0eba7ff4d707ad16f850d8a47
+  commit: 6569269cc7d35c555dff92686ade187f17d46b27


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Selvedge
**Repository URL:** https://github.com/masondelan/selvedge
**Brief Description:** Decision provenance for AI-coded codebases: the why, and what was already tried and rejected. A `git blame` for decisions — captured live by the agent as the change happens, not inferred from the diff afterward.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (MIT)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile at the repo root; `server.yaml` pins the commit
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: SECURITY.md in the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

On the two unchecked boxes: I drafted this on a machine without Docker, so I'm leaning on CI for validate/build. Happy to fix anything it flags. No credentials needed — the server runs fully local.

Adding **Selvedge** to the catalog. Selvedge is decision provenance for AI-coded codebases. AI coding agents (Claude Code, Cursor, Copilot) call its MCP tools as they work to log structured change events with reasoning to a local SQLite database, captured live by the agent in the same context that produced the change — not inferred from the diff afterward. As of the current release (**v0.3.11**) it also records explicit `reject`/`revert`/`supersede` verdicts — so the trail reads tried → reverted → re-opened — and emits **Agent Trace v0.1.0** (`selvedge export --format agent-trace`).

- **8 MCP tools:** `log_change`, `prior_attempts`, `blame`, `diff`, `history`, `changeset`, `search`, `stale_decisions`
- **Local-first:** SQLite under `.selvedge/`; the server makes no network calls
- **MIT**, Python 3.10+, on PyPI (`pip install selvedge`) and the Official MCP Registry (`io.github.masondelan/selvedge`)
- Website: https://selvedge.sh · Repo: https://github.com/masondelan/selvedge

Submitted as a local (containerized) server via Option A — no `image:` provided, so Docker builds and signs `mcp/selvedge` from the Dockerfile in the source repo. Category: `devops` (matches the `git` reference server). Happy to adjust category, tags, or description.
