### PR TITLE
Add Form.io UAG MCP server

### DIFF
--- a/servers/formio-uag/server.yaml
+++ b/servers/formio-uag/server.yaml
@@ -16,7 +16,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/11790256?v=4
 source:
   project: https://github.com/formio/uag
-  commit: 7388468c69778af705df153aabf7943515651604
+  commit: 981249970c4512bd8651deaa17b94c7caf6a5123
 config:
   description: Configure the connection to your Form.io deployment
   secrets:

--- a/servers/formio-uag/server.yaml
+++ b/servers/formio-uag/server.yaml
@@ -16,7 +16,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/11790256?v=4
 source:
   project: https://github.com/formio/uag
-  commit: 981249970c4512bd8651deaa17b94c7caf6a5123
+  commit: 55c61439e9f0adb718a0ff1f0430a5d34a2b6ba3
 config:
   description: Configure the connection to your Form.io deployment
   secrets:

--- a/servers/formio-uag/server.yaml
+++ b/servers/formio-uag/server.yaml
@@ -1,0 +1,48 @@
+name: formio-uag
+image: formio/uag
+type: server
+meta:
+  category: productivity
+  tags:
+    - forms
+    - automation
+    - data-collection
+    - workflow
+    - Form.io
+    - formio
+about:
+  title: Form.io - Universal Agent Gateway (UAG)
+  description: Turns Form.io forms, resources, and workflows into agent-readable context so an AI agent can collect, validate, and submit structured data. Form JSON schemas are converted into markdown the model can reason about, and submissions are validated against the same rules the human renderer enforces — so unstructured conversation becomes a deterministic, validated record. Tools cover listing forms, inspecting fields and their validation rules, collecting and confirming field data, fetching external or Resource-backed option data, searching existing submissions, and submitting or updating records.
+  icon: https://avatars.githubusercontent.com/u/11790256?v=4
+source:
+  project: https://github.com/formio/uag
+  commit: 7388468c69778af705df153aabf7943515651604
+config:
+  description: Configure the connection to your Form.io deployment
+  secrets:
+    - name: formio-uag.jwt_secret
+      env: JWT_SECRET
+      example: <JWT_SECRET>
+    - name: formio-uag.project_key
+      env: PROJECT_KEY
+      example: <PROJECT_KEY>
+  env:
+    - name: PROJECT
+      example: https://your-project.form.io
+      value: "{{formio-uag.project}}"
+    # The server starts without this, but it is published in the .well-known
+    # OIDC definitions and used for auth callbacks, so remote agents cannot
+    # authenticate when it is missing.
+    - name: BASE_URL
+      example: https://uag.your-domain.com
+      value: "{{formio-uag.base_url}}"
+  parameters:
+    type: object
+    properties:
+      project:
+        type: string
+      base_url:
+        type: string
+    required:
+      - project
+      - base_url

