### PR TITLE
Add Renology Renovation Cost Data MCP server

### DIFF
--- a/servers/renology-cost-data/server.yaml
+++ b/servers/renology-cost-data/server.yaml
@@ -18,4 +18,4 @@ about:
   icon: https://www.google.com/s2/favicons?domain=therenology.com&sz=64
 source:
   project: https://github.com/asafichaki/renology-cost-data-mcp
-  commit: 218e1235107f80d9ac4ce0731bd4a053a1653cb7
+  commit: cadf40ad54351bf8f150d25a215cc427ae0695ff

--- a/servers/renology-cost-data/server.yaml
+++ b/servers/renology-cost-data/server.yaml
@@ -1,0 +1,21 @@
+name: renology-cost-data
+image: mcp/renology-cost-data
+type: server
+meta:
+  category: data-analytics
+  tags:
+    - ai-tools
+    - california
+    - cost-data
+    - home-renovation
+    - model-context-protocol
+    - open-data
+    - remodeling
+    - washington
+about:
+  title: Renology Renovation Cost Data
+  description: Read-only 2026 city-level home renovation planning cost ranges with sources, dates, limitations, and citation guidance.
+  icon: https://www.google.com/s2/favicons?domain=therenology.com&sz=64
+source:
+  project: https://github.com/asafichaki/renology-cost-data-mcp
+  commit: 218e1235107f80d9ac4ce0731bd4a053a1653cb7


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Renology Renovation Cost Data
**Repository URL:** https://github.com/asafichaki/renology-cost-data-mcp
**Brief Description:** Read-only access to a versioned 2026 city-level home renovation planning-cost dataset, with sources, dates, limitations, citation guidance, and commercial disclosure.

## Basic Requirements

- [x] **Open Source**: MIT code and CC BY 4.0 bundled data/documentation
- [x] **MCP Compliant**: Validated with the official SDK and real stdio clients
- [x] **Active Development**: Versioned v1.0.0 release and passing CI
- [x] **Docker Artifact**: Root Dockerfile, built by the registry tooling
- [x] **Documentation**: README with setup, tools, interpretation rules, and client configuration
- [x] **Security Contact**: SECURITY.md and GitHub private vulnerability reporting

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I tested the MCP Server using `task validate -- --name renology-cost-data`
- [x] I built the MCP Server using `task build -- --tools renology-cost-data`
- [x] The server requires no credentials or network access at runtime

## Validation evidence

The registry validator passed name, directory, title, YAML, pinned commit, secrets/config, license, icon, remote, and OAuth-dynamic checks. The registry build pinned commit `218e1235107f80d9ac4ce0731bd4a053a1653cb7`, built `mcp/renology-cost-data`, and discovered five tools.
