### PR TITLE
Add seo-tools-mcp: 5 read-only SEO servers (Google/Yandex, RU/CIS)

### DIFF
--- a/servers/seo-tools-mcp-aparser/server.yaml
+++ b/servers/seo-tools-mcp-aparser/server.yaml
@@ -19,7 +19,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/aparser/Dockerfile
 config:
   description: A-Parser instance API URL and password (A-Parser Settings -> API).

--- a/servers/seo-tools-mcp-aparser/server.yaml
+++ b/servers/seo-tools-mcp-aparser/server.yaml
@@ -19,7 +19,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/aparser/Dockerfile
 config:
   description: A-Parser instance API URL and password (A-Parser Settings -> API).

--- a/servers/seo-tools-mcp-aparser/server.yaml
+++ b/servers/seo-tools-mcp-aparser/server.yaml
@@ -19,7 +19,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/aparser/Dockerfile
 config:
   description: A-Parser instance API URL and password (A-Parser Settings -> API).

--- a/servers/seo-tools-mcp-aparser/server.yaml
+++ b/servers/seo-tools-mcp-aparser/server.yaml
@@ -19,7 +19,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/aparser/Dockerfile
 config:
   description: A-Parser instance API URL and password (A-Parser Settings -> API).

--- a/servers/seo-tools-mcp-aparser/server.yaml
+++ b/servers/seo-tools-mcp-aparser/server.yaml
@@ -1,0 +1,41 @@
+name: seo-tools-mcp-aparser
+image: mcp/seo-tools-mcp-aparser
+type: server
+meta:
+  category: search
+  tags:
+    - seo
+    - serp
+    - a-parser
+    - scraper
+    - google
+    - yandex
+about:
+  title: "SEO Tools: A-Parser bridge"
+  description:
+    "Bridge to a self-hosted A-Parser instance via its HTTP API: Google/Yandex SERP, search
+    suggestions and 150+ built-in parsers. Read-only."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  dockerfile: servers/aparser/Dockerfile
+config:
+  description: A-Parser instance API URL and password (A-Parser Settings -> API).
+  secrets:
+    - name: seo-tools-mcp-aparser.password
+      env: APARSER_PASSWORD
+      example: <APARSER_PASSWORD>
+  env:
+    - name: APARSER_URL
+      example: "http://IP:9091/API"
+      value: "{{seo-tools-mcp-aparser.url}}"
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        description: A-Parser API endpoint, e.g. http://IP:9091/API.
+    required:
+      - url