--- a/servers/formio-uag/tools.json
+++ b/servers/formio-uag/tools.json
@@ -1,0 +1,349 @@
+[
+  {
+    "name": "get_forms",
+    "description": "Get a list of all available forms with their descriptions. Use this tool when a user expresses intent to add, create, submit, fill out, register for something (e.g., \"I want to add a new Contact\", \"I need to submit a User Registration\", \"I met a contact who was the CMO\", \"What was the email of the contact\"). This tool can also be used when they ask what forms are available.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "get_form_fields",
+    "description": "Get high level overview of the fields that are present in a form, and to understand the \"rules\" on how the data for each field type should be collected. The purpose of this tool is to determine what fields the user is requesting (and to understand how to format that values for that data), and use that to create a list of field data_path's that the user is providing context for. This list can then be provided to the `get_field_info` tool to determine the specific field level information for those fields (validation, required, collection rules, etc). PREREQUISITE: You must call the `get_forms` tool first to understand what forms are available to submit and the permissions associated with those forms.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "criteria": {
+          "default": "required",
+          "description": "Returns only the fields of the specified criteria. \"all\" returns all fields, \"required\" returns only the required fields, and \"optional\" returns only optional fields. To start a new form collection flow, you typically want to get only the \"required\" fields first.",
+          "type": "string",
+          "enum": ["all", "required", "optional"]
+        },
+        "parent_path": {
+          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = \u2705 Yes. If not provided, the tool assumes data is being collected for the root form.",
+          "type": "string"
+        }
+      },
+      "required": ["form_name"]
+    }
+  },
+  {
+    "name": "get_field_info",
+    "description": "Get detailed information about a specific field(s) that have been provided from the user. It is used to understand the properties, validation rules, and options of the specific field(s) the user has provided values for. This purpose of this tool is to provide detailed information for any field(s) (provided using the `field_paths` parameter) to help understand the structure and requirements of a form. PREREQUISITE: This tool should be called after the `get_form_fields` tool has been called AND once the user has provided some values for the provided fields.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "field_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+          },
+          "description": "An array of `data_path`(s) to get detailed information for specific fields."
+        },
+        "parent_path": {
+          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = \u2705 Yes. If not provided, the tool assumes data is being collected for the root form.",
+          "type": "string"
+        }
+      },
+      "required": ["form_name", "field_paths"]
+    }
+  },
+  {
+    "name": "collect_field_data",
+    "description": "Collect data for a form, or a specific field with nested components. Identify the component by its path, validate the provided value, and update the form_data object. After updating, determine the next required field to collect or indicate if all required fields are complete. PREREQUISITE: This tool should only be called after the `get_form_fields` tool AND subsequentially the `get_field_info` tool have been called to understand the structure and validation rules of the fields.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "form_data": {
+          "default": {},
+          "description": "The current data collected so far for the whole form without any updates applied. Include ALL previously collected field data to maintain session state.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+          },
+          "additionalProperties": {
+            "description": "The value collected for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
+          }
+        },
+        "parent_path": {
+          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = \u2705 Yes. If not provided, the tool assumes data is being collected for the root form.",
+          "type": "string"
+        },
+        "as_json": {
+          "default": false,
+          "description": "If true, the submission data will be returned as a JSON object result instead of formatted text. Any errors will also be returned as a structured JSON array. Set this property to `true` ONLY if the prompt indicates that JSON output of the submission data is required.",
+          "type": "boolean"
+        },
+        "updates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data_path": {
+                "type": "string",
+                "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+              },
+              "new_value": {
+                "description": "The complete new value for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
+              }
+            },
+            "required": ["data_path", "new_value"],
+            "description": "A single field update including the `data_path` and new value."
+          },
+          "description": "An array of field updates to apply to the `form_data`. Each update specifies the `data_path` and the complete new value."
+        }
+      },
+      "required": ["form_name", "updates"]
+    }
+  },
+  {
+    "name": "confirm_form_submission",
+    "description": "Show a summary of the collected form data if the user wishes to see a summary of the collected data",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "form_data": {
+          "default": {},
+          "description": "The current data collected so far for the whole form without any updates applied. Include ALL previously collected field data to maintain session state.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+          },
+          "additionalProperties": {
+            "description": "The value collected for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
+          }
+        }
+      },
+      "required": ["form_name"]
+    }
+  },
+  {
+    "name": "submit_completed_form",
+    "description": "Submit the completed form data. Should only be used once all the required fields have been collected, and the user has explicitly confirmed submission (e.g. has said \"submit\", \"send\", \"done\", etc)",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "form_data": {
+          "default": {},
+          "description": "The current data collected so far for the whole form without any updates applied. Include ALL previously collected field data to maintain session state.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+          },
+          "additionalProperties": {
+            "description": "The value collected for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
+          }
+        }
+      },
+      "required": ["form_name"]
+    }
+  },
+  {
+    "name": "find_submissions",
+    "description": "Find existing form submissions based on field values (search query). Use this to search for people, records, or data by name, email, phone, position, company, or other field values. Examples: find a contact by name, find someone who works at a company, find records with specific criteria. To retrieve the total count of records within a form, use this tool without providing a `search_query`.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "search_query": {
+          "description": "Array of search criteria to find matching submissions. All criteria must match (AND logic). Do not provide this parameter to get the total count of submissions without retrieving the submission details.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data_path": {
+                "type": "string",
+                "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+              },
+              "operator": {
+                "default": "contains",
+                "description": "The operator to use for matching. \"equals\" for exact match, \"contains\" for substring match, \"starts_with\" or \"ends_with\" for prefix/suffix match, \"regex\" for regular expression match, \"greater_than\" or \"less_than\" only for numeric values, \"in\" if searching for multiple values as comma-separated values, \"nin\" if excluding multiple values as comma-separated values.",
+                "type": "string",
+                "enum": [
+                  "equals",
+                  "not_equals",
+                  "contains",
+                  "starts_with",
+                  "ends_with",
+                  "regex",
+                  "in",
+                  "nin",
+                  "greater_than",
+                  "greater_than_equal",
+                  "less_than",
+                  "less_than_equal"
+                ]
+              },
+              "search_value": {
+                "type": "string",
+                "description": "The value of the field to use when searching."
+              }
+            },
+            "required": ["data_path", "search_value"],
+            "description": "Object containing the `data_path` and search value. Use `get_form_fields` to get all the field information to populate this search query object."
+          }
+        },
+        "fields_requested": {
+          "description": "An array of `data_path`(s) for values you wish to include in the result. If not provided, only submission IDs and timestamps are returned. (e.g., [\"employee.email\"] - \"What is the email address for the employee Joe Smith?\")",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+          }
+        },
+        "limit": {
+          "default": 5,
+          "description": "The maximum number of results to return. Defaults to 5.",
+          "type": "number"
+        },
+        "submission_id": {
+          "description": "The full ID of the submission to retrieve details for. This value is provided using the `find_submissions` tool.",
+          "type": "string"
+        },
+        "submission_id_partial": {
+          "description": "Last 4 characters of a specific submission ID. Should ONLY be used when multiple matches are found from a previous query and the user provides the last 4 characters of the Submission ID to disambiguate.",
+          "type": "string"
+        }
+      },
+      "required": ["form_name"]
+    }
+  },
+  {
+    "name": "submission_update",
+    "description": "Apply multiple planned field updates to a selected submission after the user confirmed they wish to update the record.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "submission_id": {
+          "description": "The full ID of the submission to retrieve details for. This value is provided using the `find_submissions` tool.",
+          "type": "string"
+        },
+        "updates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data_path": {
+                "type": "string",
+                "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+              },
+              "new_value": {
+                "description": "The complete new value for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
+              }
+            },
+            "required": ["data_path", "new_value"],
+            "description": "A single field update including the `data_path` and new value."
+          },
+          "description": "An array of field updates to apply to the `form_data`. Each update specifies the `data_path` and the complete new value."
+        }
+      },
+      "required": ["form_name", "updates"]
+    }
+  },
+  {
+    "name": "agent_provide_data",
+    "description": "Provides a mechanism for agents to process existing submission data, understand it, and then to provide additional data values provided a criteria and form context.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "submission_id": {
+          "description": "The full ID of the submission to retrieve details for. This value is provided using the `find_submissions` tool.",
+          "type": "string"
+        },
+        "persona": {
+          "description": "The agent persona \"type\" to use when processing the existing submission data. The persona provides context to the agent on how to interpret and understand the data within the form submission. If not provided, the default persona defined within the form's UAG settings will be used.",
+          "type": "string"
+        }
+      },
+      "required": ["form_name"]
+    }
+  },
+  {
+    "name": "fetch_external_data",
+    "description": "Fetch external data for a component that loads data from an external URL, a Form.io Resource, or a DataSource. Use this tool when `get_form_fields` indicates that a field requires calling `fetch_external_data` to retrieve its data. For select components, this returns the available options. For datasource components, this returns the fetched data. You can optionally provide a `search_value` to filter results server-side. If the component's URL or headers contain interpolation tokens (e.g. `{{ data.someField }}`), you MUST provide `form_data` with the current collected data so the tokens can be resolved.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "form_name": {
+          "type": "string",
+          "enum": [],
+          "description": "The name of the form being filled out"
+        },
+        "data_path": {
+          "type": "string",
+          "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+        },
+        "form_data": {
+          "default": {},
+          "description": "The current data collected so far for the whole form without any updates applied. Include ALL previously collected field data to maintain session state.",
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "description": "The `data_path` (or \"full path\") to a component's instance value within a form submission (e.g., \"customer.firstName\"). Use `get_form_fields` to find the `data_path` of this component."
+          },
+          "additionalProperties": {
+            "description": "The value collected for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
+          }
+        },
+        "search_value": {
+          "description": "An optional search string to filter the select options server-side. The component must have a `searchField` configured for this to take effect.",
+          "type": "string"
+        }
+      },
+      "required": ["form_name", "data_path"]
+    }
+  }
+]

