### PR TITLE
Add mcpindex server

### DIFF
--- a/servers/mcpindex/readme.md
+++ b/servers/mcpindex/readme.md
@@ -1,0 +1,17 @@
+# mcpindex
+
+The directory client for [mcpindex.ai](https://mcpindex.ai). Find MCP servers by
+natural-language task, and get advisory trust screens for a server or tool before
+you connect. Advisory, not a safety verdict (the in-path gate is mcpindex-gate).
+
+## Tools
+- `recommend_mcp_for_task` - top MCP servers for a task, with reasoning + install commands.
+- `search_mcp_servers` - keyword + semantic search across the registry.
+- `get_install_command` - exact install command for a server + client.
+- `compare_servers` - side-by-side comparison of 2 to 5 servers.
+- `check_tool_trust` - advisory pre-invocation screen for a specific tool.
+- `assess_server` - aggregated advisory trust assessment for a whole server.
+
+Zero-config: it queries the public mcpindex.ai API; no credentials required.
+
+More: https://mcpindex.ai

--- a/servers/mcpindex/server.yaml
+++ b/servers/mcpindex/server.yaml
@@ -13,6 +13,5 @@ about:
   description: Find MCP servers by natural-language task, plus advisory trust screens before you connect. The directory client for mcpindex.ai.
   icon: https://www.google.com/s2/favicons?domain=mcpindex.ai&sz=64
 source:
-  project: https://github.com/mcpindex-ai/mcpindex-web
-  directory: mcp-server-mcpindex
-  commit: c621df4981ae59ecd5fffcebf02efb67a19db16d
+  project: https://github.com/mcpindex-ai/mcp-server-mcpindex
+  commit: 524ef58ca59e1f666c4b527dcee1b17c6f03a131

--- a/servers/mcpindex/server.yaml
+++ b/servers/mcpindex/server.yaml
@@ -1,0 +1,18 @@
+name: mcpindex
+image: mcp/mcpindex
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - mcp
+    - discovery
+    - security
+    - trust
+about:
+  title: Mcpindex
+  description: Find MCP servers by natural-language task, plus advisory trust screens before you connect. The directory client for mcpindex.ai.
+  icon: https://www.google.com/s2/favicons?domain=mcpindex.ai&sz=64
+source:
+  project: https://github.com/mcpindex-ai/mcpindex-web
+  directory: mcp-server-mcpindex
+  commit: c621df4981ae59ecd5fffcebf02efb67a19db16d

--- a/servers/mcpindex/tools.json
+++ b/servers/mcpindex/tools.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "recommend_mcp_for_task",
+    "description": "Recommend the best MCP servers for a natural-language task; returns top 3 ranked picks with reasoning, install commands, and quality scores."
+  },
+  {
+    "name": "search_mcp_servers",
+    "description": "Keyword + semantic search across the full MCP server registry."
+  },
+  {
+    "name": "get_install_command",
+    "description": "Get the exact install command for a given MCP server and client, ready to paste into the client config."
+  },
+  {
+    "name": "compare_servers",
+    "description": "Side-by-side comparison of 2 to 5 MCP servers: quality scores, install paths, transport types, env vars."
+  },
+  {
+    "name": "check_tool_trust",
+    "description": "Pre-invocation advisory screen for a specific tool on an MCP server; returns an advisory verdict (REVIEW or UNVERIFIED at v1). Not the in-path gate."
+  },
+  {
+    "name": "assess_server",
+    "description": "Aggregated pre-flight advisory trust assessment across all tools on an MCP server."
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcpindex
**Repository URL:** https://github.com/mcpindex-ai/mcpindex-web (directory: `mcp-server-mcpindex`)
**Brief Description:** Find MCP servers by natural-language task, plus advisory trust screens (`check_tool_trust`, `assess_server`) before you connect. The directory client for mcpindex.ai. Advisory, not a safety verdict.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: 6 tools; `task validate --name mcpindex` and `task build --tools mcpindex` both pass locally (image builds as `mcp/mcpindex`, `tools/list` returns all 6 tools)
- [x] **Active Development**: actively maintained (github.com/mcpindex-ai)
- [x] **Docker Artifact**: Dockerfile added at `mcp-server-mcpindex/Dockerfile` in the source repo, pinned by commit in server.yaml
- [x] **Documentation**: README in the entry + full docs at https://mcpindex.ai
- [x] **Security Contact**: https://github.com/mcpindex-ai/mcpindex-web/issues and hello@mcpindex.ai

Zero-config: it queries the public mcpindex.ai API, no credentials required.