### PR TITLE
Add GetABrain MCP server

### DIFF
--- a/servers/getabrain/readme.md
+++ b/servers/getabrain/readme.md
@@ -1,0 +1,4 @@
+GetABrain is a human-in-the-loop API that lets AI agents collect real human feedback, ratings, and judgment.
+
+Docs: https://www.getabrain.ai/mcp
+llms.txt: https://www.getabrain.ai/llms.txt

--- a/servers/getabrain/server.yaml
+++ b/servers/getabrain/server.yaml
@@ -1,0 +1,26 @@
+name: getabrain
+image: mcp/getabrain
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - human-in-the-loop
+    - data-collection
+about:
+  title: GetABrain
+  description: Get real human feedback, ratings, and judgment for AI applications via a human-in-the-loop API. Supports 16 structured query types (yes/no, rating, ranking, A/B test, sentiment, image comparison, free text, voice/video/photo capture, and more). Ships with a free test mode that returns synthetic responses at zero cost so integrations can be built before adding funds.
+  icon: https://www.google.com/s2/favicons?domain=getabrain.ai&sz=64
+source:
+  project: https://github.com/Guitarmaniac24/getabrain-mcp-server
+  branch: main
+  commit: cc644b86393c0a15f0a1250063e758f777b003f3
+config:
+  description: Configure GetABrain API credentials
+  secrets:
+    - name: getabrain.api_key
+      env: GETABRAIN_API_KEY
+      example: gab_k_xxxxxxxxxxxxxxxx
+    - name: getabrain.api_secret
+      env: GETABRAIN_API_SECRET
+      example: gab_s_xxxxxxxxxxxxxxxx

--- a/servers/getabrain/tools.json
+++ b/servers/getabrain/tools.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "submit_query",
+    "description": "Submit a query to real humans for a response",
+    "arguments": []
+  },
+  {
+    "name": "get_responses",
+    "description": "Retrieve responses collected for a query",
+    "arguments": []
+  },
+  {
+    "name": "get_query",
+    "description": "Get the status and details of a submitted query",
+    "arguments": []
+  },
+  {
+    "name": "list_queries",
+    "description": "List queries submitted by the requestor",
+    "arguments": []
+  },
+  {
+    "name": "cancel_query",
+    "description": "Cancel a pending query",
+    "arguments": []
+  },
+  {
+    "name": "get_balance",
+    "description": "Check the current account balance",
+    "arguments": []
+  },
+  {
+    "name": "create_topup_link",
+    "description": "Create a hosted link to add funds to the account",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** GetABrain
**Repository URL:** https://github.com/Guitarmaniac24/getabrain-mcp-server
**Brief Description:** Human-in-the-loop API letting AI agents get real human feedback, ratings, and judgment — 16 structured query types (yes/no, rating, ranking, A/B test, sentiment, image comparison, free text, voice/video/photo capture). Free test mode returns synthetic responses at zero cost.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (uses `@modelcontextprotocol/sdk`)
- [x] **Active Development**: Recent commits, published npm package `@getabrain/mcp-server` v0.2.0
- [x] **Docker Artifact**: Dockerfile present in repo
- [x] **Documentation**: README with setup instructions at repo root
- [x] **Security Contact**: support@getabrain.ai / admin@getabrain.ai

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME` — not run locally (no Docker/Go toolchain available in this environment); requesting CI run this.
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME` — same as above.
- [ ] No test credentials shared — server requires an API key/secret pair (`GETABRAIN_API_KEY` / `GETABRAIN_API_SECRET`), free test-mode keys can be minted with no card via the site if reviewers need one.