### PR TITLE
Add DialMCP remote MCP server

### DIFF
--- a/servers/dialmcp/readme.md
+++ b/servers/dialmcp/readme.md
@@ -1,0 +1,8 @@
+# DialMCP
+
+Hosted remote MCP server that lets AI agents place real phone calls from the user's own SMS-verified number.
+
+- Website: https://dialmcp.com
+- Endpoint: https://mcp.dialmcp.com/mcp (Streamable HTTP + OAuth 2.1)
+- Registry: `com.dialmcp/dialmcp`
+- Connector: https://github.com/SkillfulAgents/dialmcp-connector

--- a/servers/dialmcp/server.yaml
+++ b/servers/dialmcp/server.yaml
@@ -1,0 +1,19 @@
+name: dialmcp
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: communication
+  tags:
+    - communication
+    - telephony
+    - outbound
+    - phone
+    - remote
+about:
+  title: DialMCP
+  description: Let AI agents place real phone calls from your verified number, with transcripts and recordings
+  icon: https://raw.githubusercontent.com/SkillfulAgents/dialmcp-connector/main/assets/logo.png
+remote:
+  transport_type: streamable-http
+  url: https://mcp.dialmcp.com/mcp


### PR DESCRIPTION
## Add DialMCP (remote)

Adds **DialMCP** via the **remote** track (no Dockerfile / local image).

| Field | Value |
|---|---|
| Type | `remote` |
| Transport | `streamable-http` |
| URL | `https://mcp.dialmcp.com/mcp` |
| Auth | OAuth 2.1 with dynamic client registration (browser sign-in via SMS) — no API key / PAT |
| Website | https://dialmcp.com |
| Official registry | `com.dialmcp/dialmcp` v0.1.0 |
| Connector repo | https://github.com/SkillfulAgents/dialmcp-connector (MIT) |

Modeled after existing remote entries such as `dialer` and `miro-remote`. Category: communication.

**Note:** OAuth is interactive DCR (same class as many remote SaaS entries). There is no long-lived personal access token to put in `config.secrets`; users complete OAuth in the client.

Happy to adjust naming, category, or add a tools snapshot if required by CI.
