### PR TITLE
Add Live Tennis remote MCP server

### DIFF
--- a/servers/livetennisapi/server.yaml
+++ b/servers/livetennisapi/server.yaml
@@ -1,0 +1,26 @@
+name: livetennisapi
+type: remote
+meta:
+  category: sports
+  tags:
+    - sports
+    - tennis
+    - live-scores
+    - data
+    - remote
+about:
+  title: Live Tennis
+  description: Real-time tennis scores, players and fixtures for ATP, WTA, Challenger and ITF. Twelve read-only tools; a plan wall returns a plain-English explanation instead of a bare 403.
+  icon: https://livetennisapi.com/favicon.ico
+remote:
+  transport_type: streamable-http
+  url: https://mcp.livetennisapi.com/mcp
+  headers:
+    X-API-Key: "${LIVETENNISAPI_KEY}"
+config:
+  description: A Live Tennis API key. A free tier (no card, 1,000 requests/day) is available at https://livetennisapi.com/subscribe/free — tools are listable without a key, but calling them requires one.
+  secrets:
+    - name: livetennisapi.api_key
+      env: LIVETENNISAPI_KEY
+      example: twjp_your_key_here
+      required: true


### PR DESCRIPTION
Adds `livetennisapi` — a remote (streamable-http) MCP server for the [Live Tennis API](https://livetennisapi.com).

**Endpoint:** `https://mcp.livetennisapi.com/mcp`

Real-time tennis: live scores, upcoming matches, results, player profiles and fixtures across ATP, WTA, Challenger and ITF. Twelve read-only tools (every one a GET); tools that sit behind a paid plan return a plain-English explanation naming the plan instead of a bare 403.

Notes for validation:
- **`tools/list` works without any credential** — the server is deliberately introspectable anonymously, so discovery/validation can enumerate all 12 tools with no key.
- Tool *calls* need an API key (`X-API-Key`, wired via the secret per the context7 pattern). A **free key is self-serve, no card** at https://livetennisapi.com/subscribe/free — happy to provide test credentials through the credentials form if needed.
- MIT-licensed server source: https://github.com/livetennisapi/livetennisapi-mcp (also on npm as `livetennisapi-mcp`). Multi-tenant: each request is served on the caller's own key; the host holds no credential.