### PR TITLE
Add Macfax remote MCP server

### DIFF
--- a/servers/macfax/readme.md
+++ b/servers/macfax/readme.md
@@ -1,0 +1,1 @@
+Docs: https://macfax.com/developers

--- a/servers/macfax/server.yaml
+++ b/servers/macfax/server.yaml
@@ -1,0 +1,20 @@
+name: macfax
+type: remote
+meta:
+  category: ecommerce
+  tags:
+    - ecommerce
+    - mac
+    - apple
+    - marketplace
+    - prices
+    - remote
+about:
+  title: Macfax
+  description: "Used-Mac market data: quality-gated live listings with deep links, asking-price statistics with a disclosed sold-price slice, per-listing trust checks, Mac serial lookup, verified condition reports, and email-confirmed listing alerts."
+  icon: https://raw.githubusercontent.com/macfax/macfax-mcp/main/assets/icon-400.png
+source:
+  project: https://github.com/macfax/macfax-mcp
+remote:
+  transport_type: streamable-http
+  url: https://macfax.com/mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** macfax
**Repository URL:** https://github.com/macfax/macfax-mcp
**Brief Description:** Used-Mac market data: quality-gated live listings with deep links, asking-price statistics with a disclosed sold-price slice, per-listing trust checks, Mac serial lookup, verified condition reports, and email-confirmed listing alerts.

## Remote Server Details

- Type: `remote`, transport `streamable-http`, endpoint: https://macfax.com/mcp
- Authless and stateless: no OAuth, no secrets, no configuration required. An optional free API key raises rate limits but is never required.
- Published in the official MCP registry as `com.macfax/macfax`
- Source: https://github.com/macfax/macfax-mcp (MIT)
- Docs: https://macfax.com/developers
- OpenAPI twin of the same data: https://macfax.com/api/v1/openapi.json
- Six tools: `search_mac_listings`, `get_mac_price_stats`, `check_mac_listing`, `lookup_mac_serial`, `get_mac_report`, `create_mac_alert`. The five read tools carry `readOnlyHint: true` annotations. `create_mac_alert` is the single write tool and is consent-gated: an API-created alert stays inactive until the recipient clicks an emailed confirmation link.
- No `tools.json` is included so tools are discovered by probing the endpoint, matching other authless remote entries (deepwiki, gitmcp, cloudflare-docs).

## Basic Requirements

- [x] **Open Source**: MIT (https://github.com/macfax/macfax-mcp/blob/main/LICENSE)
- [x] **MCP Compliant**: streamable HTTP transport; initialize and tools/list verified working against the live endpoint today
- [x] **Active Development**: maintained alongside macfax.com
- [ ] **Docker Artifact**: not applicable, this is a `type: remote` submission and remote servers do not require a Dockerfile per CONTRIBUTING.md
- [x] **Documentation**: README in the source repo plus https://macfax.com/developers
- [x] **Security Contact**: GitHub issues on https://github.com/macfax/macfax-mcp

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name macfax`. The `task` binary was unavailable locally, so I ran the identical underlying command `go run ./cmd/validate --name macfax`: all checks pass, and the live remote-tools probe reported "Remote tools are valid. Found 6 tools."
- [ ] `task build -- --tools macfax` is not applicable: remote server, no image to build
- [ ] Test credentials form is not applicable: the endpoint is authless and needs no credentials to test
