### PR TITLE
Add PulseFeed x402 Trust — verify x402 payment endpoints before an agent pays

### DIFF
--- a/servers/pulsefeed/server.yaml
+++ b/servers/pulsefeed/server.yaml
@@ -16,4 +16,4 @@ about:
 source:
   project: https://github.com/Nikolife2016/pulsefeed-x402
   branch: master
-  commit: 1ea83eff7da5d874f9cc450d7ff7ecdcc0dabe98
+  commit: 8675c8cd0eb0747eded3b7f68ec9cefa139267e3

--- a/servers/pulsefeed/server.yaml
+++ b/servers/pulsefeed/server.yaml
@@ -1,0 +1,19 @@
+name: pulsefeed
+image: mcp/pulsefeed
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - payments
+    - verification
+    - ai-agents
+    - x402
+about:
+  title: PulseFeed x402 Trust
+  description: Verify x402 payment endpoints before an AI agent pays them. PulseFeed continuously audits the x402 agent-payment ecosystem (~5k endpoints) and the MCP server ecosystem (950+ servers), and exposes 10 free tools - endpoint liveness and scam checks (payTo hijack, bait-and-switch, honeypot), trust-score leaderboard, live security incidents with on-chain proof, ecosystem stats and change feed, MCP server safety audits by npm package name. No API key required.
+  icon: https://www.google.com/s2/favicons?domain=pulsefeed.dev&sz=64
+source:
+  project: https://github.com/Nikolife2016/pulsefeed-x402
+  branch: master
+  commit: 1ea83eff7da5d874f9cc450d7ff7ecdcc0dabe98

--- a/servers/pulsefeed/server.yaml
+++ b/servers/pulsefeed/server.yaml
@@ -11,7 +11,7 @@ meta:
     - x402
 about:
   title: PulseFeed x402 Trust
-  description: Verify x402 payment endpoints before an AI agent pays them. PulseFeed continuously audits the x402 agent-payment ecosystem (~5k endpoints) and the MCP server ecosystem (950+ servers), and exposes 10 free tools - endpoint liveness and scam checks (payTo hijack, bait-and-switch, honeypot), trust-score leaderboard, live security incidents with on-chain proof, ecosystem stats and change feed, MCP server safety audits by npm package name. No API key required.
+  description: Verify x402 payment endpoints before an AI agent pays them. PulseFeed continuously audits the x402 agent-payment ecosystem (~5k endpoints) and the MCP server ecosystem (950+ servers), and exposes 10 free tools - endpoint liveness (reads the challenge from both the response body and the v2 PAYMENT-REQUIRED header) and anomaly checks (receiver-address changes between observations, catalog price vs. challenge price, invalid receiver, testnet listed as production, scheme outside the x402 spec), trust-score leaderboard, live security incidents with on-chain proof, ecosystem stats and change feed, MCP server safety audits by npm package name. No API key required.
   icon: https://www.google.com/s2/favicons?domain=pulsefeed.dev&sz=64
 source:
   project: https://github.com/Nikolife2016/pulsefeed-x402

--- a/servers/pulsefeed/tools.json
+++ b/servers/pulsefeed/tools.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "x402_working_services",
+    "description": "List x402 agent-payment services that are currently ALIVE and return a valid x402 challenge, ranked by trust score. About 85% of x402 endpoints are dead or invalid — use this to avoid paying broken or scam endpoints. Free.",
+    "arguments": []
+  },
+  {
+    "name": "check_x402_endpoint",
+    "description": "Before paying an unknown x402 endpoint, check whether it is live and returns a valid x402 payment challenge. Returns liveness, price, network and a pay/avoid verdict. For full uptime + reputation, use PulseFeed's paid /trust API.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "The x402 endpoint URL to verify"
+      }
+    ]
+  },
+  {
+    "name": "pulsefeed_products",
+    "description": "List PulseFeed's paid x402 products — real-time Base on-chain intelligence for AI agents: token pulse, whale alerts, smart-money accumulation/distribution, momentum, and the x402 trust oracle — and how to pay via x402.",
+    "arguments": []
+  },
+  {
+    "name": "x402_ecosystem_stats",
+    "description": "Live health of the entire x402 agent-payment ecosystem: how many endpoints are tracked/alive/dead, catalog accuracy audit (what share of 'healthy' listings actually work), scam-risk distribution and receiver-stability breakdown. Compact aggregates from PulseFeed's continuous independent audit. Free.",
+    "arguments": []
+  },
+  {
+    "name": "x402_leaderboard",
+    "description": "Top x402 services ranked by PulseFeed Trust Score (0-100, open standard): the most reliable live agent-payment endpoints right now, with price and network. Use to pick a trustworthy service to pay. Free.",
+    "arguments": []
+  },
+  {
+    "name": "x402_incidents",
+    "description": "Live security incidents in the x402 economy caught by PulseFeed's detector: receiver hijacks (payTo swapped), bait-and-switch pricing, honeypots, unverified receivers, price gouging — each with an on-chain proof URL. Check before paying anything. Free.",
+    "arguments": []
+  },
+  {
+    "name": "x402_changes",
+    "description": "What changed in the x402 ecosystem in the last 7 days: services that went dark, receiver (payTo) swaps — possible hijacks, price changes, recovered and newly-seen services. Derived from PulseFeed's compounding time-series (cannot be reconstructed after the fact). Free.",
+    "arguments": []
+  },
+  {
+    "name": "mcp_security_report",
+    "description": "State of MCP Security: how many audited MCP servers run an arbitrary install script on npm i, are abandoned, ship no repository or license — with day-over-day deltas and a sample of currently-flagged servers. From PulseFeed's daily MCP audit (950+ servers). Free.",
+    "arguments": []
+  },
+  {
+    "name": "mcp_check_server",
+    "description": "Before installing an MCP server, audit it by npm package name: does it run an install script (arbitrary code at npm i), is it abandoned, does it ship a repository/license, weekly downloads, provenance — verdict safe/caution/avoid. Free.",
+    "arguments": [
+      {
+        "name": "package",
+        "type": "string",
+        "desc": "npm package name of the MCP server, e.g. @scope/name"
+      }
+    ]
+  },
+  {
+    "name": "x402_data_sample",
+    "description": "FREE sample of the PulseFeed Data API: top-10 live x402 services as FULL records (compounding payTo/price history, scam flags, on-chain receiver profile), top-10 MCP servers with full audit profile, and 3 live incidents. The full cross-domain dataset is GET /data/full ($1 via x402). Free.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
Adds **PulseFeed x402 Trust** (`servers/pulsefeed/server.yaml`), local server built from the repository Dockerfile (Node 20, stdio, no env vars / secrets required).

**What it does:** trust & safety layer for the x402 agent-payment economy. 10 free tools: verify an x402 endpoint before paying (liveness + scam/anomaly scan: payTo hijack, bait-and-switch pricing, honeypot receivers, plus registry trust score), trust-score leaderboard of working services, live security incidents with on-chain proof, ecosystem stats/changes, State-of-MCP-Security report and per-package MCP server safety audit.

- Repo: https://github.com/Nikolife2016/pulsefeed-x402 (MIT, Dockerfile at root, builds & passes MCP introspection — 10 tools)
- Listed in awesome-mcp-servers and the Glama directory (claimed, quality A)
- No configuration: works out of the box, no API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)