### PR TITLE
Add PostEverywhere MCP server

### DIFF
--- a/servers/posteverywhere/server.yaml
+++ b/servers/posteverywhere/server.yaml
@@ -1,0 +1,25 @@
+name: posteverywhere
+image: mcp/posteverywhere
+type: server
+meta:
+  category: productivity
+  tags:
+    - social-media
+    - productivity
+    - marketing
+about:
+  title: PostEverywhere
+  description: Schedule and publish social media posts across X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Threads, Pinterest, Bluesky, Telegram, and Discord from one place. 33 tools covering post creation and scheduling, media upload, AI caption and image generation, campaigns, analytics, account health, and webhooks.
+  icon: https://posteverywhere.ai/mcp-logo-400.png
+source:
+  project: https://github.com/posteverywhere/mcp
+  commit: 42ddc75f161332b485060b876b81e4ba4b6fbe78
+config:
+  description: Requires a PostEverywhere API key (create one at app.posteverywhere.ai under Developers)
+  secrets:
+    - name: posteverywhere.api_key
+      env: POSTEVERYWHERE_API_KEY
+      example: pe_live_xxxxxxxxxxxxxxxxxxxxxxxx
+run:
+  allowHosts:
+    - app.posteverywhere.ai:443


### PR DESCRIPTION
Adds PostEverywhere (https://posteverywhere.ai) — social media scheduling and publishing across 11 platforms (X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Threads, Pinterest, Bluesky, Telegram, Discord) with 33 tools: post creation/scheduling, media upload, AI caption + image generation, campaigns, analytics, account health, and webhooks.

- Source: https://github.com/posteverywhere/mcp (MIT, Dockerfile at repo root, stdio transport)
- Also listed on the official MCP registry as `ai.posteverywhere/mcp` and on npm as `@posteverywhere/mcp`
- Auth: single `POSTEVERYWHERE_API_KEY` env (users create keys in-app)
- Server only talks to `app.posteverywhere.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)