### PR TITLE
Add Cycles MCP server

### DIFF
--- a/servers/cycles/server.yaml
+++ b/servers/cycles/server.yaml
@@ -1,0 +1,37 @@
+name: cycles
+image: mcp/cycles
+type: server
+meta:
+  category: devops
+  tags:
+    - budget
+    - cost-control
+    - governance
+    - agents
+    - metering
+about:
+  title: Cycles
+  description: Runtime budget authority for AI agents — reserve, enforce, and reconcile spend across providers. Agents reserve budget before costly operations (LLM calls, tool invocations, external actions), commit actual usage afterward, and are denied when policy or balance would be exceeded. 9 tools covering the reserve/commit/release lifecycle, preflight decisions, balances, and usage events.
+  icon: https://www.google.com/s2/favicons?domain=runcycles.io&sz=64
+source:
+  project: https://github.com/runcycles/cycles-mcp-server
+  commit: d1d67f9122c1983760bde2ef587e74bf454f9d0a
+config:
+  description: Connection to your self-hosted Cycles server
+  secrets:
+    - name: cycles.api_key
+      env: CYCLES_API_KEY
+      example: your-cycles-api-key
+  env:
+    - name: CYCLES_BASE_URL
+      example: https://api.runcycles.io
+      value: "{{cycles.base_url}}"
+  parameters:
+    type: object
+    required:
+      - base_url
+    properties:
+      base_url:
+        type: string
+        description: URL of your Cycles server
+        example: https://api.runcycles.io

--- a/servers/cycles/server.yaml
+++ b/servers/cycles/server.yaml
@@ -26,6 +26,24 @@ config:
     - name: CYCLES_BASE_URL
       example: https://api.runcycles.io
       value: "{{cycles.base_url}}"
+    - name: CYCLES_DEFAULT_TENANT
+      example: acme
+      value: "{{cycles.default_tenant}}"
+    - name: CYCLES_DEFAULT_WORKSPACE
+      example: prod
+      value: "{{cycles.default_workspace}}"
+    - name: CYCLES_DEFAULT_APP
+      example: support-bot
+      value: "{{cycles.default_app}}"
+    - name: CYCLES_DEFAULT_WORKFLOW
+      example: ticket-triage
+      value: "{{cycles.default_workflow}}"
+    - name: CYCLES_DEFAULT_AGENT
+      example: researcher
+      value: "{{cycles.default_agent}}"
+    - name: CYCLES_DEFAULT_TOOLSET
+      example: web-tools
+      value: "{{cycles.default_toolset}}"
   parameters:
     type: object
     required:
@@ -35,3 +53,21 @@ config:
         type: string
         description: URL of your Cycles server
         example: https://api.runcycles.io
+      default_tenant:
+        type: string
+        description: Optional default tenant merged into tool calls that omit the subject
+      default_workspace:
+        type: string
+        description: Optional default workspace merged into tool calls that omit the subject
+      default_app:
+        type: string
+        description: Optional default app merged into tool calls that omit the subject
+      default_workflow:
+        type: string
+        description: Optional default workflow merged into tool calls that omit the subject
+      default_agent:
+        type: string
+        description: Optional default agent merged into tool calls that omit the subject
+      default_toolset:
+        type: string
+        description: Optional default toolset merged into tool calls that omit the subject


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Cycles
**Repository URL:** https://github.com/runcycles/cycles-mcp-server
**Brief Description:** Runtime budget authority for AI agents — agents reserve budget before costly operations (LLM calls, tool invocations), commit actual usage afterward, and are denied when policy or balance would be exceeded. 9 tools covering the reserve/commit/release lifecycle, preflight decisions, balances, and usage events.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP API specification (published on the official MCP Registry as `io.github.runcycles/cycles-mcp-server`; all 9 tools carry titles, read-only/destructive annotations, and output schemas)
- [x] **Active Development**: Actively maintained; latest release v0.5.0 (2026-07-22)
- [x] **Docker Artifact**: Dockerfile at repo root (multi-stage node:20-alpine; pinned commit contains it). Image locally built and verified with a full MCP handshake over `docker run -i` — initialize, tools/list (9 tools with complete metadata), resource reads, and tool calls.
- [x] **Documentation**: README with setup for Claude Desktop/Code/Cursor, tool tables, security model; docs site at https://runcycles.io
- [x] **Security Contact**: hello@runcycles.io; security posture documented at https://runcycles.io/security

## Notes for reviewers

- Docker-built submission (image: `mcp/cycles`) — please build from the pinned commit.
- The server connects only to the operator's self-hosted Cycles server (`CYCLES_BASE_URL` parameter + `CYCLES_API_KEY` secret); no other egress, no telemetry.
- Privacy policy: https://runcycles.io/privacy