### PR TITLE
Add VK (VKontakte) MCP server

### DIFF
--- a/servers/vk/server.yaml
+++ b/servers/vk/server.yaml
@@ -1,0 +1,24 @@
+name: vk
+image: mcp/vk
+type: server
+meta:
+  category: communication
+  tags:
+    - vk
+    - vkontakte
+    - social
+    - communication
+about:
+  title: VK
+  description: Read and act on VK (VKontakte) — walls, users, communities, members, reactions and community statistics, plus publishing, editing and commenting on posts and uploading photos. Read-only tools are annotated so clients can auto-approve them, every tool declares an output schema, and list results say which offset continues the page.
+  icon: https://www.google.com/s2/favicons?domain=vk.com&sz=64
+source:
+  project: https://github.com/bulatko/vk-mcp-server
+  commit: 3c8a7e7e005801ca3f2d3cd9edaca6839d6ec31e
+config:
+  description: Configure the VK access token the server acts with
+  secrets:
+    - name: vk.access_token
+      env: VK_ACCESS_TOKEN
+      example: vk1.a.<your-token>
+      description: A community token is the quickest route if you manage a community — Manage → API usage → Access tokens, ticking wall and photos — and it is tied to neither a browser nor an IP. To act as yourself, create your own Standalone app and run `npx vk-mcp-server --login <APP_ID>`. See the [setup guide](https://github.com/bulatko/vk-mcp-server/blob/master/docs/SETUP.md).


### PR DESCRIPTION
Adds VK (VKontakte), the social network, to the catalog. There are entries for Slack, Discord, Reddit and LinkedIn, but none for VK.

**Server:** https://github.com/bulatko/vk-mcp-server · MIT · stdio · [npm](https://www.npmjs.com/package/vk-mcp-server) · official registry `io.github.bulatko/vk`

Nineteen tools: reading and searching walls, users, communities, members and reactions; community statistics; publishing, editing, deleting and commenting on posts; uploading photos. Read-only tools carry `readOnlyHint` so clients can auto-approve them, every tool declares an output schema, and list results carry the offset that continues the page.

A few things relevant to review:

- The Dockerfile is in the repository root and the image builds from source.
- The server starts and answers `tools/list` with **no credentials in its environment**, so introspection during the build works without a token. A tool call without one returns an explanatory error instead.
- VK issues three kinds of token that look identical in a config file and differ a lot in reach. `npx vk-mcp-server --check` reports which one is configured and which tools it can actually use; the setup guide covers getting one.
- 80 tests run the real server over the MCP protocol in CI on Node 18, 20 and 22.

Happy to adjust the description, category or tags. For the credentials your review process asks for: say the word and I will send a token through the form — a community token, which is scoped to a single test community and revocable from its settings page.