### PR TITLE
Add kundlit-astro remote server

### DIFF
--- a/servers/kundlit-astro/readme.md
+++ b/servers/kundlit-astro/readme.md
@@ -1,0 +1,1 @@
+Docs: https://kundlit.com/mcp

--- a/servers/kundlit-astro/server.yaml
+++ b/servers/kundlit-astro/server.yaml
@@ -1,0 +1,16 @@
+name: kundlit-astro
+type: remote
+meta:
+  category: lifestyle
+  tags:
+    - astrology
+    - vedic-astrology
+    - panchang
+    - remote
+about:
+  title: Kundlit Vedic Astrology
+  description: "Free Vedic astrology tools: daily panchang for any city, janam kundali birth charts, kundli milan matching, manglik dosha and sade sati"
+  icon: https://kundlit.com/icon.png
+remote:
+  transport_type: streamable-http
+  url: https://kundlit.com/api/mcp


### PR DESCRIPTION
Adds **Kundlit Vedic Astrology** (kundlit-astro), a hosted remote MCP server.

- **Endpoint:** https://kundlit.com/api/mcp (streamable-http)
- **Auth:** none — anonymous compute, no user accounts, no OAuth needed
- **Docs:** https://kundlit.com/mcp (per-client setup, example prompts, limitations)
- **Tools (5, all read-only):** get_panchang, get_janam_kundali, match_kundli, check_manglik, get_sade_sati — deterministic Swiss Ephemeris computation (sidereal, Lahiri ayanamsa), free, rate-limited 30 req/min/IP
- All tools declare readOnlyHint: true, destructiveHint: false, openWorldHint: false
- Also published on the official MCP registry as com.kundlit/astro
- Privacy: https://kundlit.com/privacy · Support: support@kundlit.com

No test credentials needed — the server is public and unauthenticated; reviewers can connect and call tools immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsSTpfWPN3YfpMUuBvq5sE