### PR TITLE
Add DexPaprika MCP server

### DIFF
--- a/servers/dexpaprika/server.yaml
+++ b/servers/dexpaprika/server.yaml
@@ -1,0 +1,19 @@
+name: dexpaprika
+image: mcp/dexpaprika
+type: server
+meta:
+  category: monitoring
+  tags:
+    - cryptocurrency
+    - dex
+    - defi
+    - blockchain
+    - onchain
+about:
+  title: DexPaprika
+  description: "Real-time DEX and on-chain data: liquidity pools, token prices, swaps, and trading volume across blockchain networks."
+  icon: https://avatars.githubusercontent.com/u/38780303?v=4
+source:
+  project: https://github.com/coinpaprika/dexpaprika-mcp
+  branch: main
+  commit: e20ef6a77aa450b3447bceb0a9eb277b99cab11c


### PR DESCRIPTION
Adds the **DexPaprika** MCP server — real-time DEX and on-chain data (liquidity pools, token prices, swaps, trading volume) across 36 blockchain networks.

- **Repo:** https://github.com/coinpaprika/dexpaprika-mcp (official, MIT-licensed)
- **Dockerfile:** at repo root; builds from source and runs over stdio (`node dist/bin.js`)
- **Auth:** none — the DexPaprika API is keyless and read-only, so **no test credentials are required** for review
- **Category:** monitoring (real-time market/pool data); happy to change if you'd prefer another
- Pinned to commit `e20ef6a` on `main`

Also published on npm (`dexpaprika-mcp`) and as a hosted MCP at mcp.dexpaprika.com.