### PR TITLE
Add Ratatosk MCP server

### DIFF
--- a/servers/ratatosk/server.yaml
+++ b/servers/ratatosk/server.yaml
@@ -1,0 +1,18 @@
+name: ratatosk
+image: mcp/ratatosk
+type: server
+meta:
+  category: devops
+  tags:
+    - cncf
+    - kubernetes
+    - security
+    - release-notes
+about:
+  title: Ratatosk
+  description: CNCF release intelligence — typed, quoted facts (security fixes, breaking changes, deprecations) from every graduated/incubating project's release notes, updated daily. check_stack compares running versions locally; versions never leave the container.
+  icon: https://avatars.githubusercontent.com/u/148346166?s=200&v=4
+source:
+  project: https://github.com/garlicKim21/ratatosk-mcp
+  branch: main
+  commit: f8588f417b9b3e3bf984bf4b52fc05b8e3435930


### PR DESCRIPTION
Adds [ratatosk-mcp](https://github.com/garlicKim21/ratatosk-mcp) as a Docker-built local server.

**What it is**: a read-only MCP server for [Ratatosk](https://ratatosk.io), which reads every CNCF graduated/incubating project's release notes daily and extracts typed facts — security fixes, breaking changes, removals, deprecations — each with a verbatim quote and a source URL. Five tools: `list_projects`, `check_stack`, `get_release`, `facts_by_entity`, `list_facts`.

**Notes for review**:
- No configuration needed: no secrets, no env vars, no volumes. The upstream API is public, read-only, rate-limited (60 req/min/IP), terms at https://ratatosk.io/terms.
- Privacy by design: `check_stack` compares the user's running versions locally inside the container; only project slugs reach the server.
- Dockerfile at repo root, static Go binary on distroless (runs as non-root), stdio by default.
- Apache-2.0 licensed. Also published in the official MCP registry as `io.github.garlicKim21/ratatosk-mcp` and verified in-cluster with kagent.