### PR TITLE
Add patch-tuesday MCP server

### DIFF
--- a/servers/patch-tuesday/server.yaml
+++ b/servers/patch-tuesday/server.yaml
@@ -1,0 +1,41 @@
+name: patch-tuesday
+image: mcp/patch-tuesday
+type: server
+meta:
+  category: search
+  tags:
+    - security
+    - patch-tuesday
+    - msrc
+    - cve
+    - vulnerability-management
+    - microsoft
+    - windows
+    - epss
+    - cisa-kev
+about:
+  title: Patch Tuesday
+  description: |
+    Query Microsoft Patch Tuesday security updates from the official MSRC Security Update Guide API, enriched with FIRST.org EPSS exploitation-probability scores and the CISA KEV (Known Exploited Vulnerabilities) catalog. No API keys or accounts required — all three data sources are public.
+
+    A single consolidated tool, msrc_search, models the monthly release itself:
+    • Monthly rollups and stats ("summarize this month's Patch Tuesday")
+    • CVE lookups with KBs, affected products, parsed CVSS, and reference links
+    • KB-to-CVE mapping, batched KB lookups, and supersedence chain walking
+    • Product/family filtering and named product watchlists
+    • Urgency-ranked results: CISA KEV/exploited first, then EPSS, severity, CVSS
+    • Filters for exploited, publicly disclosed, ransomware-linked, EPSS/CVSS thresholds, CWE class, and CVSS exposure fields
+    • Markdown/CSV triage briefing exports and historical trend searches
+
+    Built for security analysts, sysadmins, and IT professionals who triage Microsoft security updates every month.
+  icon: https://avatars.githubusercontent.com/u/18173142?v=4
+source:
+  project: https://github.com/jonnybottles/patch-tuesday-mcp
+  branch: main
+  commit: e9edc377ecd2425040c888bb1515893f21e7ebaa
+config:
+  description: Runs over stdio for the MCP Gateway (overrides the image's HTTP-serving default)
+  env:
+    - name: MCP_TRANSPORT
+      example: stdio
+      value: stdio

--- a/servers/patch-tuesday/server.yaml
+++ b/servers/patch-tuesday/server.yaml
@@ -32,7 +32,7 @@ about:
 source:
   project: https://github.com/jonnybottles/patch-tuesday-mcp
   branch: main
-  commit: e9edc377ecd2425040c888bb1515893f21e7ebaa
+  commit: 290c1a72caad84572d2b4d2f9d10e8cd165378c1
 config:
   description: Runs over stdio for the MCP Gateway (overrides the image's HTTP-serving default)
   env:


### PR DESCRIPTION
Adds **patch-tuesday** ([jonnybottles/patch-tuesday-mcp](https://github.com/jonnybottles/patch-tuesday-mcp)) — Microsoft Patch Tuesday triage from the official MSRC Security Update Guide API, enriched with FIRST.org EPSS scores and the CISA KEV catalog.

**Checklist**
- MIT licensed
- Dockerfile at repo root (multi-stage, digest-pinned `python:3.14-slim`, non-root user, HEALTHCHECK)
- No API keys or secrets required — MSRC/EPSS/KEV are public feeds; no config parameters needed
- Single consolidated tool (`msrc_search`) — monthly rollups, CVE/KB lookups, supersedence chains, product watchlists, urgency-ranked triage
- `config.env` pins `MCP_TRANSPORT=stdio` (the image's default env serves streamable HTTP for remote hosting; stdio is the correct mode under the MCP Gateway)
- Source pinned to current main commit `e9edc37`
- Also listed in the official MCP Registry as `io.github.jonnybottles/patch-tuesday` and on Glama (tool quality score A, 4.8/5.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)