--- a/servers/seo-tools-mcp-ga4/server.yaml
+++ b/servers/seo-tools-mcp-ga4/server.yaml
@@ -17,7 +17,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/ga4/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-ga4/server.yaml
+++ b/servers/seo-tools-mcp-ga4/server.yaml
@@ -1,0 +1,50 @@
+name: seo-tools-mcp-ga4
+image: mcp/seo-tools-mcp-ga4
+type: server
+meta:
+  category: analytics
+  tags:
+    - seo
+    - analytics
+    - google-analytics
+    - ga4
+about:
+  title: "SEO Tools: Google Analytics 4"
+  description:
+    "Read-only Google Analytics 4 via the Data API: arbitrary reports, traffic sources, geo,
+    devices, landing pages, events and realtime."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  dockerfile: servers/ga4/Dockerfile
+config:
+  description:
+    Google OAuth credentials for Google Analytics (the ga4_oauth_start / ga4_oauth_finish tools
+    obtain the refresh token; a service-account JSON key works as an alternative).
+  secrets:
+    - name: seo-tools-mcp-ga4.client_secret
+      env: GOOGLE_CLIENT_SECRET
+      example: <GOOGLE_CLIENT_SECRET>
+    - name: seo-tools-mcp-ga4.refresh_token
+      env: GA4_REFRESH_TOKEN
+      example: <GA4_REFRESH_TOKEN>
+  env:
+    - name: GOOGLE_CLIENT_ID
+      example: "1234567890-abc.apps.googleusercontent.com"
+      value: "{{seo-tools-mcp-ga4.client_id}}"
+    - name: GA4_PROPERTY_ID
+      example: "123456789"
+      value: "{{seo-tools-mcp-ga4.property_id}}"
+  parameters:
+    type: object
+    properties:
+      client_id:
+        type: string
+        description: Google OAuth client ID (Desktop app).
+      property_id:
+        type: string
+        description: Default GA4 property id (numeric, not the G-XXXXXXX Measurement ID).
+    required:
+      - client_id

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -1,0 +1,51 @@
+name: seo-tools-mcp-gsc
+image: mcp/seo-tools-mcp-gsc
+type: server
+meta:
+  category: analytics
+  tags:
+    - seo
+    - google-search-console
+    - gsc
+    - analytics
+    - search
+about:
+  title: "SEO Tools: Google Search Console"
+  description:
+    "Read-only Google Search Console: Search Analytics (clicks, impressions, CTR, position),
+    URL Inspection (index status) and sitemaps. OAuth refresh token or service account."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  dockerfile: servers/gsc/Dockerfile
+config:
+  description:
+    Google OAuth credentials for Search Console (read-only scope). Obtain a refresh token once
+    via the interactive gsc_oauth flow (run locally), then provide it here.
+  secrets:
+    - name: seo-tools-mcp-gsc.client_secret
+      env: GOOGLE_CLIENT_SECRET
+      example: <GOOGLE_CLIENT_SECRET>
+    - name: seo-tools-mcp-gsc.refresh_token
+      env: GSC_REFRESH_TOKEN
+      example: <GSC_REFRESH_TOKEN>
+  env:
+    - name: GOOGLE_CLIENT_ID
+      example: xxxxx.apps.googleusercontent.com
+      value: "{{seo-tools-mcp-gsc.client_id}}"
+    - name: GSC_SITE_URL
+      example: sc-domain:example.com
+      value: "{{seo-tools-mcp-gsc.site_url}}"
+  parameters:
+    type: object
+    properties:
+      client_id:
+        type: string
+        description: Google OAuth client ID (Desktop app).
+      site_url:
+        type: string
+        description: Default GSC property, e.g. sc-domain:example.com (optional).
+    required:
+      - client_id

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  commit: c5358908fdd7d746e429c56f45a441203a8275a8
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 28068f64d560917be7d03724078b267ba64e8d02
+  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  commit: 28068f64d560917be7d03724078b267ba64e8d02
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: c5358908fdd7d746e429c56f45a441203a8275a8
+  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-gsc/server.yaml
+++ b/servers/seo-tools-mcp-gsc/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/gsc/Dockerfile
 config:
   description:

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -1,0 +1,38 @@
+name: seo-tools-mcp-metrika
+image: mcp/seo-tools-mcp-metrika
+type: server
+meta:
+  category: analytics
+  tags:
+    - seo
+    - yandex
+    - metrica
+    - analytics
+    - web-analytics
+about:
+  title: "SEO Tools: Yandex.Metrica"
+  description:
+    "Read-only Yandex.Metrica Stat API: arbitrary reports (any dimensions by metrics), time
+    series, traffic sources, geo, devices and goals."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  dockerfile: servers/metrika/Dockerfile
+config:
+  description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.
+  secrets:
+    - name: seo-tools-mcp-metrika.oauth_token
+      env: YANDEX_OAUTH_TOKEN
+      example: <YANDEX_OAUTH_TOKEN>
+  env:
+    - name: METRIKA_COUNTER_ID
+      example: "12345678"
+      value: "{{seo-tools-mcp-metrika.counter_id}}"
+  parameters:
+    type: object
+    properties:
+      counter_id:
+        type: string
+        description: Default Yandex.Metrica counter ID (optional).

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  commit: 28068f64d560917be7d03724078b267ba64e8d02
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  commit: c5358908fdd7d746e429c56f45a441203a8275a8
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 28068f64d560917be7d03724078b267ba64e8d02
+  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: c5358908fdd7d746e429c56f45a441203a8275a8
+  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-metrika/server.yaml
+++ b/servers/seo-tools-mcp-metrika/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/metrika/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 28068f64d560917be7d03724078b267ba64e8d02
+  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -1,0 +1,40 @@
+name: seo-tools-mcp-wordstat
+image: mcp/seo-tools-mcp-wordstat
+type: server
+meta:
+  category: search
+  tags:
+    - seo
+    - wordstat
+    - yandex
+    - keywords
+    - search
+about:
+  title: "SEO Tools: Yandex Wordstat"
+  description:
+    "Read-only Yandex Wordstat keyword frequencies via the official API v2 (Yandex Cloud Search
+    API): broad and exact frequency, demand dynamics and regional distribution."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  dockerfile: servers/wordstat/Dockerfile
+config:
+  description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).
+  secrets:
+    - name: seo-tools-mcp-wordstat.api_key
+      env: WORDSTAT_API_KEY
+      example: <WORDSTAT_API_KEY>
+  env:
+    - name: WORDSTAT_FOLDER_ID
+      example: b1gxxxxxxxxxxxxxxxxx
+      value: "{{seo-tools-mcp-wordstat.folder_id}}"
+  parameters:
+    type: object
+    properties:
+      folder_id:
+        type: string
+        description: Yandex Cloud folder ID.
+    required:
+      - folder_id

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  commit: c5358908fdd7d746e429c56f45a441203a8275a8
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  commit: 28068f64d560917be7d03724078b267ba64e8d02
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: c5358908fdd7d746e429c56f45a441203a8275a8
+  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-wordstat/server.yaml
+++ b/servers/seo-tools-mcp-wordstat/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/wordstat/Dockerfile
 config:
   description: Yandex Cloud Search API credentials (create at https://console.yandex.cloud).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -1,0 +1,40 @@
+name: seo-tools-mcp-xmlriver
+image: mcp/seo-tools-mcp-xmlriver
+type: server
+meta:
+  category: search
+  tags:
+    - seo
+    - serp
+    - google
+    - yandex
+    - indexation
+about:
+  title: "SEO Tools: XMLRiver SERP (Google + Yandex)"
+  description:
+    "Read-only Google and Yandex SERP via XMLRiver: organic (depth in one request), image and
+    news verticals, and a Google URL indexation check."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  dockerfile: servers/xmlriver/Dockerfile
+config:
+  description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).
+  secrets:
+    - name: seo-tools-mcp-xmlriver.key
+      env: XMLRIVER_KEY
+      example: <XMLRIVER_KEY>
+  env:
+    - name: XMLRIVER_USER
+      example: "12345"
+      value: "{{seo-tools-mcp-xmlriver.user}}"
+  parameters:
+    type: object
+    properties:
+      user:
+        type: string
+        description: XMLRiver user ID from the dashboard.
+    required:
+      - user

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  commit: c5358908fdd7d746e429c56f45a441203a8275a8
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: c5358908fdd7d746e429c56f45a441203a8275a8
+  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlriver/server.yaml
+++ b/servers/seo-tools-mcp-xmlriver/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/xmlriver/Dockerfile
 config:
   description: XMLRiver API credentials (sign up and top up at https://xmlriver.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  commit: 28068f64d560917be7d03724078b267ba64e8d02
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -1,0 +1,40 @@
+name: seo-tools-mcp-xmlstock
+image: mcp/seo-tools-mcp-xmlstock
+type: server
+meta:
+  category: search
+  tags:
+    - seo
+    - serp
+    - google
+    - yandex
+    - search
+about:
+  title: "SEO Tools: XMLStock SERP (Google + Yandex)"
+  description:
+    "Read-only Google and Yandex SERP via XMLStock: organic results with highlights, plus images,
+    news and video verticals. Region, device, language and time-period controls."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  dockerfile: servers/xmlstock/Dockerfile
+config:
+  description: XMLStock API credentials (sign up and top up at https://xmlstock.com).
+  secrets:
+    - name: seo-tools-mcp-xmlstock.key
+      env: XMLSTOCK_KEY
+      example: <XMLSTOCK_KEY>
+  env:
+    - name: XMLSTOCK_USER
+      example: "12345"
+      value: "{{seo-tools-mcp-xmlstock.user}}"
+  parameters:
+    type: object
+    properties:
+      user:
+        type: string
+        description: XMLStock user ID from the dashboard.
+    required:
+      - user

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  commit: c5358908fdd7d746e429c56f45a441203a8275a8
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 28068f64d560917be7d03724078b267ba64e8d02
+  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: c5358908fdd7d746e429c56f45a441203a8275a8
+  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-xmlstock/server.yaml
+++ b/servers/seo-tools-mcp-xmlstock/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/xmlstock/Dockerfile
 config:
   description: XMLStock API credentials (sign up and top up at https://xmlstock.com).

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 28068f64d560917be7d03724078b267ba64e8d02
+  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  commit: 28068f64d560917be7d03724078b267ba64e8d02
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -1,0 +1,38 @@
+name: seo-tools-mcp-ywm
+image: mcp/seo-tools-mcp-ywm
+type: server
+meta:
+  category: search
+  tags:
+    - seo
+    - yandex
+    - webmaster
+    - backlinks
+    - search
+about:
+  title: "SEO Tools: Yandex.Webmaster"
+  description:
+    "Read-only Yandex.Webmaster: search queries, external backlinks, broken links, indexing
+    and SQI history, diagnostics, monitored URLs and sitemaps."
+  icon: https://raw.githubusercontent.com/antohins/seo-tools-mcp/main/assets/logo-400.png
+source:
+  project: https://github.com/antohins/seo-tools-mcp
+  branch: main
+  commit: 74147333f3f434ae986f5f4b4a2ed0211d7d0d5f
+  dockerfile: servers/ywm/Dockerfile
+config:
+  description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.
+  secrets:
+    - name: seo-tools-mcp-ywm.oauth_token
+      env: YANDEX_OAUTH_TOKEN
+      example: <YANDEX_OAUTH_TOKEN>
+  env:
+    - name: YWM_HOST_ID
+      example: https:example.com:443
+      value: "{{seo-tools-mcp-ywm.host_id}}"
+  parameters:
+    type: object
+    properties:
+      host_id:
+        type: string
+        description: Default Webmaster host, format https:example.com:443 (optional).

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e0e4360ef9eeb6fa88b9afa8eb9249f14d0c3b38
+  commit: c5358908fdd7d746e429c56f45a441203a8275a8
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
+  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: c5358908fdd7d746e429c56f45a441203a8275a8
+  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
+  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: eddd6a988a9ad33c944f1c73a0cb907dd3496a29
+  commit: 9f7e9267b6b91fb211d0018f1435d6462a4b1137
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: aacc7f8b920a212812f029957d40bc6a35fc99fc
+  commit: e5678ed5409adf97ce16aafe3bad49c927556eea
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.

--- a/servers/seo-tools-mcp-ywm/server.yaml
+++ b/servers/seo-tools-mcp-ywm/server.yaml
@@ -18,7 +18,7 @@ about:
 source:
   project: https://github.com/antohins/seo-tools-mcp
   branch: main
-  commit: 75920d3d7272c68f81f9618a9f9ddae760a655c5
+  commit: 2a3a0d878c7b118ed228352e2feeede902eeb6df
   dockerfile: servers/ywm/Dockerfile
 config:
   description: Yandex OAuth token (shared Webmaster and Metrica scopes), read-only.


### PR DESCRIPTION
## MCP Server Information

**Server Name:** seo-tools-mcp (a suite of 5 servers: `seo-tools-mcp-xmlstock`, `-wordstat`, `-gsc`, `-ywm`, `-metrika`)
**Repository URL:** https://github.com/antohins/seo-tools-mcp
**Brief Description:** Five read-only MCP servers for SEO on the Google/Yandex (RU/CIS) market — a segment not yet covered in the catalog:

- **seo-tools-mcp-xmlstock** (`search`) — Google & Yandex SERP via XMLStock: organic + highlights + images/news/video verticals
- **seo-tools-mcp-wordstat** (`search`) — Yandex Wordstat keyword frequencies (official API v2)
- **seo-tools-mcp-gsc** (`analytics`) — Google Search Console: Search Analytics, URL Inspection, sitemaps
- **seo-tools-mcp-ywm** (`search`) — Yandex.Webmaster: queries, backlinks, indexing, diagnostics
- **seo-tools-mcp-metrika** (`analytics`) — Yandex.Metrica Stat API: reports, traffic, geo, devices, goals

~55 read-only tools total. Multi-account, OAuth (Google + Yandex), strict JSON output, secrets masked in logs. Also published to npm (`seo-tools-mcp-*`) and the official MCP Registry (`io.github.antohins/seo-tools-mcp-*`).

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile (per server, multi-stage source build, non-root, prod-only deps)
- [x] **Documentation**: README (RU + EN) with setup and per-tool docs
- [x] **Security Contact**: SECURITY.md (private GitHub Security Advisories)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME` (all 5 pass every check)
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME` (all 5 build; tools discovered: xmlstock 7, wordstat 6, gsc 11, ywm 17, metrika 14)
- [ ] If the server requires credentials to test it: tool **discovery** works with no credentials (verified via `task build --tools`). Live API calls need read-only credentials (XMLStock key / Yandex OAuth token / Google refresh token) — happy to share read-only test credentials via the form on request.

### Notes for reviewers
- Each image runs one stdio MCP server built from source at the pinned commit (`source.dockerfile: servers/<s>/Dockerfile`, context = repo root for the pnpm workspace).
- All tools are strictly read-only. Credentials are provided as Docker secrets/env (declared in each `config` block); no interactive OAuth is needed inside the container (a refresh token / OAuth token is supplied directly).