--- a/servers/formio-uag/tools.json
+++ b/servers/formio-uag/tools.json
@@ -6,6 +6,13 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "type": "object",
       "properties": {}
+    },
+    "annotations": {
+      "title": "Get available forms",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -24,14 +31,27 @@
           "default": "required",
           "description": "Returns only the fields of the specified criteria. \"all\" returns all fields, \"required\" returns only the required fields, and \"optional\" returns only optional fields. To start a new form collection flow, you typically want to get only the \"required\" fields first.",
           "type": "string",
-          "enum": ["all", "required", "optional"]
+          "enum": [
+            "all",
+            "required",
+            "optional"
+          ]
         },
         "parent_path": {
-          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = \u2705 Yes. If not provided, the tool assumes data is being collected for the root form.",
+          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = ✅ Yes. If not provided, the tool assumes data is being collected for the root form.",
           "type": "string"
         }
       },
-      "required": ["form_name"]
+      "required": [
+        "form_name"
+      ]
+    },
+    "annotations": {
+      "title": "Get form fields",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -55,11 +75,21 @@
           "description": "An array of `data_path`(s) to get detailed information for specific fields."
         },
         "parent_path": {
-          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = \u2705 Yes. If not provided, the tool assumes data is being collected for the root form.",
+          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = ✅ Yes. If not provided, the tool assumes data is being collected for the root form.",
           "type": "string"
         }
       },
