### PR TITLE
Add Talamus MCP server

### DIFF
--- a/servers/talamus/server.yaml
+++ b/servers/talamus/server.yaml
@@ -1,0 +1,36 @@
+name: talamus
+image: mcp/talamus
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - memory
+    - knowledge-graph
+    - local-first
+about:
+  title: Talamus
+  description: Local-first, source-grounded memory for AI agents with cited Markdown notes, provenance, bitemporal history, and review-gated corrections.
+  icon: https://raw.githubusercontent.com/ampres-ai/talamus/392657212829d963d74b1e772e3bf5b4d63c7ccf/docs/assets/talamus-mcp-icon.png
+source:
+  project: https://github.com/ampres-ai/talamus
+  commit: 392657212829d963d74b1e772e3bf5b4d63c7ccf
+run:
+  volumes:
+    - "{{talamus.brain_path}}:/data"
+config:
+  description: Select a writable, initialized Talamus brain. The Anthropic API key is optional and only enables LLM-backed tools when that brain uses the anthropic-api engine; local retrieval does not require it.
+  secrets:
+    - name: talamus.anthropic_api_key
+      env: ANTHROPIC_API_KEY
+      example: <ANTHROPIC_API_KEY>
+      required: false
+  parameters:
+    type: object
+    properties:
+      brain_path:
+        type: string
+        description: Absolute host path to the initialized Talamus brain/project directory
+        default: /Users/local-test/talamus-brain
+    required:
+      - brain_path

--- a/servers/talamus/server.yaml
+++ b/servers/talamus/server.yaml
@@ -11,10 +11,10 @@ meta:
 about:
   title: Talamus
   description: Local-first, source-grounded memory for AI agents with cited Markdown notes, provenance, bitemporal history, and review-gated corrections.
-  icon: https://raw.githubusercontent.com/ampres-ai/talamus/392657212829d963d74b1e772e3bf5b4d63c7ccf/docs/assets/talamus-mcp-icon.png
+  icon: https://raw.githubusercontent.com/ampres-ai/talamus/407e8fcb8683a01c1fa1dbc57e577a6826cb809f/docs/assets/talamus-mcp-icon.png
 source:
   project: https://github.com/ampres-ai/talamus
-  commit: 392657212829d963d74b1e772e3bf5b4d63c7ccf
+  commit: 407e8fcb8683a01c1fa1dbc57e577a6826cb809f
 run:
   volumes:
     - "{{talamus.brain_path}}:/data"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Talamus
**Repository URL:** https://github.com/ampres-ai/talamus
**Brief Description:** Local-first, source-grounded memory for AI agents with cited Markdown notes, provenance, bitemporal history, and review-gated corrections.

## Basic Requirements

- [x] **Open Source**: Apache-2.0 license
- [x] **MCP Compliant**: Implements MCP over stdio and optional local Streamable HTTP
- [x] **Active Development**: Current maintained release is 1.1.3
- [x] **Docker Artifact**: Root Dockerfile runs as a non-root user and persists the selected brain at `/data`
- [x] **Documentation**: README, quickstart, command reference, MCP documentation, case study, and public docs site
- [x] **Security Contact**: Private GitHub security advisories are documented in `SECURITY.md`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I ran the current registry validator against `talamus`
- [ ] I built the server using `task build -- --tools talamus` locally — Docker is unavailable on this machine, so the official PR CI must perform this build and tool-discovery check
- [x] Test credentials are not required; the Anthropic API key is optional and is not needed to start the server or list tools

## Validation Performed

- Source and icon are pinned to the verified Talamus v1.1.3 release commit, `407e8fcb8683a01c1fa1dbc57e577a6826cb809f`.
- GitHub reports that commit as verified and exposes the pinned root `Dockerfile` and dedicated 512 px icon at that exact revision.
- Prettier and `git diff --check` pass on the current v1.1.3 YAML.
- The registry validator, catalog generator, `go test ./...`, and `go vet ./...` passed before the pin-only refresh; upstream CI remains the source of truth for the refreshed image build and MCP tool discovery.
- The Talamus v1.1.3 project gate passes with `ALL GREEN` (745 tests, 5 skipped).

## User Impact

After approval, Docker can build, sign, attest, and publish `mcp/talamus`, making a persistent local Talamus brain installable through Docker Desktop, MCP Toolkit, and the Docker MCP Catalog.
