### PR TITLE
Add Patchrooms remote MCP server

### DIFF
--- a/servers/patchrooms/readme.md
+++ b/servers/patchrooms/readme.md
@@ -1,0 +1,1 @@
+Docs: https://docs.patchrooms.com/reference/mcp/

--- a/servers/patchrooms/server.yaml
+++ b/servers/patchrooms/server.yaml
@@ -1,0 +1,23 @@
+name: patchrooms
+type: remote
+meta:
+  category: productivity
+  tags:
+    - feedback
+    - code-review
+    - qa
+    - remote
+about:
+  title: Patchrooms
+  description: Human feedback for AI agents — read visual bug reports and review comments, reply, and close them once fixed
+  icon: https://www.google.com/s2/favicons?domain=patchrooms.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://room.patchrooms.com/mcp
+  headers:
+    Authorization: "Bearer ${PATCHROOMS_API_KEY}"
+config:
+  secrets:
+    - name: patchrooms.api_key
+      env: PATCHROOMS_API_KEY
+      example: <YOUR_PR_SK_API_KEY>

--- a/servers/patchrooms/tools.json
+++ b/servers/patchrooms/tools.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "introduce",
+    "description": "Introduce yourself: your agent name and (optionally) who you work for/with. Call this once, before other tools — reports you file and reports you read get attributed to you.",
+    "arguments": []
+  },
+  {
+    "name": "list_reports",
+    "description": "List staging-review feedback reports for the project (compact).",
+    "arguments": []
+  },
+  {
+    "name": "get_report",
+    "description": "Get one report as Markdown.",
+    "arguments": []
+  },
+  {
+    "name": "create_report",
+    "description": "File a new feedback report on behalf of an agent or user.",
+    "arguments": []
+  },
+  {
+    "name": "set_status",
+    "description": "Triage a report: set its status to new | triaged | in-progress | fixed | verified | canceled.",
+    "arguments": []
+  },
+  {
+    "name": "add_comment",
+    "description": "Reply in a report's comment thread as this agent.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** patchrooms
**Repository URL:** N/A — remote MCP server (closed source), endpoint `https://room.patchrooms.com/mcp`, docs: https://docs.patchrooms.com/reference/mcp/
**Brief Description:** Human feedback for AI agents — Patchrooms is a review layer for AI-built apps and staging previews. Reviewers click an element and leave a comment or voice note; the report captures the DOM selector, screenshot, URL, viewport, and console errors. Over MCP, an agent can list and read those reports, file new ones, reply in threads, and close them once fixed.

## Basic Requirements

- [x] **MCP Compliant**: Implements MCP API specification (streamable HTTP, Bearer API key; OAuth 2.0 with dynamic client registration also supported)
- [x] **Active Development**: Actively maintained hosted service
- [x] **Documentation**: https://docs.patchrooms.com/reference/mcp/
- [x] **Security Contact**: hello@patchrooms.com
- [ ] **Open Source** / **Docker Artifact**: N/A — remote server entry per "Adding a Remote MCP Server" (metadata + URL only, no image build)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name patchrooms` (all checks pass)
- [x] I have built the MCP Server using `task build -- --tools patchrooms` (build skipped for remote server, as expected)
- [ ] Test credentials: the server requires a `pr_sk_*` API key; will share via the credentials form on request.
