### PR TITLE
Add Lumi App Finder

### DIFF
--- a/servers/lumi-app-finder/server.yaml
+++ b/servers/lumi-app-finder/server.yaml
@@ -12,11 +12,11 @@ meta:
     - search
 about:
   title: Lumi App Finder
-  description: Read-only first-party finder for 28 verified live Lumi Studio iOS apps across all 50 Apple locales, with localized publisher facts and direct App Store links. Results are not independent rankings.
+  description: Read-only first-party finder for 29 verified live Lumi Studio iOS apps across all 50 Apple locales, with localized publisher facts and direct App Store links. Results are not independent rankings.
   icon: https://avatars.githubusercontent.com/u/13523864?s=200&v=4
 source:
   project: https://github.com/alice51849/lumi-mcp
-  commit: 344c923a217d189a40cacb5e4cfc4eed1f07f78d
+  commit: 89d5cf5c13cb943163267b8ddcd62e6164971578
 run:
   allowHosts:
     - alice51849.github.io:443

--- a/servers/lumi-app-finder/server.yaml
+++ b/servers/lumi-app-finder/server.yaml
@@ -8,6 +8,7 @@ meta:
     - app-store
     - app-discovery
     - localization
+    - privacy
     - search
 about:
   title: Lumi App Finder

--- a/servers/lumi-app-finder/server.yaml
+++ b/servers/lumi-app-finder/server.yaml
@@ -1,0 +1,21 @@
+name: lumi-app-finder
+image: mcp/lumi-app-finder
+type: server
+meta:
+  category: search
+  tags:
+    - ios
+    - app-store
+    - app-discovery
+    - localization
+    - search
+about:
+  title: Lumi App Finder
+  description: Read-only first-party finder for 28 verified live Lumi Studio iOS apps across all 50 Apple locales, with localized publisher facts and direct App Store links. Results are not independent rankings.
+  icon: https://avatars.githubusercontent.com/u/13523864?s=200&v=4
+source:
+  project: https://github.com/alice51849/lumi-mcp
+  commit: 344c923a217d189a40cacb5e4cfc4eed1f07f78d
+run:
+  allowHosts:
+    - alice51849.github.io:443


### PR DESCRIPTION
## MCP Server Information

**Server Name:** lumi-app-finder  
**Repository URL:** https://github.com/alice51849/lumi-mcp  
**Brief Description:** Read-only first-party finder for 29 verified live Lumi Studio iOS apps across all 50 Apple locales, returning localized publisher facts and direct App Store links. Results are explicitly disclosed as first-party material, not independent rankings.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements stdio MCP initialize, tools/list, and tools/call
- [x] **Active Development**: Current release v1.1.3 and recent main-branch maintenance
- [x] **Docker Artifact**: Non-root zero-dependency Dockerfile at the pinned source commit
- [x] **Documentation**: README includes version-pinned installation and usage
- [x] **Security Contact**: GitHub private vulnerability reporting with SECURITY.md

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I have tested the MCP Server using `task validate -- --name lumi-app-finder`
- [x] I have built the MCP Server using `task build -- --tools lumi-app-finder`
- [x] Test credentials are not required; the single read-only tool needs no account, API key, secret, or user configuration

## Validation

The upstream-compatible fork validation [completed successfully](https://github.com/alice51849/mcp-registry/actions/runs/29793686932): all Go unit tests, `task validate`, Docker `task build -- --tools`, MCP introspection, and `task catalog` passed.

Additional upstream checks:

- 15 server, catalog, localization, installer, and container-metadata tests pass
- MCPB manifest validation passes
- Direct stdio probes for `initialize`, `tools/list`, and `tools/call` pass
- Catalog coverage is 29 apps × 50 Apple locales = 1,450 unique routes
- Every App Store URL is a clean direct link with no query or campaign parameters
- Source is pinned to `89d5cf5c13cb943163267b8ddcd62e6164971578`