### PR TITLE
Add Orphograph MCP server

### DIFF
--- a/servers/orphograph/server.yaml
+++ b/servers/orphograph/server.yaml
@@ -1,0 +1,23 @@
+name: orphograph
+image: mcp/orphograph
+type: server
+meta:
+  category: security
+  tags:
+    - bitcoin
+    - timestamp
+    - provenance
+    - notary
+about:
+  title: Orphograph
+  description: Anchor a file's SHA-256 fingerprint to Bitcoin. The file never leaves the device.
+  icon: https://www.google.com/s2/favicons?domain=orphograph.com&sz=64
+source:
+  project: https://github.com/Orphograph/Orphograph
+  commit: bbfd67d2a0ef44b0ca1c7c674f87504d8ca874ff
+  directory: mcp
+config:
+  secrets:
+    - name: orphograph.api_key
+      env: ORPHO_API_KEY
+      example: orpho_****


### PR DESCRIPTION
## MCP Server Information

**Server Name:** orphograph
**Repository URL:** https://github.com/Orphograph/Orphograph (server in `mcp/`)
**Brief Description:** Bitcoin-anchored proof-of-existence notary. The server hashes files locally and transmits only the SHA-256 fingerprint — the file never leaves the machine. Receipts verify independently via OpenTimestamps.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: MCP 2024-11-05 over stdio (single-file, stdlib-only Python)
- [x] **Active Development**: multiple commits this week; listed in the official MCP registry as `io.github.Orphograph/orphograph`
- [x] **Docker Artifact**: `mcp/Dockerfile` (python:3.12-slim, stdio entrypoint, no ports)
- [x] **Documentation**: `mcp/README.md` + https://orphograph.com/mcp.html
- [x] **Security Contact**: https://orphograph.com/security (hello@orphograph.com)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] `task validate` — not run locally (no Docker on the submission machine); deferring to CI. Happy to address any failures.
- [ ] `task build` — same as above.
- [x] No credentials are required to test: the server works unauthenticated on the free tier (3 anchors/day). The optional `ORPHO_API_KEY` secret only lifts the rate limit.
