### PR TITLE
Add cmdop-care MCP server

### DIFF
--- a/servers/cmdop-care/server.yaml
+++ b/servers/cmdop-care/server.yaml
@@ -1,0 +1,16 @@
+name: cmdop-care
+image: mcp/cmdop-care
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - monitoring
+    - fleet-management
+about:
+  title: cmdop Care
+  description: Read-only visibility into an already-enrolled cmdop machine fleet. Exposes four tools — fleet roster, durable machine-health projection, one bounded live process/startup diagnostic, and cmdop-owned storage inventory. It deliberately omits every tool that executes a command, reads an arbitrary file, or delegates an open-ended task to another machine.
+  icon: https://avatars.githubusercontent.com/u/261992651?v=4
+source:
+  project: https://github.com/commandoperator/cmdop-care-mcp
+  commit: 49d27a3e0b0ee10dad8a73eab552190568077c9a


### PR DESCRIPTION
## What

Adds `cmdop-care`, a read-only MCP server for [cmdop](https://cmdop.com) machine fleets.

Source: [commandoperator/cmdop-care-mcp](https://github.com/commandoperator/cmdop-care-mcp) · Go · Apache-2.0 · Dockerfile in repo · pinned to commit `49d27a3`.

## Tools (4, all read-only)

| Tool | What it does |
|---|---|
| `list_machines` | Lists machines in the enrolled fleet |
| `care_status` | Reads the durable Machine Care projection — facts, findings, coverage |
| `care_diagnose` | Runs one bounded, typed process/startup diagnostic on a live enrolled machine |
| `care_storage_inventory` | Reads the latest validated cmdop-owned storage inventory |

## Scope is deliberately narrow

This is **not** the full cmdop MCP surface. It intentionally omits `ask_machine`, `run_command`, `read_file`, and `list_dir` — every tool that executes a command, reads an arbitrary file, or delegates an open-ended task to another machine.

That separation is the point: an agent can answer "is this machine healthy?" without being handed the ability to act on it. The broader product-integration surface lives behind the main `cmdop` CLI (`cmdop mcp stdio`) and is not proposed here.

## Credentials

No test credentials are needed to review the entry. The server reads a token from the local keyring left by a prior `cmdop connect`. With no token present, every tool returns a clear "not enrolled" message rather than failing or prompting — so it is safe to run unconfigured.

## Checklist

- [x] Licence permits consumption — Apache-2.0
- [x] `Dockerfile` present in the source repository
- [x] Entry added under `servers/cmdop-care/server.yaml`
- [x] Source pinned to a specific commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)