### PR TITLE
Add Find MCP (remote server)

### DIFF
--- a/servers/find-mcp/readme.md
+++ b/servers/find-mcp/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/agentage/find-mcp

--- a/servers/find-mcp/server.yaml
+++ b/servers/find-mcp/server.yaml
@@ -1,0 +1,16 @@
+name: find-mcp
+type: remote
+meta:
+  category: search
+  tags:
+    - search
+    - discovery
+    - mcp
+    - registry
+about:
+  title: Find MCP
+  description: Search 17,000+ MCP servers from the official MCP registry - remote Streamable HTTP (catalog.agentage.io/mcp, no auth for search) or stdio (npx @agentage/find-mcp).
+  icon: https://github.com/agentage.png
+remote:
+  transport_type: streamable-http
+  url: https://catalog.agentage.io/mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Find MCP
**Repository URL:** https://github.com/agentage/find-mcp
**Brief Description:** MCP server for discovering other MCP servers. Searches the agentage MCP Catalog (17,000+ servers synced from the official MCP registry, registry.modelcontextprotocol.io). Tools: `mcp_search`, `mcp_get`, `mcp_categories`.

Adds `servers/find-mcp/server.yaml` as a **remote** server (no Docker image needed, hosted at `https://catalog.agentage.io/mcp`, streamable-http, no auth required for search) plus `servers/find-mcp/readme.md`, following the precedent set by `servers/remote-mcp` and `servers/cloudflare-docs`.

- Official registry entry: `io.agentage/find-mcp`
- npm: `@agentage/find-mcp` (stdio alternative: `npx -y @agentage/find-mcp`)
- Web UI: https://catalog.agentage.io/mcp

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (Streamable HTTP)
- [x] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: N/A - this is a remote server (hosted, no Dockerfile per remote-server convention)
- [x] **Documentation**: Basic README and setup instructions
- [ ] **Security Contact**: No dedicated SECURITY.md yet; issues reported via GitHub Issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above (remote-server exceptions noted)
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME` - N/A for remote servers per CONTRIBUTING.md remote-server flow (CI validates)
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME` - N/A, no Docker image for remote servers
- [ ] If the server requires credentials to test it - N/A, no auth required for search

Disclosure: I maintain Find MCP.
