### PR TITLE
Add Lians agent memory server

### DIFF
--- a/servers/lians/server.yaml
+++ b/servers/lians/server.yaml
@@ -1,0 +1,21 @@
+name: lians
+image: ghcr.io/lians-ai/lians-mcp:0.4.1
+type: server
+meta:
+  category: ai
+  tags:
+    - memory
+    - agent-memory
+    - bitemporal
+    - point-in-time
+    - local-first
+about:
+  title: Lians Agent Memory
+  description: Local-first agent memory with bitemporal facts, point-in-time retrieval, supersession, and auditable history.
+  icon: https://www.google.com/s2/favicons?domain=lians.ai&sz=64
+source:
+  project: https://github.com/Lians-ai/Lians
+  commit: 04f55789cf4b2ed81abc75e4bb8e86765bc74d55
+run:
+  volumes:
+    - lians-data:/data

--- a/servers/lians/server.yaml
+++ b/servers/lians/server.yaml
@@ -1,5 +1,5 @@
 name: lians
-image: ghcr.io/lians-ai/lians-mcp:0.4.1
+image: ghcr.io/lians-ai/lians-mcp:0.5.0
 type: server
 meta:
   category: ai
@@ -15,7 +15,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=lians.ai&sz=64
 source:
   project: https://github.com/Lians-ai/Lians
-  commit: 04f55789cf4b2ed81abc75e4bb8e86765bc74d55
+  commit: 33aac778bad2ec28fa3b46bcbac0c671c32244e3
 run:
   volumes:
     - lians-data:/data


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Lians Agent Memory
**Repository URL:** https://github.com/Lians-ai/Lians
**Brief Description:** Local-first agent memory with bitemporal facts, point-in-time retrieval, supersession, and auditable history.

## What changed

Adds Lians to the Docker MCP Registry using the public, versioned, multi-architecture image at `ghcr.io/lians-ai/lians-mcp:0.4.1`.

The server runs over stdio, requires no credentials in its default local SQLite configuration, and persists state in a named volume mounted at `/data`.

## Why

Lians gives MCP clients a memory layer designed for facts that change over time. Its point-in-time retrieval and supersession model help agents distinguish current knowledge from historical knowledge while retaining an auditable record.

## Basic Requirements

- [x] **Open Source**: Apache-2.0 license
- [x] **MCP Compliant**: Implements MCP and exposes eight tools
- [x] **Active Development**: Current release and recent commits
- [x] **Docker Artifact**: Public GHCR image built from `Dockerfile.glama`
- [x] **Documentation**: README and deployment documentation are available
- [x] **Security Contact**: Security policy and `security@lians.dev`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using the registry validator
- [x] I have pulled and tested the MCP Server using the registry build command with tool discovery
- [x] The server does not require credentials in its default configuration

## Validation

- Ran the registry validator successfully. Name, directory, title, YAML formatting, commit pin, secrets, environment configuration, license, icon, remote configuration, and OAuth configuration all passed.
- Ran the registry build command with `--pull-community --tools lians`.
- Pulled the public OCI image by digest `sha256:359db582fd68d2974d58c9fffa433265358fbc6a563ed112686c44425e0dd8e0`.
- Confirmed the running image exposes 8 MCP tools.
- Ran `git diff --check`.
