### PR TITLE
Add SoulSketch MCP server

### DIFF
--- a/servers/soulsketch/server.yaml
+++ b/servers/soulsketch/server.yaml
@@ -1,0 +1,51 @@
+name: soulsketch
+image: mcp/soulsketch
+type: server
+meta:
+  category: ai
+  tags:
+    - memory
+    - identity
+    - continuity
+    - ai
+    - portable
+    - privacy
+about:
+  title: SoulSketch
+  description: |
+    SoulSketch gives AI assistants portable, user-owned memory. Your assistant's
+    identity lives in a "memory pack": five plain Markdown/JSONL files (persona,
+    relationships, technical domains, voice, runtime observations) kept in a
+    private Git repo you control - your Soul-Sanctum - instead of a vendor
+    database.
+
+    Tools:
+    • soulsketch_read_pack - load an identity so the assistant "comes home"
+    • soulsketch_observe - append one observation line (the only write; append-only)
+    • soulsketch_validate_pack - health-check a 5-file memory pack
+    • soulsketch_fingerprint_pack - deterministic SHA-256 seal of the pack state
+    • soulsketch_diff_packs - which identity dimension changed between two packs
+    • soulsketch_continuity_record - fingerprint + provenance labels for audit
+
+    Five of the six tools are read-only; the sixth can only append. The server
+    is local-first with no network calls or telemetry, and only sees the
+    directory you mount.
+  icon: https://avatars.githubusercontent.com/u/100811071?v=4
+source:
+  project: https://github.com/bytewizard42i/soulSketch
+  commit: 3d6272fc88e8788f1e9d1f19dd4f53c5ae1b5875
+  dockerfile: packages/mcp-server/Dockerfile
+run:
+  volumes:
+    - "{{soulsketch.sanctum_path}}:/memories"
+  disableNetwork: true
+config:
+  description: Mount your Soul-Sanctum (the folder or repo holding your memory packs)
+  parameters:
+    type: object
+    properties:
+      sanctum_path:
+        type: string
+        default: /Users/local-test/soul-sanctum
+    required:
+      - sanctum_path


### PR DESCRIPTION
## MCP Server Information

**Server Name:** SoulSketch
**Repository URL:** https://github.com/bytewizard42i/soulSketch
**Brief Description:** Portable, user-owned AI memory packs. An assistant's identity (persona, relationships, technical context, voice, observations) lives in five plain Markdown/JSONL files in a private Git repo the user controls. Tools: read a pack (load an identity), append observations (append-only, the sole write), validate, deterministic SHA-256 fingerprints, per-dimension diff, and continuity/provenance records. Local-first: no network calls, no telemetry; `disableNetwork: true` in this entry.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP API specification (official TypeScript SDK, stdio transport); listed in the official MCP Registry as `io.github.bytewizard42i/soulsketch`
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Multi-stage Dockerfile at `packages/mcp-server/Dockerfile` (unprivileged user, works with networking disabled)
- [x] **Documentation**: README plus a plain-language guide at `docs/MCP_SERVER.md`
- [x] **Security Contact**: `SECURITY.md` in the repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name soulsketch` (all checks pass)
- [x] I have built the MCP Server using `task build -- --tools soulsketch` (image builds; 6 tools found)
- [x] No credentials are required to test: point the mounted volume at any folder containing a 5-file memory pack. A sanitized example pack is available at `examples/reference_memory_pack/` in the repository.