### PR TITLE
Add CoinPaprika MCP server

### DIFF
--- a/servers/coinpaprika/server.yaml
+++ b/servers/coinpaprika/server.yaml
@@ -1,0 +1,19 @@
+name: coinpaprika
+image: mcp/coinpaprika
+type: server
+meta:
+  category: monitoring
+  tags:
+    - cryptocurrency
+    - crypto
+    - market-data
+    - finance
+    - prices
+about:
+  title: CoinPaprika
+  description: "Cryptocurrency market data: prices, tickers, exchanges, OHLCV candles, coin metadata, and global market stats."
+  icon: https://avatars.githubusercontent.com/u/38780303?v=4
+source:
+  project: https://github.com/coinpaprika/coinpaprika-mcp
+  branch: main
+  commit: a11b082da36c5a9b67e83f4df1733c1476c19753


### PR DESCRIPTION
Adds the **CoinPaprika** MCP server — cryptocurrency market data: prices, tickers, exchanges, OHLCV candles, coin metadata, and global market stats.

- **Repo:** https://github.com/coinpaprika/coinpaprika-mcp (official, MIT-licensed)
- **Dockerfile:** at repo root; builds from source and runs over stdio (`node dist/index.js`)
- **Auth:** runs keyless against the free CoinPaprika API, so **no test credentials are required** for review. An optional `COINPAPRIKA_API_KEY` env var unlocks paid-tier endpoints, but is not needed to start or test the server.
- **Category:** monitoring (real-time market data); happy to change if you'd prefer another
- Pinned to commit `a11b082` on `main`

Companion to #4553 (DexPaprika). Also on npm (`@coinpaprika/mcp`) and hosted at mcp.coinpaprika.com.