### PR TITLE
Add APIVerve MCP server

### DIFF
--- a/servers/apiverve/server.yaml
+++ b/servers/apiverve/server.yaml
@@ -1,0 +1,27 @@
+name: apiverve
+image: mcp/apiverve
+type: server
+meta:
+  category: data
+  tags:
+    - apiverve
+    - api
+    - weather
+    - finance
+    - developer-tools
+about:
+  title: APIVerve
+  description: Give agents 350+ real-world APIs — weather, geocoding, finance, DNS, validation, text processing and more — over the Model Context Protocol, on one key.
+  icon: https://apiverve.com/images/favicon.png
+source:
+  project: https://github.com/apiverve/mcp-server
+  branch: main
+  commit: 7eea5dedb5aed3004b84b09864d46bfca1e26d15
+  directory: docker
+config:
+  description: Configure your APIVerve API key
+  secrets:
+    - name: apiverve.api_key
+      env: APIVERVE_API_KEY
+      example: YOUR_API_KEY_HERE
+      description: Get a free API key at https://apiverve.com


### PR DESCRIPTION
Adds APIVerve — 350+ real-world APIs on a single key (official submission; I maintain APIVerve).

APIVerve exposes weather, geocoding, finance, DNS, validation, text processing and more over MCP.
This entry is Docker-built from a thin, MIT-licensed stdio↔remote bridge (`docker/` in the source repo)
that forwards to the hosted server at https://api.apiverve.com/v1/mcp, injecting the API key as an
`x-api-key` header. Because the tool list comes from the remote server, the catalog stays current with
no image changes.

- Source: https://github.com/apiverve/mcp-server (public, MIT)
- Docs: https://docs.apiverve.com
- Website: https://apiverve.com