### PR TITLE
Add VirtualSMS MCP server

### DIFF
--- a/servers/virtualsms/server.yaml
+++ b/servers/virtualsms/server.yaml
@@ -1,0 +1,24 @@
+name: virtualsms
+image: mcp/virtualsms
+type: server
+meta:
+  category: communication
+  tags:
+    - sms
+    - verification
+    - otp
+    - 2fa
+    - phone-numbers
+about:
+  title: VirtualSMS
+  description: VirtualSMS is an account verification platform that combines real carrier mobile numbers, matching-country proxies and a private cloud browser into one connected workflow.
+  icon: https://avatars.githubusercontent.com/u/265610251?v=4
+source:
+  project: https://github.com/virtualsms-io/mcp-server
+  commit: 5a0a910457dc749e48c50a3f15aa62bc2969aff9
+config:
+  description: Configure the connection to your VirtualSMS account.
+  secrets:
+    - name: virtualsms.api_key
+      env: VIRTUALSMS_API_KEY
+      example: <YOUR_VIRTUALSMS_API_KEY>


### PR DESCRIPTION
This PR adds the VirtualSMS MCP server to the catalog.

VirtualSMS is an account verification platform that combines real carrier mobile numbers, matching-country proxies and a private cloud browser into one connected workflow. The MCP server exposes 40 tools for SMS/OTP verification, number rentals, and proxy management.

- Source: https://github.com/virtualsms-io/mcp-server (MIT licensed)
- Docker-built local server (Dockerfile at repo root; no prebuilt image supplied, so Docker builds + signs it)
- Transport: stdio
- Lists tools without requiring credentials (API key only needed at call time)

— The VirtualSMS Team