### PR TITLE
Add JobsPipe remote MCP server

### DIFF
--- a/servers/jobspipe/readme.md
+++ b/servers/jobspipe/readme.md
@@ -1,0 +1,1 @@
+Docs: https://jobspipe.dev/docs

--- a/servers/jobspipe/server.yaml
+++ b/servers/jobspipe/server.yaml
@@ -1,0 +1,23 @@
+name: jobspipe
+type: remote
+meta:
+  category: search
+  tags:
+    - search
+    - jobs
+    - data
+    - remote
+about:
+  title: JobsPipe
+  description: Live job postings for AI agents - search normalized postings from 30+ ATS feeds and job boards by title, skill, country, remote, seniority and recency.
+  icon: https://jobspipe.dev/icon.png
+remote:
+  transport_type: streamable-http
+  url: https://jobspipe.dev/mcp
+  headers:
+    Authorization: "Bearer ${JOBSPIPE_API_KEY}"
+config:
+  secrets:
+    - name: jobspipe.api_key
+      env: JOBSPIPE_API_KEY
+      example: <YOUR_API_KEY>

--- a/servers/jobspipe/tools.json
+++ b/servers/jobspipe/tools.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "search_jobs",
+    "description": "Search live, normalized job postings across 30+ sources by title, skill/tech, country, remote, seniority, employment type and recency.",
+    "arguments": []
+  },
+  {
+    "name": "list_job_sources",
+    "description": "List the ATS and job-board sources JobsPipe normalizes into a single JSON schema, with coverage and freshness notes.",
+    "arguments": []
+  },
+  {
+    "name": "list_pricing_plans",
+    "description": "List JobsPipe pricing plans with monthly price in USD, request quota and included features.",
+    "arguments": []
+  },
+  {
+    "name": "search_upwork_jobs",
+    "description": "Search live Upwork postings ingested by JobsPipe with budget, skills and client signals.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
Adds JobsPipe, a hosted remote MCP server (streamable HTTP) for searching live job postings across 30+ ATS feeds and job boards, normalized to one schema.

- Endpoint: https://jobspipe.dev/mcp
- Server card: https://jobspipe.dev/.well-known/mcp/server-card.json
- Docs: https://jobspipe.dev/docs
- First-party implementation; same submission shape as my earlier AgenticEmail PR (#4249).

🤖 Generated with [Claude Code](https://claude.com/claude-code)