### PR TITLE
Add dominion-observatory-remote (MCP trust & drift checks)

### DIFF
--- a/servers/dominion-observatory-remote/server.yaml
+++ b/servers/dominion-observatory-remote/server.yaml
@@ -1,0 +1,18 @@
+name: dominion-observatory-remote
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: security
+  tags:
+    - security
+    - trust
+    - monitoring
+    - remote
+about:
+  title: Dominion Observatory
+  description: Trust checks for MCP servers - behavioral trust scores, tool-manifest drift detection (catches silently changed tool descriptions), and signed diligence receipts. Free, no key required.
+  icon: https://www.google.com/s2/favicons?domain=dominionobservatory.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://dominionobservatory.com/mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** dominion-observatory-remote
**Type:** remote (Streamable HTTP) — no Docker image required
**Endpoint:** https://dominionobservatory.com/mcp
**Website:** https://dominionobservatory.com
**Brief Description:** Trust checks for MCP servers — behavioral trust scores, tool-manifest drift detection (catches silently changed tool descriptions), and signed diligence receipts. Free, no key required.

## Basic Requirements

- [x] **Open Source:** Client SDK is MIT-licensed (PyPI `dominion-trust-check`); the service exposes free public read endpoints.
- [x] **MCP Compliant:** Implements the MCP spec; `/mcp` answers `tools/list` over Streamable HTTP.
- [x] **Active Development:** Actively maintained; also published to the official MCP Registry (`com.dominionobservatory/observatory`, domain-verified).
- [x] **Documentation:** https://dominionobservatory.com/docs (+ `/openapi.json`, `/llms.txt`, `/.well-known/mcp/server-card.json`)
- [ ] **Docker Artifact:** N/A — this is a `type: remote` server (hosted endpoint), so no Dockerfile/image is built. `server.yaml` follows the remote-server format (modeled on `servers/linear`).

## Notes

No `oauth`/secrets block because the public endpoints require no authentication. Category: `security`.