### PR TITLE
Add Human For AI (remote MCP server)

### DIFF
--- a/servers/humanforai/readme.md
+++ b/servers/humanforai/readme.md
@@ -1,0 +1,12 @@
+# Human For AI (remote MCP server)
+
+Human For AI lets an AI agent hire one verified human operator for tasks that need
+physical presence, human perception, or human judgment: real-world verification,
+product and app testing, AI output review, data collection, and local physical-world
+errands. Free during the proof-of-concept pilot; no authentication; every task is
+reviewed by the human before acceptance.
+
+- Remote endpoint (streamable HTTP, no auth): https://humanforai.dev/mcp
+- Documentation: https://humanforai.dev/api and https://humanforai.dev/for-agents
+- Source (stdio proxy + server manifest): https://github.com/humanforai/humanforai-mcp
+- Official MCP registry name: `dev.humanforai/humanforai`

--- a/servers/humanforai/server.yaml
+++ b/servers/humanforai/server.yaml
@@ -1,0 +1,18 @@
+name: humanforai
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: productivity
+  tags:
+    - human-in-the-loop
+    - verification
+    - testing
+    - remote
+about:
+  title: Human For AI
+  description: Hire a real human for real-world verification, product testing, AI output review, and errands.
+  icon: https://humanforai.dev/icon.png
+remote:
+  transport_type: streamable-http
+  url: https://humanforai.dev/mcp

--- a/servers/humanforai/tools.json
+++ b/servers/humanforai/tools.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "get_human_services",
+    "description": "Fetch the Human For AI manifest: services, operator profile, response times, accepted and rejected task types, and trust policy",
+    "arguments": []
+  },
+  {
+    "name": "submit_human_task",
+    "description": "Submit a task for the human operator to perform in the real world; returns a task_id",
+    "arguments": []
+  },
+  {
+    "name": "check_task_status",
+    "description": "Look up a submitted task by its task_id: current status, history, and operator notes",
+    "arguments": []
+  },
+  {
+    "name": "message_human_operator",
+    "description": "Send a free-form message to the human operator for questions or scoping before submitting",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
Adds **Human For AI** as a remote MCP server entry (`servers/humanforai/`), following the `notion-remote` pattern.

- **Remote endpoint** (streamable HTTP, publicly accessible, **no authentication** — hence no `oauth` section): `https://humanforai.dev/mcp`
- **What it does**: lets AI agents hire a real human operator for tasks that need physical presence, human perception, or human judgment — real-world verification, product and app testing, AI output review, data collection, and local errands. Free during the proof-of-concept pilot; every task is human-reviewed before acceptance.
- **tools.json** snapshots the four tools currently exposed (`dynamic.tools: true` is set, matching the live server).
- Also listed in the official MCP registry as `dev.humanforai/humanforai`, plus Smithery and Glama. Docs: https://humanforai.dev/api · agent quick-start: https://humanforai.dev/for-agents · source: https://github.com/humanforai/humanforai-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)