### PR TITLE
Add maverick-mcp server

### DIFF
--- a/servers/maverick-mcp/server.yaml
+++ b/servers/maverick-mcp/server.yaml
@@ -1,0 +1,28 @@
+name: maverick-mcp
+image: mcp/maverick-mcp
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - stocks
+    - market-data
+    - technical-analysis
+    - portfolio
+about:
+  title: Maverick
+  description: Personal-use stock analysis MCP server — market data, stock screening, technical indicators, and portfolio tracking with cost-basis P&L. Educational use only; not financial advice.
+  icon: https://avatars.githubusercontent.com/u/553618?v=4
+source:
+  project: https://github.com/wshobson/maverick-mcp
+  branch: main
+  commit: 3ae3b1ac11be37f426da78f720f51302a36d0e8d
+run:
+  command:
+    - uv
+    - run
+    - python
+    - -m
+    - maverick.server
+    - --transport
+    - stdio


### PR DESCRIPTION
## Summary

Adds `maverick-mcp` to the Docker MCP Catalog: a personal-use, educational MCP server for stock analysis (market data, screening, technical indicators, portfolio tracking with cost-basis P&L, plus optional backtesting and deep research extras). Not financial advice.

- Canonical MCP name: `io.github.wshobson/maverick-mcp`
- Repository: https://github.com/wshobson/maverick-mcp
- License: MIT
- Transports: stdio (catalog entry) and streamable HTTP
- Core tools need no API key (market data via yfinance)

## Validation

- `task validate -- --name maverick-mcp` passes all checks
- `task build -- --tools maverick-mcp` builds the image and enumerates all 52 tools over stdio