### PR TITLE
Add iLoveVideoEditor MCP server

### DIFF
--- a/servers/ilovevideoeditor/server.yaml
+++ b/servers/ilovevideoeditor/server.yaml
@@ -1,0 +1,29 @@
+name: ilovevideoeditor
+image: mcp/ilovevideoeditor
+type: server
+meta:
+  category: video
+  tags:
+    - video
+    - rendering
+    - motion-design
+    - ai-agents
+about:
+  title: iLoveVideoEditor
+  description: Render videos from JSON via the iLoveVideoEditor cloud API — motion-design templates, GPU effects, transitions, batch rendering, webhooks.
+  icon: https://avatars.githubusercontent.com/u/68660753?s=200&v=4
+source:
+  project: https://github.com/ilovevideoeditor/mcp-server
+  branch: main
+  commit: ef5e4b0dfc7329f9fe7842c4e87a47c0ac807537
+  directory: .
+run:
+  allowHosts:
+    - api.ilovevideoeditor.com:443
+config:
+  description: Configure the connection to iLoveVideoEditor
+  secrets:
+    - name: ilovevideoeditor.api_key
+      env: VF_API_KEY
+      example: <YOUR_ILOVEVIDEOEDITOR_API_KEY>
+      description: You can generate an API key at https://ilovevideoeditor.com/dashboard/account/api


### PR DESCRIPTION
Adds the iLoveVideoEditor MCP server to the Docker MCP Catalog.\n\n- Renders videos from JSON via the iLoveVideoEditor cloud API: motion-design templates, GPU effects, transitions, batch rendering, webhooks.\n- Containerized MCP server built from https://github.com/ilovevideoeditor/mcp-server (Dockerfile on main, pinned commit ef5e4b0).\n- Transport: stdio; only external host is api.ilovevideoeditor.com.\n- Requires VF_API_KEY (generate at https://ilovevideoeditor.com/dashboard/account/api).\n\nI am happy to share test credentials via the Docker review form if needed.