### PR TITLE
Add SideButton MCP server

### DIFF
--- a/servers/sidebutton/server.yaml
+++ b/servers/sidebutton/server.yaml
@@ -1,0 +1,25 @@
+name: sidebutton
+image: mcp/sidebutton
+type: server
+meta:
+  category: productivity
+  tags:
+    - browser-automation
+    - workflows
+    - productivity
+about:
+  title: SideButton
+  description: >-
+    Browser automation for AI agents, with a YAML workflow engine and reusable
+    knowledge packs that teach an agent a specific web app. The container
+    bundles Chromium and installs the SideButton extension itself, so all 28
+    tools work out of the box — navigate, click, extract, screenshot, run
+    workflows. Install the Chrome extension on your own machine instead to drive
+    the browser you are already signed into. Setup and docs at
+    https://sidebutton.com
+  icon: https://avatars.githubusercontent.com/u/251921899?s=200&v=4
+source:
+  project: https://github.com/sidebutton/sidebutton
+  commit: 1957a2a0b87258711f8eee05e04c68e8aaf02b43
+  dockerfile: packages/server/Dockerfile
+  buildTarget: browser


### PR DESCRIPTION
## MCP Server Information

**Server Name:** sidebutton
**Repository URL:** https://github.com/sidebutton/sidebutton
**Brief Description:** Browser automation for AI agents, with a YAML workflow engine and reusable knowledge packs that teach an agent a specific web app.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name sidebutton`
- [x] I have built the MCP Server using `task build -- --tools sidebutton`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6) — **not applicable: no credentials are required.** The server starts, enumerates all 28 tools and runs them with no configuration of any kind, so there is nothing to share. Please don't hold review waiting on the form.

---

### How it differs from the browser servers already in the catalog

Playwright, Puppeteer, Browserbase and friends drive a headless browser through code. SideButton is aimed at a different job:

- **Automations are declarative YAML**, not scripts — a workflow is data an agent can read, compose and hand back.
- **Knowledge packs** teach an agent a specific web app: its selectors, states and data model, so it doesn't rediscover them on every run. They are exposed over MCP as `skill://` resources.
- **On the desktop it drives the user's own Chrome** — real profile, existing logged-in session — via a browser extension, rather than a fresh headless context.

### What the container does

The image bundles Chromium and installs the SideButton extension itself, via a Chrome managed policy that force-installs the published Web Store extension on first launch. **All 28 tools work with no host setup.**

Two things worth flagging for review, since both are visible in the Dockerfile:

- **`buildTarget: browser`.** One Dockerfile ships two stages: `browser` (default, bundles Chromium, ~1.5 GB) and `runner` (server only, ~580 MB, no browser). `browser` is also the last stage, so a plain `docker build` produces the same image even if the field were ignored.
- **First launch reaches out to `clients2.google.com`** to fetch the extension. No `run.allowHosts` is set on purpose: it restricts egress, and a browser-automation server has to reach whatever site the agent is asked to drive.

No extension source ships in the image and nothing is redistributed — the browser fetches the signed CRX from Google, and it auto-updates without re-pinning this entry.

### Verification

Run against this branch. Task isn't installed on my machine, so I invoked the
same underlying commands the Taskfile wraps:

- `go run ./cmd/validate --name sidebutton` (i.e. `task validate`) — all 11 checks pass.
- `go run ./cmd/build --tools sidebutton` (i.e. `task build`) — passes, reporting `28 tools found` and `✅ Image built as mcp/sidebutton`.
- `go run ./cmd/catalog sidebutton` — generates cleanly.
- Conformance, run against the built image rather than a local checkout:
  `node packages/server/scripts/mcp-stdio-probe.mjs -- docker run -i --rm mcp/sidebutton`
  asserts protocol `2025-06-18`, `serverInfo.name`, 28 tools with a blank `$HOME` and no credentials, the seeded `skill://` resources, and JSON-RPC-only stdout.
  `mcp-browser-probe.mjs` additionally asserts the extension attaches and that `navigate`, `snapshot`, `extract`, `exists`, `screenshot` and `evaluate` return live page data.
- The image runs as an unprivileged user, contains no baked `.env`, and disables crash reporting by default via `SIDEBUTTON_CONTAINER=1`.
