### PR TITLE
Add flopsindex (remote MCP server)

### DIFF
--- a/servers/flopsindex/server.yaml
+++ b/servers/flopsindex/server.yaml
@@ -1,0 +1,18 @@
+name: flopsindex
+type: remote
+meta:
+  category: tools
+  tags:
+    - finance
+    - gpu
+    - pricing
+    - compute
+    - reference-rate
+    - remote
+about:
+  title: FLOPS Index
+  description: GPU compute price indices (spot, on-demand, DePIN) over MCP — catalog, search, price, and verify. Every published value carries a verify URL for citation. Source-opaque and key-free.
+  icon: https://github.com/zeroatflops.png
+remote:
+  transport_type: streamable-http
+  url: https://app.flopsindex.com/mcp


### PR DESCRIPTION
Adds **flopsindex** as a remote (hosted, streamable-http) MCP server at https://app.flopsindex.com/mcp — GPU compute price indices (spot, on-demand, DePIN) with catalog/search/price/verify tools. Key-free (no credentials required); every value carries a verify URL for citation. Already on the official MCP registry as io.github.zeroatflops/flopsindex-mcp.