### PR TITLE
Add Pagewatch remote MCP server

### DIFF
--- a/servers/pagewatch/readme.md
+++ b/servers/pagewatch/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/toolshedlabs-hash/web-access-skills

--- a/servers/pagewatch/server.yaml
+++ b/servers/pagewatch/server.yaml
@@ -1,0 +1,17 @@
+name: pagewatch
+type: remote
+meta:
+  category: search
+  tags:
+    - screenshot
+    - pdf
+    - markdown
+    - web-scraping
+    - remote
+about:
+  title: Pagewatch
+  description: Give an agent hosted web access. Screenshot a URL to PNG or JPEG, save a page or raw HTML to PDF, and read any URL as clean markdown with JavaScript rendered.
+  icon: https://www.google.com/s2/favicons?domain=pagelens.dev&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://pagelens.dev/mcp


### PR DESCRIPTION
Adds Pagewatch, a remote (hosted) MCP server, under `servers/pagewatch/`.

Pagewatch gives an agent web access through a hosted browser: screenshot a URL to PNG or JPEG, save a page or raw HTML to PDF, and read any URL as clean markdown with JavaScript rendered. It is a remote streamable-http server, so there is no Docker image to build.

- Endpoint: `https://pagelens.dev/mcp` (streamable-http, publicly accessible, no OAuth)
- Docs: https://github.com/toolshedlabs-hash/web-access-skills
- Also on the Model Context Protocol registry as `dev.pagelens/pagewatch`

The server lists its tools without auth and mints a free trial key on the first call, so no credentials are needed to test it. MIT licensed skills, hosted service in free preview.