### PR TITLE
Add bernstein MCP server

### DIFF
--- a/servers/bernstein/server.yaml
+++ b/servers/bernstein/server.yaml
@@ -11,14 +11,10 @@ meta:
 about:
   title: Bernstein
   description: >-
-    Deterministic orchestration for CLI coding agents. Submit a goal and
-    Bernstein decomposes it into tasks, runs agents in parallel git worktrees,
-    and records every run in a replay journal with lineage tracking and an
-    opt-in HMAC-chained audit log that verifies offline. Adapters ship for
-    Claude Code, Codex, Gemini CLI, Aider, OpenHands and 40+ other agent CLIs.
-    The MCP server exposes 14 tools covering run control, task listing and
-    claiming, progress updates, artifact posting, approvals, subtasks, cost
-    reporting, context capsules, and skill loading.
+    Governance layer for AI agents. Submit a goal; Bernstein splits it into
+    tasks, runs them in parallel git worktrees, and journals each run in an
+    opt-in HMAC-chained audit log verifiable offline. Tools cover runs, tasks,
+    approvals, artifacts, and cost.
   icon: https://avatars.githubusercontent.com/u/271707709?v=4
 source:
   project: https://github.com/sipyourdrink-ltd/bernstein

--- a/servers/bernstein/server.yaml
+++ b/servers/bernstein/server.yaml
@@ -1,0 +1,28 @@
+name: bernstein
+image: ghcr.io/sipyourdrink-ltd/bernstein
+type: server
+meta:
+  category: devops
+  tags:
+    - orchestration
+    - multi-agent
+    - coding-agents
+    - ci
+about:
+  title: Bernstein
+  description: >-
+    Deterministic orchestration for CLI coding agents. Submit a goal and
+    Bernstein decomposes it into tasks, runs agents in parallel git worktrees,
+    and records every run in a replay journal with lineage tracking and an
+    opt-in HMAC-chained audit log that verifies offline. Adapters ship for
+    Claude Code, Codex, Gemini CLI, Aider, OpenHands and 40+ other agent CLIs.
+    The MCP server exposes 13 tools covering run control, task listing and
+    claiming, progress updates, artifact posting, approvals, subtasks, cost
+    reporting, and skill loading.
+  icon: https://avatars.githubusercontent.com/u/271707709?v=4
+source:
+  project: https://github.com/sipyourdrink-ltd/bernstein
+  commit: ec2c1306eba4f51ace107382dab495156e7f20e6
+run:
+  command:
+    - mcp

--- a/servers/bernstein/server.yaml
+++ b/servers/bernstein/server.yaml
@@ -16,9 +16,9 @@ about:
     and records every run in a replay journal with lineage tracking and an
     opt-in HMAC-chained audit log that verifies offline. Adapters ship for
     Claude Code, Codex, Gemini CLI, Aider, OpenHands and 40+ other agent CLIs.
-    The MCP server exposes 13 tools covering run control, task listing and
+    The MCP server exposes 14 tools covering run control, task listing and
     claiming, progress updates, artifact posting, approvals, subtasks, cost
-    reporting, and skill loading.
+    reporting, context capsules, and skill loading.
   icon: https://avatars.githubusercontent.com/u/271707709?v=4
 source:
   project: https://github.com/sipyourdrink-ltd/bernstein


### PR DESCRIPTION
Adds `servers/bernstein/server.yaml`.

## What it is

[Bernstein](https://github.com/sipyourdrink-ltd/bernstein) is a deterministic orchestrator for CLI coding agents. You give it a goal; it decomposes the goal into tasks, runs agents in parallel git worktrees, and records every run in a replay journal with lineage tracking. An HMAC-chained audit log is opt-in and verifies offline. Adapters ship for Claude Code, Codex, Gemini CLI, Aider, OpenHands and 40+ other agent CLIs.

The MCP server advertises 13 tools at its default tier: run control (`bernstein_run`, `bernstein_stop`, `bernstein_approve`), task listing and claiming (`bernstein_tasks`, `bernstein_status`, `bernstein_claim`, `bernstein_task_handle`, `bernstein_create_subtask`), progress reporting (`bernstein_update`, `bernstein_post_artifact`), cost reporting (`bernstein_cost`), liveness (`bernstein_health`), and skill loading (`load_skill`).

## Entry details

- Image: `ghcr.io/sipyourdrink-ltd/bernstein`, published by the project's own release workflow with BuildKit provenance, SBOM, and a Sigstore keyless build-provenance attestation.
- Source pinned to commit `ec2c1306eba4f51ace107382dab495156e7f20e6` (release 3.9.0).
- License: Apache-2.0.
- No secrets and no environment variables, so there are no test credentials to share. The agent CLIs Bernstein drives are configured by the user outside the container.
- The image `ENTRYPOINT` is `bernstein`, so `run.command` is just `[mcp]`.

## Verification run locally

```
$ task validate -- -name bernstein
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid

$ task build -- --tools --pull-community bernstein
13 tools found.
✅ Image pulled as ghcr.io/sipyourdrink-ltd/bernstein
```

Submitted by the project maintainer.