-      "required": ["form_name", "field_paths"]
+      "required": [
+        "form_name",
+        "field_paths"
+      ]
+    },
+    "annotations": {
+      "title": "Get field details",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -87,7 +117,7 @@
           }
         },
         "parent_path": {
-          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = \u2705 Yes. If not provided, the tool assumes data is being collected for the root form.",
+          "description": "The `data_path` of the parent component that contains nested components. Use this parameter if collecting data for fields within a specific nested component within a form. To find the `parent_path`, you can use the `get_field_info` tool, and use the `data_path` of any component that ****Has Nested Components**** = ✅ Yes. If not provided, the tool assumes data is being collected for the root form.",
           "type": "string"
         },
         "as_json": {
@@ -108,13 +138,26 @@
                 "description": "The complete new value for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
               }
             },
-            "required": ["data_path", "new_value"],
+            "required": [
+              "data_path",
+              "new_value"
+            ],
             "description": "A single field update including the `data_path` and new value."
           },
           "description": "An array of field updates to apply to the `form_data`. Each update specifies the `data_path` and the complete new value."
         }
       },
-      "required": ["form_name", "updates"]
+      "required": [
+        "form_name",
+        "updates"
+      ]
+    },
+    "annotations": {
+      "title": "Collect field data",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -142,7 +185,16 @@
           }
         }
       },
-      "required": ["form_name"]
+      "required": [
+        "form_name"
+      ]
+    },
+    "annotations": {
+      "title": "Summarise before submitting",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -170,7 +222,16 @@
           }
         }
       },
-      "required": ["form_name"]
+      "required": [
+        "form_name"
+      ]
+    },
+    "annotations": {
+      "title": "Submit a completed form",
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "idempotentHint": false,
+      "openWorldHint": true
     }
   },
   {
@@ -219,7 +280,10 @@
                 "description": "The value of the field to use when searching."
               }
             },
-            "required": ["data_path", "search_value"],
+            "required": [
+              "data_path",
+              "search_value"
+            ],
             "description": "Object containing the `data_path` and search value. Use `get_form_fields` to get all the field information to populate this search query object."
           }
         },
@@ -245,7 +309,16 @@
           "type": "string"
         }
       },
-      "required": ["form_name"]
+      "required": [
+        "form_name"
+      ]
+    },
+    "annotations": {
+      "title": "Find submissions",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -277,13 +350,26 @@
                 "description": "The complete new value for the field. The rules for the value is determined using the `get_form_fields` tool within the **Field Rules** section for this component type, and formatted according the the **Format** section of that component (if applicable). If a value already exists, and it is a string, then you can append/prepend to it to the existing value in the proper order (append/prepend) determined by the user response. If the value is not a string, then replace the value entirely."
               }
             },
-            "required": ["data_path", "new_value"],
+            "required": [
+              "data_path",
+              "new_value"
+            ],
             "description": "A single field update including the `data_path` and new value."
           },
           "description": "An array of field updates to apply to the `form_data`. Each update specifies the `data_path` and the complete new value."
         }
       },
-      "required": ["form_name", "updates"]
+      "required": [
+        "form_name",
+        "updates"
+      ]
+    },
+    "annotations": {
+      "title": "Update a submission",
+      "readOnlyHint": false,
+      "destructiveHint": true,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -307,7 +393,16 @@
           "type": "string"
         }
       },
