### PR TITLE
Add quantakrypto MCP server

### DIFF
--- a/servers/quantakrypto/server.yaml
+++ b/servers/quantakrypto/server.yaml
@@ -1,0 +1,32 @@
+name: quantakrypto
+image: mcp/quantakrypto
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - cryptography
+    - post-quantum
+    - code-analysis
+    - sast
+about:
+  title: quantakrypto pqc-tools
+  description: Scans source code for quantum-vulnerable cryptography (RSA, ECC, Diffie-Hellman) and returns NIST post-quantum migration guidance. Generates CycloneDX CBOMs and checks dependencies. Content-based analysis, no API key needed.
+  icon: https://raw.githubusercontent.com/quantakrypto/pqc-tools/main/.github/logo-400.png
+source:
+  project: https://github.com/quantakrypto/pqc-tools
+  commit: 7f18694debd4960bfb23da4bc2d37aebed4c52ff
+run:
+  volumes:
+    - "{{quantakrypto.path|volume-target}}:/project"
+  disableNetwork: true
+config:
+  description: The directory quantakrypto is allowed to scan.
+  parameters:
+    type: object
+    properties:
+      path:
+        type: string
+        default: /Users/you/project
+    required:
+      - path


### PR DESCRIPTION
Adds **quantakrypto** (`mcp/quantakrypto`), an open-source post-quantum crypto scanner.

- **Type:** Docker-built (`type: server`), built from the repo's root `Dockerfile`, pinned to a commit.
- **What it does:** scans source code for quantum-vulnerable cryptography (RSA, ECC, Diffie-Hellman), returns NIST post-quantum migration guidance, generates CycloneDX CBOMs, and checks dependencies. Content-based analysis, no API key or secrets needed to run.
- **License:** Apache-2.0 (permissive, on the accepted list).
- **Source:** https://github.com/quantakrypto/pqc-tools  (npm: `@quantakrypto/mcp`; also on the official MCP Registry as `io.github.quantakrypto/pqc-tools`).
- Mirrors the `ast-grep` entry: mounts the user's project directory to scan and runs with `disableNetwork: true`. No test credentials required.
