### PR TITLE
Add Klaket MCP server

### DIFF
--- a/servers/klaket/server.yaml
+++ b/servers/klaket/server.yaml
@@ -1,0 +1,34 @@
+name: klaket
+image: mcp/klaket
+type: server
+meta:
+  category: ai
+  tags:
+    - video
+    - transcription
+    - klaket
+about:
+  title: Klaket
+  description: Let AI agents watch videos — word-timestamped transcripts, speaker labels, scenes, chapters and exact-moment search from any video URL or file, fully local.
+  icon: https://raw.githubusercontent.com/huseyinstif/klaket/main/assets/logo.png
+source:
+  project: https://github.com/huseyinstif/klaket
+  branch: main
+  commit: 43287c058ba33576ca4399632051f963bd1fc64b
+  directory: apps/mcp
+config:
+  description: Configure the connection to your Klaket API (self-hosted via docker compose in the source repo)
+  secrets:
+    - name: klaket.api_key
+      env: KLAKET_API_KEY
+      example: <YOUR_API_KEY>
+      required: false
+  env:
+    - name: KLAKET_API_URL
+      example: http://host.docker.internal:8484
+      value: '{{klaket.api_url}}'
+  parameters:
+    type: object
+    properties:
+      api_url:
+        type: string


### PR DESCRIPTION
Adds **Klaket** — an MCP server that lets AI agents watch videos: word-timestamped transcripts (~100 languages, faster-whisper), speaker labels, scene detection with keyframes, on-screen text (OCR), chapters and exact-moment search from any video URL or file. Fully local, no API keys required.

- **Source:** https://github.com/huseyinstif/klaket (monorepo — server in `apps/mcp`, MIT licensed, Dockerfile included; MCP handshake verified inside the container)
- **npm:** [klaket-mcp](https://www.npmjs.com/package/klaket-mcp) · listed in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=klaket) as `io.github.huseyinstif/klaket-mcp`
- **Config:** zero-config by default; `KLAKET_API_URL` optional (Docker users point it at `http://host.docker.internal:8484` where the self-hosted Klaket API runs), `KLAKET_API_KEY` optional secret for authenticated deployments
- Tools list without any configuration (4 tools: klaket_ingest, klaket_job_status, klaket_get_result, klaket_find_moment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)