### PR TITLE
Add better-telegram-mcp

### DIFF
--- a/servers/better-telegram-mcp/server.yaml
+++ b/servers/better-telegram-mcp/server.yaml
@@ -1,0 +1,21 @@
+name: better-telegram-mcp
+image: mcp/better-telegram-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - telegram
+    - messaging
+about:
+  title: Better Telegram
+  description: Telegram for AI agents across both bot (Bot API) and full user-account (MTProto) modes. Domain-separated composite tools for messages, chats, media, and contacts with multi-account support.
+  icon: https://avatars.githubusercontent.com/u/135627235?v=4
+source:
+  project: https://github.com/n24q02m/better-telegram-mcp
+  commit: 4505561c56cbb34c0d0b317dd84a0867ce5b63d9
+config:
+  description: Configure Telegram credentials. Bot mode uses a bot token; user mode uses API ID, API hash, and phone number.
+  secrets:
+    - name: better-telegram-mcp.bot_token
+      env: TELEGRAM_BOT_TOKEN
+      example: "123456789:AA-your-bot-token"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** better-telegram-mcp
**Repository URL:** https://github.com/n24q02m/better-telegram-mcp
**Brief Description:** Telegram for AI agents across both bot (Bot API) and full user-account (MTProto) modes, with domain-separated composite tools and multi-account support.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements the MCP specification (stdio + streamable-http transports)
- [x] **Active Development**: Actively maintained with recent commits
- [x] **Docker Artifact**: `Dockerfile` present at repository root
- [x] **Documentation**: README with setup instructions
- [x] **Security Contact**: `SECURITY.md` in the repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have validated the entry with the repository validator (`cmd/validate --name better-telegram-mcp` — all checks pass)
- [ ] I have built the MCP Server using `task build -- --tools better-telegram-mcp`
- [ ] If the server requires credentials to test it, I have shared test credentials using the form

> **Note on credentials:** this server needs TELEGRAM_BOT_TOKEN (bot mode) or TELEGRAM_API_ID/API_HASH/PHONE (user mode) to exercise its tools. Test credentials will be shared by the maintainer via the [Docker test-credentials form](https://forms.gle/6Lw3nsvu2d6nFg8e6). `tools/list` works without credentials, so automated tool discovery is unaffected.

> The image build step (`task build --tools`) was not run in the submission environment (no Docker daemon available); it should be covered by maintainer CI. `server.yaml` passes the repository's `cmd/validate` checks (name, directory, title, YAML formatting, pinned commit, secrets, config env, license, icon).
