### PR TITLE
Add Form.io MCP server

### DIFF
--- a/servers/formio/server.yaml
+++ b/servers/formio/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/11790256?v=4
 source:
   project: https://github.com/formio/ai
-  commit: 9893c8a09c107afa5f48a3153f390d9bb4a2e1bf
+  commit: 9cce99506f6092de97887755600daebf62ccd6b8
   directory: packages/mcp-server
 config:
   description: Configure the connection to your Form.io project. A project API key is required in a container, because the browser portal-login flow cannot reach the host from inside one.

--- a/servers/formio/server.yaml
+++ b/servers/formio/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/11790256?v=4
 source:
   project: https://github.com/formio/ai
-  commit: 9cce99506f6092de97887755600daebf62ccd6b8
+  commit: 5073600fe6394fb7ddd870671ecc5288474e48f8
   directory: packages/mcp-server
 config:
   description: Configure the connection to your Form.io project. A project API key is required in a container, because the browser portal-login flow cannot reach the host from inside one.

--- a/servers/formio/server.yaml
+++ b/servers/formio/server.yaml
@@ -1,0 +1,41 @@
+name: formio
+image: formio/mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - forms
+    - data-collection
+    - low-code
+    - api
+    - formio
+about:
+  title: Form.io
+  description: Create and manage Form.io forms, resources, actions, roles, and projects directly from an AI agent. Tools cover listing and inspecting forms and their revisions, creating and updating form and resource schemas, managing roles and access, configuring server-side actions such as email, webhook, and login handlers, and exporting or importing an entire project template. Works against Form.io SaaS or a self-hosted deployment.
+  icon: https://avatars.githubusercontent.com/u/11790256?v=4
+source:
+  project: https://github.com/formio/ai
+  commit: 9893c8a09c107afa5f48a3153f390d9bb4a2e1bf
+  directory: packages/mcp-server
+config:
+  description: Configure the connection to your Form.io project. A project API key is required in a container, because the browser portal-login flow cannot reach the host from inside one.
+  secrets:
+    - name: formio.api_key
+      env: FORMIO_API_KEY
+      example: <FORMIO_API_KEY>
+  env:
+    - name: FORMIO_PROJECT_URL
+      example: https://your-project.form.io
+      value: "{{formio.project_url}}"
+    - name: FORMIO_BASE_URL
+      example: https://api.form.io
+      value: "{{formio.base_url}}"
+  parameters:
+    type: object
+    properties:
+      project_url:
+        type: string
+      base_url:
+        type: string
+    required:
+      - project_url

--- a/servers/formio/server.yaml
+++ b/servers/formio/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/11790256?v=4
 source:
   project: https://github.com/formio/ai
-  commit: 5073600fe6394fb7ddd870671ecc5288474e48f8
+  commit: 4296e4d3616a7ea690b3971e6238ab3b6b163d97
   directory: packages/mcp-server
 config:
   description: Configure the connection to your Form.io project. A project API key is required in a container, because the browser portal-login flow cannot reach the host from inside one.


### PR DESCRIPTION
## MCP Server Information

**Server Name:** formio
**Repository URL:** https://github.com/formio/ai
**Brief Description:** Official MCP server for Form.io. Lets an AI agent create and manage Form.io forms, resources, actions, roles, and projects, against Form.io SaaS or a self-hosted deployment. 19 tools.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name formio`
- [x] I have built the MCP Server using `task build -- --tools formio`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

**License:** MIT.

**Image:** community-built as [`formio/mcp`](https://hub.docker.com/r/formio/mcp), published from CI on release for `linux/amd64` and `linux/arm64`. Also on npm as [`@formio/mcp`](https://www.npmjs.com/package/@formio/mcp) with provenance attestation, and in the official MCP Registry as `io.form/formio-mcp`.

**Verification run locally against the pinned commit:**

- `task validate -- --name formio` — all checks pass
- `task build -- --tools formio` — image pulled, 19 tools found

**Credentials for testing:** `tools/list` works with no configuration, so the tool surface can be inspected immediately. Exercising the tools needs a Form.io project — `FORMIO_PROJECT_URL` plus `FORMIO_API_KEY`. I am submitting test credentials through the form above; happy to provide a dedicated sandbox project if that is easier for the reviewer.

**A note on the container's auth:** the npm package can authenticate through a browser portal-login flow, but that cannot work inside a container, so the image expects `FORMIO_API_KEY`. This is documented in the image overview and the package README, and the server now reports the situation explicitly rather than hanging.

Entries drafted with Claude Code, following the "Add server entry with Claude Code" flow in CONTRIBUTING.md, and validated with the repo's own `cmd/validate` and `cmd/build`.