-      "required": ["form_name"]
+      "required": [
+        "form_name"
+      ]
+    },
+    "annotations": {
+      "title": "Process submission data",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   },
   {
@@ -343,7 +438,17 @@
           "type": "string"
         }
       },
-      "required": ["form_name", "data_path"]
+      "required": [
+        "form_name",
+        "data_path"
+      ]
+    },
+    "annotations": {
+      "title": "Fetch external field data",
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "idempotentHint": true,
+      "openWorldHint": true
     }
   }
 ]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** formio-uag
**Repository URL:** https://github.com/formio/uag
**Brief Description:** The Form.io Universal Agent Gateway. Turns Form.io forms, resources, and workflows into agent-readable context so an AI agent can collect, validate, and submit structured data — validated against the same rules the human renderer enforces. 10 tools.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name formio-uag`
- [x] I have built the MCP Server using `task build -- --tools formio-uag`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6) — *no credentials are needed, because the Open Source stack below runs without a licence or an account. Happy to supply a hosted Enterprise project through the form if you would prefer that.*

## Notes

**License:** MIT.

**Image:** community-built as [`formio/uag`](https://hub.docker.com/r/formio/uag), published from CI on release for `linux/amd64` and `linux/arm64`. Also on npm as [`@formio/uag`](https://www.npmjs.com/package/@formio/uag) and in the official MCP Registry as `io.form/formio-uag`.

**Relationship to `formio`:** this is a second, distinct product, submitted separately in #4574. `formio` is a stdio server for *building* Form.io forms, resources, and roles from a coding agent. This one is a deployed runtime gateway for *filling and submitting* them — an agent reads a form's schema as markdown, collects data conversationally, and submits a validated record.

### Testing without credentials

The UAG connects to a Form.io deployment, so it needs a server to talk to. The quickest way to exercise it is the Open Source stack, which needs **no license and no account** — this is exactly how the accompanying `tools.json` was generated.

`docker-compose.yml`:

```yaml
services:
  mongo:
    image: mongo
  formio:
    image: formio/formio
    depends_on: [mongo]
    environment:
      NODE_CONFIG: '{"mongo":"mongodb://mongo:27017/formio-oss","jwt":{"secret":"CHANGEME"},"mongoSecret":"CHANGEME"}'
      ROOT_EMAIL: admin@example.com
      ROOT_PASSWORD: CHANGEME
      ADMIN_KEY: CHANGEME
      PORT: 3001
  formio-uag:
    image: formio/uag
    depends_on: [formio]
    ports: ['3200:3200']
    environment:
      PORT: 3200
      PROJECT: http://formio:3001
      ADMIN_KEY: CHANGEME
      JWT_SECRET: CHANGEME
      BASE_URL: http://localhost:3200
      PROJECT_TTL: 10
```

Then exchange the admin key for a token and call the MCP endpoint:

```bash
TOKEN=$(curl -s -X POST http://localhost:3200/auth/token \
  -H 'Content-Type: application/json' \
  -d '{"grant_type":"client_credentials","client_id":"formio-oss-x-admin-key","client_secret":"CHANGEME"}' \
  | jq -r .access_token)

curl -s -X POST http://localhost:3200/mcp \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
```

More complete stacks, including a conversational example and an agentic workflow, are in [`examples/`](https://github.com/formio/uag/tree/main/examples).

### Notes for the reviewer

**`tools.json` is included.** The UAG derives its runtime state from the Form.io project it is bound to, so a bare container has no project and cannot enumerate tools — unlike a self-contained stdio server. The committed `tools.json` was captured from `tools/list` on a running instance against the Open Source stack above, so it reflects real output rather than hand-written schemas.

**Required configuration** is `PROJECT`, `JWT_SECRET`, and `BASE_URL`. `BASE_URL` is worth calling out: the server starts without it, but it is published in the `.well-known` OIDC (PKCE) definitions and used for auth callbacks, so remote agents cannot authenticate when it is missing. `ADMIN_KEY` is for Open Source servers; `PROJECT_KEY` plus `UAG_LICENSE` for Enterprise projects.

Entry drafted with Claude Code, following the "Add server entry with Claude Code" flow in CONTRIBUTING.md, and verified with the repo's own `cmd/validate` and `cmd/build`.
