### PR TITLE
Add BeachFinder remote MCP server

### DIFF
--- a/servers/beachfinder/readme.md
+++ b/servers/beachfinder/readme.md
@@ -1,0 +1,1 @@
+Docs: https://getbeachfinder.com/tools

--- a/servers/beachfinder/server.yaml
+++ b/servers/beachfinder/server.yaml
@@ -1,0 +1,16 @@
+name: beachfinder
+type: remote
+meta:
+  category: travel
+  tags:
+    - travel
+    - weather
+    - beach
+    - remote
+about:
+  title: BeachFinder
+  description: Live beach and swim-spot conditions for 184,900 swim spots worldwide, including sea temperature, waves, wind, and UV
+  icon: https://www.google.com/s2/favicons?domain=getbeachfinder.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://getbeachfinder.com/mcp


### PR DESCRIPTION
Adds BeachFinder as a remote MCP server entry, following the "Adding a Remote MCP Server" section of CONTRIBUTING.md.

**What it does:** live beach and swim-spot conditions for 184,900 real swim spots worldwide — sea temperature, waves, wind, UV — plus spot search, comparison and detail lookups.

**Details**
- Endpoint: `https://getbeachfinder.com/mcp` (public, `streamable-http`)
- Auth: none. It is read-only and free, so there is no `oauth` block and no test credentials are needed.
- Tools: 12, discoverable anonymously via `tools/list`, so no `tools.json` is included (same pattern as `servers/cloudflare-docs`, `servers/deepwiki` and `servers/find-a-domain`). CI should be able to fetch them directly.
- Docs: https://getbeachfinder.com/tools
- Category: `travel`

Files added: `servers/beachfinder/server.yaml` and `servers/beachfinder/readme.md`. `npx prettier --check` passes on the YAML.
