### PR TITLE
Add Lightning Enable MCP server

### DIFF
--- a/servers/lightning-enable-mcp/server.yaml
+++ b/servers/lightning-enable-mcp/server.yaml
@@ -1,0 +1,69 @@
+name: lightning-enable-mcp
+image: refinedelement/lightning-enable-mcp:1.16.1
+type: server
+meta:
+  category: finance
+  tags:
+    - bitcoin
+    - lightning
+    - payments
+    - agents
+about:
+  title: Lightning Enable
+  description: >-
+    Lets AI agents pay Bitcoin Lightning invoices and access L402-protected
+    APIs, with per-request and session spending budgets. Agents can also act
+    as sellers — issuing and verifying L402 payment challenges — and
+    discover, request, and settle paid services from other agents over the
+    Agent Service Agreement protocol. Configure one wallet: Strike, your own
+    LND node, Nostr Wallet Connect, or OpenNode.
+  icon: https://www.lightningenable.com/images/logo-icon.png
+source:
+  project: https://github.com/refined-element/lightning-enable-mcp
+  branch: main
+  directory: python/lightning-enable-mcp
+  commit: e88dc45bc2dd51801c840c77a0c762f5cfb1a527
+config:
+  description: >-
+    Configure a Lightning wallet for the agent to pay from (Strike, your own
+    LND node, Nostr Wallet Connect, or OpenNode — only one is required) and,
+    optionally, a Lightning Enable API key to unlock the L402 producer and
+    Agent Service Agreement tools.
+  secrets:
+    - name: lightning-enable-mcp.strike_api_key
+      env: STRIKE_API_KEY
+      example: your_strike_api_key
+      description: Strike API key. Supports L402 (returns a payment preimage).
+    - name: lightning-enable-mcp.lnd_macaroon_hex
+      env: LND_MACAROON_HEX
+      example: your_lnd_admin_macaroon_in_hex
+      description: Admin macaroon (hex) for your own LND node. Pair with LND_REST_HOST below. Always returns preimage, so L402 is guaranteed to work.
+    - name: lightning-enable-mcp.nwc_connection_string
+      env: NWC_CONNECTION_STRING
+      example: "nostr+walletconnect://<pubkey>?relay=<relay-url>&secret=<secret>"
+      description: Nostr Wallet Connect URI (CoinOS, CLINK, Alby Hub). Supports L402.
+    - name: lightning-enable-mcp.opennode_api_key
+      env: OPENNODE_API_KEY
+      example: your_opennode_api_key
+      description: OpenNode API key. Direct payments only — does not return a preimage, so L402 is not supported.
+    - name: lightning-enable-mcp.lightning_enable_api_key
+      env: LIGHTNING_ENABLE_API_KEY
+      example: your_lightning_enable_api_key
+      description: Optional. Unlocks the L402 producer tools and the Agent Service Agreement tools. Requires a Lightning Enable Agentic Commerce subscription.
+  env:
+    - name: LND_REST_HOST
+      example: localhost:8080
+      value: "{{lightning-enable-mcp.lnd_rest_host}}"
+    - name: OPENNODE_ENVIRONMENT
+      example: production
+      value: "{{lightning-enable-mcp.opennode_environment}}"
+  parameters:
+    type: object
+    properties:
+      lnd_rest_host:
+        type: string
+        description: LND REST API host, e.g. localhost:8080. Required only when paying with LND_MACAROON_HEX.
+      opennode_environment:
+        type: string
+        description: "OpenNode environment: production or dev (testnet). Defaults to production."
+        default: production


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Lightning Enable
**Repository URL:** https://github.com/refined-element/lightning-enable-mcp
**Brief Description:** An MCP server that lets AI agents make Bitcoin Lightning Network payments — pay invoices, access L402-protected APIs, and control spending with per-request and session budgets, all against a wallet the user configures (Strike, a self-run LND node, Nostr Wallet Connect, or OpenNode). Agents can also act as sellers by issuing and verifying L402 payment challenges, and can discover, request, and settle paid services from other agents over the Agent Service Agreement protocol (Nostr-based).

This is a community-built entry referencing our existing published Docker Hub image (`refinedelement/lightning-enable-mcp`), pinned to tag `1.16.1` / commit `e88dc45bc2dd51801c840c77a0c762f5cfb1a527`. The server is also published on PyPI (`lightning-enable-mcp`) and NuGet, and is already listed in the official MCP Registry as `io.github.refined-element/lightning-enable-mcp`.

Configuration is entirely environment-variable driven. In `servers/lightning-enable-mcp/server.yaml` I modeled the wallet credentials (Strike API key, LND REST host + macaroon, NWC connection string, OpenNode API key) and the optional Lightning Enable API key as `config.secrets`, and the two non-sensitive settings (LND REST host address, OpenNode environment) as `config.env` backed by `config.parameters`. Only one wallet provider is required; none of the wallet secrets are individually marked `required` since any one of them is sufficient.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: implements the MCP spec (stdio transport)
- [x] **Active Development**: actively maintained, most recent commit is from today
- [x] **Docker Artifact**: Dockerfile at `python/lightning-enable-mcp/Dockerfile` in the source repo; image already built and published to Docker Hub (`refinedelement/lightning-enable-mcp`)
- [x] **Documentation**: README with full setup instructions for each wallet backend
- [ ] **Security Contact**: no dedicated `SECURITY.md` yet. The README lists a support email (support@lightningenable.com) and the GitHub issue tracker. Happy to add a formal `SECURITY.md` if that's expected before merge — let me know.

## Submitter Checklist

- [x] This server meets the basic requirements listed above (with the Security Contact caveat noted)
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME` — the `task` CLI itself wasn't available in my environment, so I ran the equivalent `go run ./cmd/validate --name lightning-enable-mcp` directly (this is exactly what the `validate` Task target wraps). All checks passed: name, directory, title, YAML formatting, commit pin, secrets, config env, license, icon.
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME` — **not run**. Docker isn't installed in my environment, so I couldn't exercise the build/pull/tool-listing step locally. I did confirm the image is public and pullable (`refinedelement/lightning-enable-mcp:1.16.1` on Docker Hub) and that the server's tool-listing handler doesn't depend on wallet credentials being configured (it registers its static tool list regardless of wallet init state), so `--pull-community` should succeed in CI. Deferring to your CI for the actual pull + tool-list verification.
- [ ] Test credentials form — not submitted. No credentials are required to list the server's tools; a wallet (Strike/LND/NWC/OpenNode) is only needed to execute real payments. Happy to share sandbox credentials if your review process wants to exercise a live payment.
