### PR TITLE
Add better-email-mcp

### DIFF
--- a/servers/better-email-mcp/server.yaml
+++ b/servers/better-email-mcp/server.yaml
@@ -1,0 +1,22 @@
+name: better-email-mcp
+image: mcp/better-email-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - email
+    - imap
+    - smtp
+about:
+  title: Better Email
+  description: IMAP/SMTP email MCP server using App Passwords (no OAuth2). Auto-discovers Gmail, Outlook, Yahoo, and iCloud. Composite tools for search, read, send, reply, and forward with multi-account support.
+  icon: https://avatars.githubusercontent.com/u/135627235?v=4
+source:
+  project: https://github.com/n24q02m/better-email-mcp
+  commit: 901f3fe21fe303b1f49acdf3179e6c787c0efae3
+config:
+  description: Configure email account credentials as a JSON array of account objects
+  secrets:
+    - name: better-email-mcp.email_credentials
+      env: EMAIL_CREDENTIALS
+      example: '[{"email":"you@gmail.com","password":"app-password"}]'


### PR DESCRIPTION
## MCP Server Information

**Server Name:** better-email-mcp
**Repository URL:** https://github.com/n24q02m/better-email-mcp
**Brief Description:** IMAP/SMTP email MCP server using App Passwords (no OAuth2), multi-account support, and auto-discovery of Gmail/Outlook/Yahoo/iCloud.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements the MCP specification (stdio + streamable-http transports)
- [x] **Active Development**: Actively maintained with recent commits
- [x] **Docker Artifact**: `Dockerfile` present at repository root
- [x] **Documentation**: README with setup instructions
- [x] **Security Contact**: `SECURITY.md` in the repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have validated the entry with the repository validator (`cmd/validate --name better-email-mcp` — all checks pass)
- [ ] I have built the MCP Server using `task build -- --tools better-email-mcp`
- [ ] If the server requires credentials to test it, I have shared test credentials using the form

> **Note on credentials:** this server needs EMAIL_CREDENTIALS (JSON array of IMAP/SMTP account credentials) to exercise its tools. Test credentials will be shared by the maintainer via the [Docker test-credentials form](https://forms.gle/6Lw3nsvu2d6nFg8e6). `tools/list` works without credentials, so automated tool discovery is unaffected.

> The image build step (`task build --tools`) was not run in the submission environment (no Docker daemon available); it should be covered by maintainer CI. `server.yaml` passes the repository's `cmd/validate` checks (name, directory, title, YAML formatting, pinned commit, secrets, config env, license, icon).
