### PR TITLE
Add wet-mcp

### DIFF
--- a/servers/wet-mcp/server.yaml
+++ b/servers/wet-mcp/server.yaml
@@ -1,0 +1,16 @@
+name: wet-mcp
+image: mcp/wet-mcp
+type: server
+meta:
+  category: search
+  tags:
+    - search
+    - web
+    - documentation
+about:
+  title: Web Extended Toolkit (wet)
+  description: Web search, content extraction, and library documentation indexing with hybrid search (full-text + semantic). Embedded search backend and local embeddings; no API keys required.
+  icon: https://avatars.githubusercontent.com/u/135627235?v=4
+source:
+  project: https://github.com/n24q02m/wet-mcp
+  commit: 2a5dad4c8afc37cefc8b27a351c0fdedaa192ee9

--- a/servers/wet-mcp/server.yaml
+++ b/servers/wet-mcp/server.yaml
@@ -13,4 +13,4 @@ about:
   icon: https://avatars.githubusercontent.com/u/135627235?v=4
 source:
   project: https://github.com/n24q02m/wet-mcp
-  commit: 2a5dad4c8afc37cefc8b27a351c0fdedaa192ee9
+  commit: ab12733b40b508204a726ea325226609426faf26


### PR DESCRIPTION
## MCP Server Information

**Server Name:** wet-mcp
**Repository URL:** https://github.com/n24q02m/wet-mcp
**Brief Description:** Web search, content extraction, and library documentation indexing with hybrid (full-text + semantic) search. Embedded search backend and local embeddings; no API keys required.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements the MCP specification (stdio + streamable-http transports)
- [x] **Active Development**: Actively maintained with recent commits
- [x] **Docker Artifact**: `Dockerfile` present at repository root
- [x] **Documentation**: README with setup instructions
- [x] **Security Contact**: `SECURITY.md` in the repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have validated the entry with the repository validator (`cmd/validate --name wet-mcp` — all checks pass)
- [ ] I have built the MCP Server using `task build -- --tools wet-mcp`
- [x] No credentials are required to run this server.

> The image build step (`task build --tools`) was not run in the submission environment (no Docker daemon available); it should be covered by maintainer CI. `server.yaml` passes the repository's `cmd/validate` checks (name, directory, title, YAML formatting, pinned commit, secrets, config env, license, icon).
