### PR TITLE
Renamed the Okta MCP Server to Okta Open Source MCP Server.

### DIFF
--- a/servers/okta-mcp-server/server.yaml
+++ b/servers/okta-mcp-server/server.yaml
@@ -17,7 +17,7 @@ about:
   title: Okta
   description: |
     ## :tada: __It's Official__ :tada:
-    The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).
+    The Okta Open Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).
 
   icon: https://avatars.githubusercontent.com/u/362460?v=4
 source:
@@ -28,7 +28,7 @@ run:
     - "okta-mcp-server-keyring:/root/.local/share/python_keyring"
     - "{{okta-mcp-server.log_path|volume|into}}"
 config:
-  description: Configure the connection to Okta MCP Server
+  description: Configure the connection to Okta Open Source MCP Server
   secrets:
     - name: okta-mcp-server.okta_private_key
       env: OKTA_PRIVATE_KEY


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Okta
**Repository URL:** https://github.com/okta/okta-mcp-server
**Brief Description:**

## Basic Requirements

- [X] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [X] **MCP Compliant**: Implements MCP API specification
- [X] **Active Development**: Recent commits and maintained
- [X] **Docker Artifact**: Dockerfile
- [X] **Documentation**: Basic README and setup instructions
- [X] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [X] This server meets the basic requirements listed above
- [X] I understand this will undergo automated and manual review.
- [X] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [X] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)
