### PR TITLE
Add DataCharter server

### DIFF
--- a/servers/datacharter/server.yaml
+++ b/servers/datacharter/server.yaml
@@ -1,0 +1,32 @@
+name: datacharter
+image: mcp/datacharter
+type: server
+meta:
+  category: database
+  tags:
+    - duckdb
+    - sql
+    - database
+    - data-governance
+    - pii-masking
+    - data-contracts
+    - local-first
+about:
+  title: DataCharter
+  description: |
+    DataCharter is a local-first, contract-governed data explorer with a governed MCP server.
+
+    It federates local files and databases — CSV, Parquet, Excel, SQLite, DuckDB, Postgres — through DuckDB and exposes four read-only, PII-masked tools:
+
+    • list_sources — configured data sources and their types
+    • list_tables — all queryable tables (fully-qualified relation names)
+    • describe_table — columns and types for a relation
+    • query — run a read-only SQL query
+
+    A YAML "charter" governs access with automatic PII masking, read-only enforcement, and row-level security, so you can point an agent at real data without exposing raw PII.
+
+    This image ships a small CSV-backed demo workspace so it works out of the box. To query your own data, mount a folder that contains a charter.yaml at /workspace.
+  icon: https://raw.githubusercontent.com/datacharter/datacharter/main/brand/mark-400.png
+source:
+  project: https://github.com/datacharter/datacharter
+  commit: 1a835e1e5467866c18fc47a311ed05621b1a7909


### PR DESCRIPTION
## MCP Server Information

**Server Name:** DataCharter
**Repository URL:** https://github.com/datacharter/datacharter
**Brief Description:** A local-first, contract-governed data explorer with a governed MCP server — federates local files and databases (CSV, Parquet, Excel, SQLite, DuckDB, Postgres) through DuckDB and exposes four read-only, PII-masked tools (`list_sources`, `list_tables`, `describe_table`, `query`), with automatic PII masking, read-only enforcement, and row-level security governed by a YAML "charter".

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: stdio MCP server; verified `initialize` + `tools/list` return all four tools (also live in the official MCP Registry as `io.github.datacharter/datacharter`)
- [x] **Active Development**: actively maintained (multiple releases this week; latest v0.10.4)
- [x] **Docker Artifact**: `Dockerfile` at the repo root — offline-safe (installs `datacharter`, bakes a CSV demo workspace so the image serves out of the box)
- [x] **Documentation**: [README](https://github.com/datacharter/datacharter), [docs/mcp](https://datacharter.github.io/datacharter/mcp), and an [`llms-install.md`](https://github.com/datacharter/datacharter/blob/main/llms-install.md)
- [x] **Security Contact**: GitHub issues + [privacy policy](https://datacharter.github.io/datacharter/privacy)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name datacharter`
- [ ] I have built the MCP Server using `task build -- --tools datacharter`
- [x] No test credentials required — the image ships a self-contained CSV demo workspace and needs no API keys or accounts.

> Transparency: I couldn't run `task validate` / `task build` in my environment (no Go/Task toolchain here), so I'm relying on this PR's CI to run them. The repo `Dockerfile` is already verified to build and answer MCP introspection with **no network** (`docker run --network none` → `tools/list` returns the four tools), which is what `task build --tools` checks. Happy to fix anything CI or the review flags.

## Notes

The image serves a small CSV-backed demo workspace by default; to query real data, mount a folder containing a `charter.yaml` at `/workspace`. All four tools are read-only, so it is safe to point at real databases.
