### PR TITLE
Add Opedd MCP server

### DIFF
--- a/servers/opedd/server.yaml
+++ b/servers/opedd/server.yaml
@@ -1,0 +1,20 @@
+name: opedd
+image: mcp/opedd
+type: server
+meta:
+  category: ai
+  tags:
+    - content
+    - licensing
+    - rag
+    - compliance
+    - publishing
+    - search
+about:
+  title: Opedd
+  description: Licensed, rights-cleared content for AI agents. 17 tools to discover, license, retrieve, and verify expert publisher content — every article carries a verifiable license key, on-chain proof, and EU AI Act Article 53 attestation support. Discovery and verification tools work with no configuration; purchasing and content retrieval use optional Opedd API keys.
+  icon: https://raw.githubusercontent.com/Opedd/opedd-mcp/main/assets/opedd-icon-512.png
+source:
+  project: https://github.com/Opedd/opedd-mcp
+  branch: main
+  commit: 090305005269a8975c732613ff927f1c03774f6b


### PR DESCRIPTION
Adds [Opedd](https://github.com/Opedd/opedd-mcp) — licensed, rights-cleared content for AI agents.

- **What it does**: 17 tools to discover, license, retrieve, and verify expert publisher content. Every article carries a verifiable license key, on-chain proof, and EU AI Act Article 53 attestation support — a licensed alternative to scraping for RAG/agent pipelines.
- **License**: MIT
- **Dockerfile**: at repo root (multi-stage, node:20-alpine, stdio transport) — already used for Smithery/Glama deployments
- **No credentials needed to test**: discovery + verification tools (lookup_content, publisher_directory, verify_license, browse_registry, detect_platform, rsl_get, and more) work unauthenticated out of the box. Purchasing/content retrieval use optional Opedd API keys.
- **Also available hosted** (streamable-http) at mcp.opedd.com/mcp; this entry is the containerized local server.
- Listed on the official MCP Registry as `com.opedd/opedd-mcp` (npm `opedd-mcp`, 51-test CI).