### PR TITLE
chore: update pin for proxmox

### DIFF
--- a/servers/proxmox/server.yaml
+++ b/servers/proxmox/server.yaml
@@ -15,7 +15,7 @@ about:
 source:
   project: https://github.com/GethosTheWalrus/proxmox-mcp
   branch: main
-  commit: 798963b217b9928971fe7ada61bbce6b5e4bf4fc
+  commit: f1ae811b7ce37ed7055778465ed5410342915600
 config:
   description: Configure the connection to Proxmox VE
   secrets:

--- a/servers/proxmox/server.yaml
+++ b/servers/proxmox/server.yaml
@@ -15,7 +15,7 @@ about:
 source:
   project: https://github.com/GethosTheWalrus/proxmox-mcp
   branch: main
-  commit: f1ae811b7ce37ed7055778465ed5410342915600
+  commit: 4dd32f2b59ee5023e013b0defa3a5c41532ae1e2
 config:
   description: Configure the connection to Proxmox VE
   secrets:

--- a/servers/proxmox/server.yaml
+++ b/servers/proxmox/server.yaml
@@ -15,7 +15,7 @@ about:
 source:
   project: https://github.com/GethosTheWalrus/proxmox-mcp
   branch: main
-  commit: 060b7f5bbbf14bb69f1dac928f1566125e0b03b5
+  commit: 798963b217b9928971fe7ada61bbce6b5e4bf4fc
 config:
   description: Configure the connection to Proxmox VE
   secrets:

--- a/servers/proxmox/tools.json
+++ b/servers/proxmox/tools.json
@@ -1,0 +1,6062 @@
+[
+  {
+    "name": "change_password",
+    "description": "Change a user's password.",
+    "arguments": [
+      {
+        "name": "password",
+        "type": "string",
+        "desc": "New password."
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "create_group",
+    "description": "Create a new group.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": "Group ID."
+      }
+    ]
+  },
+  {
+    "name": "create_role",
+    "description": "Create a new role with specific privileges.",
+    "arguments": [
+      {
+        "name": "privs",
+        "type": "string",
+        "desc": "Comma-separated list of privileges (e.g. 'VM.Allocate,VM.Config.Disk,VM.PowerMgmt')."
+      },
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": "Role ID."
+      }
+    ]
+  },
+  {
+    "name": "create_user",
+    "description": "Create a new user.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Email address.",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": "Enable user.",
+        "optional": true
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": "Account expiration (Unix epoch, 0 = never).",
+        "optional": true
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": "First name.",
+        "optional": true
+      },
+      {
+        "name": "groups",
+        "type": "string",
+        "desc": "Comma-separated group list.",
+        "optional": true
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": "Last name.",
+        "optional": true
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": "Password (only for pve/pam realms).",
+        "optional": true
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm', e.g. 'myuser@pve')."
+      }
+    ]
+  },
+  {
+    "name": "create_user_token",
+    "description": "Create a new API token for a user. Returns the token value (shown only once).",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Token description.",
+        "optional": true
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": "Expiration (Unix epoch, 0 = never).",
+        "optional": true
+      },
+      {
+        "name": "privsep",
+        "type": "boolean",
+        "desc": "Enable privilege separation (token has own permissions, not user's full permissions).",
+        "optional": true
+      },
+      {
+        "name": "tokenid",
+        "type": "string",
+        "desc": "Token ID (alphanumeric)."
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "delete_group",
+    "description": "Delete a group.",
+    "arguments": [
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": "Group ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_role",
+    "description": "Delete a role.",
+    "arguments": [
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": "Role ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_user",
+    "description": "Delete a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID to delete (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "delete_user_token",
+    "description": "Delete an API token.",
+    "arguments": [
+      {
+        "name": "tokenid",
+        "type": "string",
+        "desc": "Token ID."
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "get_acl",
+    "description": "Get the full ACL (access control list) \u2014 shows all permission assignments."
+  },
+  {
+    "name": "get_auth_domain",
+    "description": "Get authentication domain configuration.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": "Realm ID (e.g. 'pam', 'pve', 'my-ldap')."
+      }
+    ]
+  },
+  {
+    "name": "get_group",
+    "description": "Get group details.",
+    "arguments": [
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": "Group ID."
+      }
+    ]
+  },
+  {
+    "name": "get_permissions",
+    "description": "Check effective permissions for a user on a given path.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Object path to check (empty = root).",
+        "optional": true
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User to check (empty = current user).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_role",
+    "description": "Get role details and its privileges.",
+    "arguments": [
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": "Role ID."
+      }
+    ]
+  },
+  {
+    "name": "get_user",
+    "description": "Get details for a specific user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm', e.g. 'admin@pam')."
+      }
+    ]
+  },
+  {
+    "name": "get_user_token",
+    "description": "Get details for a specific API token.",
+    "arguments": [
+      {
+        "name": "tokenid",
+        "type": "string",
+        "desc": "Token ID."
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "list_auth_domains",
+    "description": "List configured authentication realms/domains (PAM, PVE, LDAP, AD, OpenID)."
+  },
+  {
+    "name": "list_groups",
+    "description": "List all user groups."
+  },
+  {
+    "name": "list_roles",
+    "description": "List all available roles."
+  },
+  {
+    "name": "list_tfa",
+    "description": "List TFA (two-factor auth) entries.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "Filter by user ID (empty = all users).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_user_tokens",
+    "description": "List API tokens for a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "list_users",
+    "description": "List all users in Proxmox.",
+    "arguments": [
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Only show enabled users.",
+        "optional": true
+      },
+      {
+        "name": "full",
+        "type": "boolean",
+        "desc": "Include detailed info (groups, tokens, etc.).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "sync_auth_domain",
+    "description": "Sync users/groups from an external auth domain (LDAP/AD).",
+    "arguments": [
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": "Only show what would change.",
+        "optional": true
+      },
+      {
+        "name": "enable_new",
+        "type": "boolean",
+        "desc": "Enable newly synced users.",
+        "optional": true
+      },
+      {
+        "name": "full",
+        "type": "boolean",
+        "desc": "Full sync (not just incremental).",
+        "optional": true
+      },
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": "Realm ID to sync."
+      },
+      {
+        "name": "remove_vanished",
+        "type": "string",
+        "desc": "Comma-separated: 'entry' (remove users), 'properties' (clear), 'acl' (remove ACLs).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "update_acl",
+    "description": "Add or remove ACL entries (permission assignments).",
+    "arguments": [
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": "Remove the ACL entry instead of adding.",
+        "optional": true
+      },
+      {
+        "name": "groups",
+        "type": "string",
+        "desc": "Comma-separated group list.",
+        "optional": true
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "Object path (e.g. '/', '/vms/100', '/storage/local', '/pool/mypool')."
+      },
+      {
+        "name": "propagate",
+        "type": "boolean",
+        "desc": "Propagate permissions to child objects.",
+        "optional": true
+      },
+      {
+        "name": "roles",
+        "type": "string",
+        "desc": "Comma-separated role list."
+      },
+      {
+        "name": "tokens",
+        "type": "string",
+        "desc": "Comma-separated token list (format: 'user@realm!tokenid').",
+        "optional": true
+      },
+      {
+        "name": "users",
+        "type": "string",
+        "desc": "Comma-separated user list (format: 'user@realm').",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "update_group",
+    "description": "Update a group.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": "Group ID."
+      }
+    ]
+  },
+  {
+    "name": "update_role",
+    "description": "Update role privileges.",
+    "arguments": [
+      {
+        "name": "append",
+        "type": "boolean",
+        "desc": "Append privileges instead of replacing.",
+        "optional": true
+      },
+      {
+        "name": "privs",
+        "type": "string",
+        "desc": "Comma-separated list of privileges."
+      },
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": "Role ID."
+      }
+    ]
+  },
+  {
+    "name": "update_user",
+    "description": "Update an existing user.",
+    "arguments": [
+      {
+        "name": "append",
+        "type": "boolean",
+        "desc": "Append groups instead of replacing.",
+        "optional": true
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Email address.",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": "Enable/disable user.",
+        "optional": true
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": "Account expiration (Unix epoch, 0 = never, -1 = don't change).",
+        "optional": true
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": "First name.",
+        "optional": true
+      },
+      {
+        "name": "groups",
+        "type": "string",
+        "desc": "Comma-separated group list.",
+        "optional": true
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": "Last name.",
+        "optional": true
+      },
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": "User ID (format: 'user@realm')."
+      }
+    ]
+  },
+  {
+    "name": "create_backup_job",
+    "description": "Create a scheduled backup job.",
+    "arguments": [
+      {
+        "name": "all_guests",
+        "type": "boolean",
+        "desc": "Backup all guests.",
+        "optional": true
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "compress",
+        "type": "string",
+        "desc": "Compression: 'none', 'lzo', 'gzip', 'zstd'.",
+        "optional": true
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Enable the job.",
+        "optional": true
+      },
+      {
+        "name": "mailnotification",
+        "type": "string",
+        "desc": "'always' or 'failure'.",
+        "optional": true
+      },
+      {
+        "name": "mailto",
+        "type": "string",
+        "desc": "Comma-separated email addresses.",
+        "optional": true
+      },
+      {
+        "name": "maxfiles",
+        "type": "integer",
+        "desc": "Max backup files to keep (0 = unlimited, deprecated - use prune_backups).",
+        "optional": true
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": "Backup mode: 'snapshot', 'suspend', 'stop'.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "Only back up guests on this node.",
+        "optional": true
+      },
+      {
+        "name": "notes_template",
+        "type": "string",
+        "desc": "Template for backup notes.",
+        "optional": true
+      },
+      {
+        "name": "prune_backups",
+        "type": "string",
+        "desc": "Retention schedule (e.g. 'keep-daily=7,keep-weekly=4').",
+        "optional": true
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": "Schedule in systemd calendar format (e.g. 'daily', 'weekly', '02:00').",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage ID for backups."
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": "Comma-separated VMIDs to back up (if not all_guests).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_vzdump",
+    "description": "Start an immediate backup (vzdump) on a node.",
+    "arguments": [
+      {
+        "name": "all_guests",
+        "type": "boolean",
+        "desc": "Back up all guests on the node.",
+        "optional": true
+      },
+      {
+        "name": "compress",
+        "type": "string",
+        "desc": "Compression: 'none', 'lzo', 'gzip', 'zstd'.",
+        "optional": true
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": "Backup mode: 'snapshot', 'suspend', 'stop'.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node to run the backup on."
+      },
+      {
+        "name": "stdout",
+        "type": "boolean",
+        "desc": "Write to stdout instead of storage.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage (empty = default).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": "Comma-separated VMIDs (required if not all_guests).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "delete_backup_job",
+    "description": "Delete a scheduled backup job.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Backup job ID."
+      }
+    ]
+  },
+  {
+    "name": "download_file_restore",
+    "description": "Download a file from a vzdump backup.",
+    "arguments": [
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": "Path of the file to download from the backup."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Storage ID."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "Backup volume ID."
+      }
+    ]
+  },
+  {
+    "name": "get_backup_job",
+    "description": "Get details of a specific backup job.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Backup job ID."
+      }
+    ]
+  },
+  {
+    "name": "get_backup_job_included_volumes",
+    "description": "Get volumes included in a backup job.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Backup job ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vzdump_defaults",
+    "description": "Get the default vzdump configuration for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_vzdump_extractconfig",
+    "description": "Extract the guest configuration from a vzdump backup archive.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "Backup volume ID (e.g. 'local:backup/vzdump-qemu-100-2024_01_01-00_00_00.vma.zst')."
+      }
+    ]
+  },
+  {
+    "name": "list_backup_file_restore",
+    "description": "List files in a vzdump backup for single-file restore.",
+    "arguments": [
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": "Path within the backup (default '/').",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Storage ID."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "Backup volume ID."
+      }
+    ]
+  },
+  {
+    "name": "list_backup_jobs",
+    "description": "List all scheduled backup jobs (vzdump) in the cluster."
+  },
+  {
+    "name": "update_backup_job",
+    "description": "Update a scheduled backup job.",
+    "arguments": [
+      {
+        "name": "all_guests",
+        "type": "boolean",
+        "desc": "Backup all guests.",
+        "optional": true
+      },
+      {
+        "name": "compress",
+        "type": "string",
+        "desc": "Compression.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated properties to delete.",
+        "optional": true
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Enable/disable.",
+        "optional": true
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Backup job ID."
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": "Backup mode.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "Node filter.",
+        "optional": true
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": "Schedule in systemd calendar format.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage ID.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": "Comma-separated VMIDs.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "bulk_migrate_guests",
+    "description": "Bulk migrate guests to a target node.",
+    "arguments": [
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target node name."
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": "Comma-separated VMIDs.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "bulk_shutdown_guests",
+    "description": "Bulk shutdown guests across the cluster.",
+    "arguments": [
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": "Comma-separated list of VMIDs (empty = all).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "bulk_start_guests",
+    "description": "Bulk start guests across the cluster.",
+    "arguments": [
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": "Comma-separated list of VMIDs (empty = all).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_ceph_osd",
+    "description": "Create a new Ceph OSD on a device.",
+    "arguments": [
+      {
+        "name": "db_dev",
+        "type": "string",
+        "desc": "Separate block device for DB.",
+        "optional": true
+      },
+      {
+        "name": "dev",
+        "type": "string",
+        "desc": "Block device for the OSD (e.g. '/dev/sdb')."
+      },
+      {
+        "name": "encrypted",
+        "type": "boolean",
+        "desc": "Encrypt the OSD.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "wal_dev",
+        "type": "string",
+        "desc": "Separate block device for WAL.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_ceph_pool",
+    "description": "Create a new Ceph pool.",
+    "arguments": [
+      {
+        "name": "application",
+        "type": "string",
+        "desc": "Pool application (rbd, cephfs, rgw).",
+        "optional": true
+      },
+      {
+        "name": "min_size",
+        "type": "integer",
+        "desc": "Minimum replicas for I/O (default 2).",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Pool name."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "pg_num",
+        "type": "integer",
+        "desc": "Number of placement groups (default 128).",
+        "optional": true
+      },
+      {
+        "name": "size",
+        "type": "integer",
+        "desc": "Number of replicas (default 3).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_replication_job",
+    "description": "Create a storage replication job.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": "Create disabled.",
+        "optional": true
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Job ID (format: GUEST-JOBNUM, e.g. '100-0')."
+      },
+      {
+        "name": "rate",
+        "type": "number",
+        "desc": "Rate limit in mbps.",
+        "optional": true
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": "Schedule in systemd calendar format (default '*/15' = every 15 min).",
+        "optional": true
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target node."
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Replication type (currently only 'local').",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "delete_replication_job",
+    "description": "Delete a replication job.",
+    "arguments": [
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force removal (skip cleanup).",
+        "optional": true
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Replication job ID."
+      },
+      {
+        "name": "keep",
+        "type": "boolean",
+        "desc": "Keep replicated data on target.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_ceph_config",
+    "description": "Get the raw Ceph configuration.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_ceph_crush_rules",
+    "description": "Get Ceph CRUSH rules.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_ceph_flags",
+    "description": "Get Ceph global flags (noout, noscrub, etc.)."
+  },
+  {
+    "name": "get_ceph_metadata",
+    "description": "Get Ceph metadata (versions, services across nodes)."
+  },
+  {
+    "name": "get_ceph_status_cluster",
+    "description": "Get Ceph cluster status (health, monitors, OSDs, PGs)."
+  },
+  {
+    "name": "get_ceph_status_node",
+    "description": "Get Ceph status from a specific node's perspective.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_cluster_config",
+    "description": "Get the current cluster configuration (corosync, nodes, join info)."
+  },
+  {
+    "name": "get_cluster_config_nodes",
+    "description": "List nodes configured in the cluster."
+  },
+  {
+    "name": "get_cluster_join_info",
+    "description": "Get info needed to join a node to this cluster."
+  },
+  {
+    "name": "get_cluster_log",
+    "description": "Get the cluster log (recent events).",
+    "arguments": [
+      {
+        "name": "max_entries",
+        "type": "integer",
+        "desc": "Max log entries.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_cluster_options",
+    "description": "Get datacenter/cluster-wide options (keyboard layout, console, language, etc.)."
+  },
+  {
+    "name": "get_cluster_resources",
+    "description": "List all resources across the cluster (VMs, containers, storage, nodes).",
+    "arguments": [
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Filter by type: 'vm', 'storage', 'node', 'sdn', 'pool' (empty = all).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_cluster_status",
+    "description": "Get cluster status (nodes online, quorum, HA state)."
+  },
+  {
+    "name": "get_cluster_tasks",
+    "description": "List recent tasks across all nodes in the cluster.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum number of tasks to return.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_cluster_totem",
+    "description": "Get the corosync totem configuration."
+  },
+  {
+    "name": "get_metric_server",
+    "description": "Get metric server configuration.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Metric server ID."
+      }
+    ]
+  },
+  {
+    "name": "get_next_vmid",
+    "description": "Get the next available VMID in the cluster.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "Specific VMID to check availability for (0 = auto-assign).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_replication_job",
+    "description": "Get a specific replication job configuration.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Replication job ID (format: GUEST-JOBNUM, e.g. '100-0')."
+      }
+    ]
+  },
+  {
+    "name": "get_version",
+    "description": "Get the Proxmox VE API version information."
+  },
+  {
+    "name": "join_cluster",
+    "description": "Join a node to an existing cluster.",
+    "arguments": [
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": "SSL fingerprint of the cluster node."
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force join even with warnings.",
+        "optional": true
+      },
+      {
+        "name": "hostname",
+        "type": "string",
+        "desc": "Hostname/IP of existing cluster node."
+      },
+      {
+        "name": "nodeid",
+        "type": "integer",
+        "desc": "Force specific node ID.",
+        "optional": true
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": "Root password of the cluster node."
+      }
+    ]
+  },
+  {
+    "name": "list_ceph_fs",
+    "description": "List CephFS filesystems.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_ceph_managers",
+    "description": "List Ceph managers.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_ceph_mds",
+    "description": "List Ceph metadata servers (MDS, for CephFS).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_ceph_monitors",
+    "description": "List Ceph monitors.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_ceph_osds",
+    "description": "List Ceph OSDs on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_ceph_pools",
+    "description": "List Ceph pools.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_dir_mappings",
+    "description": "List directory mappings."
+  },
+  {
+    "name": "list_metric_servers",
+    "description": "List configured metric servers (InfluxDB, Graphite)."
+  },
+  {
+    "name": "list_notification_endpoints",
+    "description": "List all configured notification endpoints (sendmail, gotify, smtp, webhook)."
+  },
+  {
+    "name": "list_notification_matchers",
+    "description": "List all notification matchers (rules that route notifications)."
+  },
+  {
+    "name": "list_notification_targets",
+    "description": "List all notification targets."
+  },
+  {
+    "name": "list_pci_mappings",
+    "description": "List PCI device mappings for passthrough."
+  },
+  {
+    "name": "list_realm_sync_jobs",
+    "description": "List realm synchronization jobs."
+  },
+  {
+    "name": "list_replication_jobs",
+    "description": "List all replication jobs in the cluster."
+  },
+  {
+    "name": "list_scheduled_jobs",
+    "description": "List all scheduled cluster jobs (realm-sync, etc.)."
+  },
+  {
+    "name": "list_usb_mappings",
+    "description": "List USB device mappings for passthrough."
+  },
+  {
+    "name": "set_ceph_flags",
+    "description": "Set a Ceph global flag.",
+    "arguments": [
+      {
+        "name": "flag",
+        "type": "string",
+        "desc": "Flag name (noout, noscrub, nobackfill, norebalance, nodown, noup, etc.)."
+      },
+      {
+        "name": "value",
+        "type": "boolean",
+        "desc": "True to set, False to unset."
+      }
+    ]
+  },
+  {
+    "name": "test_notification_target",
+    "description": "Send a test notification to a target.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Target name."
+      }
+    ]
+  },
+  {
+    "name": "update_cluster_options",
+    "description": "Update datacenter/cluster-wide options.",
+    "arguments": [
+      {
+        "name": "console",
+        "type": "string",
+        "desc": "Default console viewer: 'applet', 'vv', 'html5', 'xtermjs'.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated settings to delete.",
+        "optional": true
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Datacenter description.",
+        "optional": true
+      },
+      {
+        "name": "email_from",
+        "type": "string",
+        "desc": "Default email sender address.",
+        "optional": true
+      },
+      {
+        "name": "http_proxy",
+        "type": "string",
+        "desc": "HTTP proxy URL.",
+        "optional": true
+      },
+      {
+        "name": "keyboard",
+        "type": "string",
+        "desc": "Keyboard layout (e.g. 'en-us', 'de').",
+        "optional": true
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "desc": "Default language.",
+        "optional": true
+      },
+      {
+        "name": "max_workers",
+        "type": "integer",
+        "desc": "Max parallel workers.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "add_firewall_ipset_entry",
+    "description": "Add an IP/CIDR to an IP set.",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": "IP address or CIDR."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "IP set name."
+      },
+      {
+        "name": "nomatch",
+        "type": "boolean",
+        "desc": "Exclude this entry (nomatch).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_cluster_firewall_rule",
+    "description": "Create a cluster-level firewall rule.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "'ACCEPT', 'DROP', 'REJECT'."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": "Destination address/range.",
+        "optional": true
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": "Destination port(s).",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enabled, 0 = disabled.",
+        "optional": true
+      },
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": "Network interface.",
+        "optional": true
+      },
+      {
+        "name": "log",
+        "type": "string",
+        "desc": "Log level: 'emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug', 'nolog'.",
+        "optional": true
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": "Use predefined macro (e.g. 'SSH', 'HTTP', 'HTTPS', 'Ping').",
+        "optional": true
+      },
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": "Rule position (-1 = append).",
+        "optional": true
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": "Protocol (tcp, udp, icmp, etc.).",
+        "optional": true
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "Source address/range (CIDR or alias).",
+        "optional": true
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": "Source port(s).",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "'in', 'out', 'group'."
+      }
+    ]
+  },
+  {
+    "name": "create_container_firewall_rule",
+    "description": "Create a firewall rule for an LXC container.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "'ACCEPT', 'DROP', 'REJECT'."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": "Destination CIDR or alias.",
+        "optional": true
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": "Destination port(s).",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enabled, 0 = disabled.",
+        "optional": true
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": "Predefined macro.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": "Protocol.",
+        "optional": true
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "Source CIDR or alias.",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "'in', 'out', 'group'."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "create_firewall_alias",
+    "description": "Create a firewall alias (named IP address or CIDR).",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": "IP address or CIDR (e.g. '10.0.0.0/24' or '192.168.1.1')."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Alias name."
+      }
+    ]
+  },
+  {
+    "name": "create_firewall_group",
+    "description": "Create a new firewall security group.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Group name."
+      }
+    ]
+  },
+  {
+    "name": "create_firewall_group_rule",
+    "description": "Add a rule to a firewall security group.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "'ACCEPT', 'DROP', 'REJECT'."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": "Destination address/range.",
+        "optional": true
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": "Destination port(s).",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enabled, 0 = disabled.",
+        "optional": true
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Security group name."
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": "Predefined macro.",
+        "optional": true
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": "Protocol.",
+        "optional": true
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "Source address/range.",
+        "optional": true
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": "Source port(s).",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "'in', 'out'."
+      }
+    ]
+  },
+  {
+    "name": "create_firewall_ipset",
+    "description": "Create a new firewall IP set.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "IP set name."
+      }
+    ]
+  },
+  {
+    "name": "create_vm_firewall_rule",
+    "description": "Create a firewall rule for a QEMU VM.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "'ACCEPT', 'DROP', 'REJECT'."
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": "Destination CIDR or alias.",
+        "optional": true
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": "Destination port(s).",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enabled, 0 = disabled.",
+        "optional": true
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": "Predefined macro.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": "Protocol.",
+        "optional": true
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "Source CIDR or alias.",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "'in', 'out', 'group'."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_cluster_firewall_rule",
+    "description": "Delete a cluster-level firewall rule.",
+    "arguments": [
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": "Rule position to delete."
+      }
+    ]
+  },
+  {
+    "name": "delete_firewall_alias",
+    "description": "Delete a firewall alias.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Alias name."
+      }
+    ]
+  },
+  {
+    "name": "delete_firewall_ipset_entry",
+    "description": "Remove an IP/CIDR from an IP set.",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": "IP address or CIDR to remove."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "IP set name."
+      }
+    ]
+  },
+  {
+    "name": "get_cluster_firewall_options",
+    "description": "Get cluster-wide firewall options (enable, policy_in, policy_out, etc.)."
+  },
+  {
+    "name": "get_cluster_firewall_rule",
+    "description": "Get a specific cluster firewall rule.",
+    "arguments": [
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": "Rule position number."
+      }
+    ]
+  },
+  {
+    "name": "get_container_firewall_options",
+    "description": "Get firewall options for an LXC container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_firewall_group_rules",
+    "description": "List rules in a firewall security group.",
+    "arguments": [
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Security group name."
+      }
+    ]
+  },
+  {
+    "name": "get_firewall_refs",
+    "description": "Get available firewall references (aliases, ipsets, names usable in rules)."
+  },
+  {
+    "name": "get_node_firewall_log",
+    "description": "Get firewall log for a node.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Max entries.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_firewall_options",
+    "description": "Get firewall options for a specific node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_firewall_options",
+    "description": "Get firewall options for a QEMU VM.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "list_cluster_firewall_rules",
+    "description": "List cluster-level firewall rules."
+  },
+  {
+    "name": "list_container_firewall_rules",
+    "description": "List firewall rules for an LXC container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "list_firewall_aliases",
+    "description": "List cluster firewall aliases (named IP addresses/ranges)."
+  },
+  {
+    "name": "list_firewall_groups",
+    "description": "List firewall security groups (reusable sets of rules)."
+  },
+  {
+    "name": "list_firewall_ipset_entries",
+    "description": "List entries in a firewall IP set.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "IP set name."
+      }
+    ]
+  },
+  {
+    "name": "list_firewall_ipsets",
+    "description": "List cluster firewall IP sets (named groups of IPs)."
+  },
+  {
+    "name": "list_firewall_macros",
+    "description": "List available firewall macros (predefined rule sets like SSH, HTTP, etc.)."
+  },
+  {
+    "name": "list_node_firewall_rules",
+    "description": "List firewall rules for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_vm_firewall_rules",
+    "description": "List firewall rules for a QEMU VM.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "set_cluster_firewall_options",
+    "description": "Set cluster-wide firewall options.",
+    "arguments": [
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated options to delete.",
+        "optional": true
+      },
+      {
+        "name": "ebtables",
+        "type": "integer",
+        "desc": "1 to enable ebtables rules, 0 to disable, -1 to not change.",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 to enable, 0 to disable, -1 to not change.",
+        "optional": true
+      },
+      {
+        "name": "log_ratelimit",
+        "type": "string",
+        "desc": "Log rate limit (e.g. 'enable=1,rate=1/second,burst=5').",
+        "optional": true
+      },
+      {
+        "name": "policy_in",
+        "type": "string",
+        "desc": "Default input policy: 'ACCEPT', 'REJECT', 'DROP'.",
+        "optional": true
+      },
+      {
+        "name": "policy_out",
+        "type": "string",
+        "desc": "Default output policy: 'ACCEPT', 'REJECT', 'DROP'.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "set_node_firewall_options",
+    "description": "Set firewall options for a node.",
+    "arguments": [
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated options to delete.",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enable, 0 = disable, -1 = don't change.",
+        "optional": true
+      },
+      {
+        "name": "log_level_in",
+        "type": "string",
+        "desc": "Input log level.",
+        "optional": true
+      },
+      {
+        "name": "log_level_out",
+        "type": "string",
+        "desc": "Output log level.",
+        "optional": true
+      },
+      {
+        "name": "ndp",
+        "type": "integer",
+        "desc": "1 = enable NDP, 0 = disable, -1 = don't change.",
+        "optional": true
+      },
+      {
+        "name": "nf_conntrack_max",
+        "type": "integer",
+        "desc": "Max conntrack entries (0 = don't change).",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "set_vm_firewall_options",
+    "description": "Set firewall options for a QEMU VM.",
+    "arguments": [
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated options to delete.",
+        "optional": true
+      },
+      {
+        "name": "dhcp",
+        "type": "integer",
+        "desc": "1 = enable DHCP.",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enable, 0 = disable.",
+        "optional": true
+      },
+      {
+        "name": "ipfilter",
+        "type": "integer",
+        "desc": "1 = enable IP filter.",
+        "optional": true
+      },
+      {
+        "name": "macfilter",
+        "type": "integer",
+        "desc": "1 = enable MAC filter.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "policy_in",
+        "type": "string",
+        "desc": "Input policy.",
+        "optional": true
+      },
+      {
+        "name": "policy_out",
+        "type": "string",
+        "desc": "Output policy.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "update_cluster_firewall_rule",
+    "description": "Update a cluster-level firewall rule.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "'ACCEPT', 'DROP', 'REJECT'.",
+        "optional": true
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated properties to delete.",
+        "optional": true
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": "Destination address/range.",
+        "optional": true
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": "Destination port(s).",
+        "optional": true
+      },
+      {
+        "name": "enable",
+        "type": "integer",
+        "desc": "1 = enabled, 0 = disabled, -1 = don't change.",
+        "optional": true
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": "Predefined macro.",
+        "optional": true
+      },
+      {
+        "name": "moveto",
+        "type": "integer",
+        "desc": "Move rule to this position.",
+        "optional": true
+      },
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": "Rule position to update."
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": "Protocol.",
+        "optional": true
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "Source address/range.",
+        "optional": true
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": "Source port(s).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_ha_group",
+    "description": "Create an HA group.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Group ID."
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": "Node list with optional priority (e.g. 'node1:2,node2:1' \u2014 higher = preferred)."
+      },
+      {
+        "name": "nofailback",
+        "type": "boolean",
+        "desc": "If true, don't fail back to higher-priority nodes once recovered.",
+        "optional": true
+      },
+      {
+        "name": "restricted",
+        "type": "boolean",
+        "desc": "Only run on nodes in this group (otherwise runs anywhere but prefers group nodes).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_ha_resource",
+    "description": "Add a resource to HA management.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "HA group name.",
+        "optional": true
+      },
+      {
+        "name": "max_relocate",
+        "type": "integer",
+        "desc": "Max relocations on failure.",
+        "optional": true
+      },
+      {
+        "name": "max_restart",
+        "type": "integer",
+        "desc": "Max restarts on failure.",
+        "optional": true
+      },
+      {
+        "name": "sid",
+        "type": "string",
+        "desc": "Resource ID (format: 'type:vmid', e.g. 'vm:100' or 'ct:101')."
+      },
+      {
+        "name": "state",
+        "type": "string",
+        "desc": "Desired state: 'started', 'stopped', 'enabled', 'disabled', 'ignored'.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "delete_ha_group",
+    "description": "Delete an HA group.",
+    "arguments": [
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Group ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_ha_resource",
+    "description": "Remove a resource from HA management.",
+    "arguments": [
+      {
+        "name": "sid",
+        "type": "string",
+        "desc": "Resource ID (format: 'type:vmid')."
+      }
+    ]
+  },
+  {
+    "name": "get_ha_group",
+    "description": "Get HA group configuration.",
+    "arguments": [
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Group ID."
+      }
+    ]
+  },
+  {
+    "name": "get_ha_manager_status",
+    "description": "Get detailed HA manager status."
+  },
+  {
+    "name": "get_ha_resource",
+    "description": "Get HA resource configuration.",
+    "arguments": [
+      {
+        "name": "sid",
+        "type": "string",
+        "desc": "HA resource ID (format: 'type:vmid', e.g. 'vm:100' or 'ct:101')."
+      }
+    ]
+  },
+  {
+    "name": "get_ha_status",
+    "description": "Get HA manager status (active, quorum, manager status)."
+  },
+  {
+    "name": "list_ha_groups",
+    "description": "List HA groups (define which nodes can run HA resources)."
+  },
+  {
+    "name": "list_ha_resources",
+    "description": "List all HA-managed resources."
+  },
+  {
+    "name": "migrate_ha_resource",
+    "description": "Request migration of an HA resource to a different node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "Target node."
+      },
+      {
+        "name": "sid",
+        "type": "string",
+        "desc": "Resource ID."
+      }
+    ]
+  },
+  {
+    "name": "relocate_ha_resource",
+    "description": "Request relocation of an HA resource to a different node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "Target node."
+      },
+      {
+        "name": "sid",
+        "type": "string",
+        "desc": "Resource ID."
+      }
+    ]
+  },
+  {
+    "name": "update_ha_group",
+    "description": "Update an HA group.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated properties to delete.",
+        "optional": true
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "Group ID."
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": "Node list with optional priority.",
+        "optional": true
+      },
+      {
+        "name": "nofailback",
+        "type": "boolean",
+        "desc": "Don't fail back.",
+        "optional": true
+      },
+      {
+        "name": "restricted",
+        "type": "boolean",
+        "desc": "Only run on group nodes.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "update_ha_resource",
+    "description": "Update an HA resource configuration.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated properties to delete.",
+        "optional": true
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": "HA group name.",
+        "optional": true
+      },
+      {
+        "name": "max_relocate",
+        "type": "integer",
+        "desc": "Max relocations (-1 = don't change).",
+        "optional": true
+      },
+      {
+        "name": "max_restart",
+        "type": "integer",
+        "desc": "Max restarts (-1 = don't change).",
+        "optional": true
+      },
+      {
+        "name": "sid",
+        "type": "string",
+        "desc": "Resource ID."
+      },
+      {
+        "name": "state",
+        "type": "string",
+        "desc": "Desired state.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "clone_container",
+    "description": "Clone a container.",
+    "arguments": [
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "full",
+        "type": "boolean",
+        "desc": "Full clone (True) or linked clone (False).",
+        "optional": true
+      },
+      {
+        "name": "hostname",
+        "type": "string",
+        "desc": "Hostname for the clone.",
+        "optional": true
+      },
+      {
+        "name": "newid",
+        "type": "integer",
+        "desc": "ID for the new container."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The source node name."
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": "Resource pool.",
+        "optional": true
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot to clone from.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage for full clone.",
+        "optional": true
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target node (default: same node).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The source container ID."
+      }
+    ]
+  },
+  {
+    "name": "convert_container_to_template",
+    "description": "Convert a container into a template (irreversible).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "create_container",
+    "description": "Create a new LXC container.",
+    "arguments": [
+      {
+        "name": "cores",
+        "type": "integer",
+        "desc": "CPU cores (default 1).",
+        "optional": true
+      },
+      {
+        "name": "cpulimit",
+        "type": "number",
+        "desc": "CPU limit (0 = unlimited).",
+        "optional": true
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Container description.",
+        "optional": true
+      },
+      {
+        "name": "features",
+        "type": "string",
+        "desc": "Comma-separated features (e.g. 'nesting=1,keyctl=1').",
+        "optional": true
+      },
+      {
+        "name": "hostname",
+        "type": "string",
+        "desc": "Container hostname.",
+        "optional": true
+      },
+      {
+        "name": "memory",
+        "type": "integer",
+        "desc": "Memory in MB (default 512).",
+        "optional": true
+      },
+      {
+        "name": "mp0",
+        "type": "string",
+        "desc": "Mount point (e.g. 'local-lvm:4,mp=/mnt/data').",
+        "optional": true
+      },
+      {
+        "name": "nameserver",
+        "type": "string",
+        "desc": "DNS nameserver.",
+        "optional": true
+      },
+      {
+        "name": "net0",
+        "type": "string",
+        "desc": "Network config (e.g. 'name=eth0,bridge=vmbr0,ip=dhcp').",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "onboot",
+        "type": "boolean",
+        "desc": "Start on host boot.",
+        "optional": true
+      },
+      {
+        "name": "ostemplate",
+        "type": "string",
+        "desc": "Template volume (e.g. 'local:vztmpl/debian-12-standard_12.2-1_amd64.tar.zst')."
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": "Root password.",
+        "optional": true
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": "Resource pool.",
+        "optional": true
+      },
+      {
+        "name": "rootfs",
+        "type": "string",
+        "desc": "Root filesystem spec (e.g. 'local-lvm:8' for 8GB).",
+        "optional": true
+      },
+      {
+        "name": "searchdomain",
+        "type": "string",
+        "desc": "DNS search domain.",
+        "optional": true
+      },
+      {
+        "name": "ssh_public_keys",
+        "type": "string",
+        "desc": "SSH public keys (newline delimited).",
+        "optional": true
+      },
+      {
+        "name": "start",
+        "type": "boolean",
+        "desc": "Start after creation.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Storage for rootfs (default 'local').",
+        "optional": true
+      },
+      {
+        "name": "swap",
+        "type": "integer",
+        "desc": "Swap in MB (default 512).",
+        "optional": true
+      },
+      {
+        "name": "tags",
+        "type": "string",
+        "desc": "Tags for the container.",
+        "optional": true
+      },
+      {
+        "name": "unprivileged",
+        "type": "boolean",
+        "desc": "Create an unprivileged container (default True, recommended).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "create_container_snapshot",
+    "description": "Create a snapshot of a container.",
+    "arguments": [
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Snapshot description.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_container",
+    "description": "Delete a container. Must be stopped first unless force=True.",
+    "arguments": [
+      {
+        "name": "destroy_unreferenced_disks",
+        "type": "boolean",
+        "desc": "Destroy unreferenced disks.",
+        "optional": true
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force destroy even if running.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "purge",
+        "type": "boolean",
+        "desc": "Remove from replication, HA, backup and ACLs too.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_container_snapshot",
+    "description": "Delete a container snapshot.",
+    "arguments": [
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force delete.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_container_config",
+    "description": "Get the configuration of a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_container_feature",
+    "description": "Check if a feature is available for a container (snapshot, clone, copy).",
+    "arguments": [
+      {
+        "name": "feature",
+        "type": "string",
+        "desc": "Feature to check ('snapshot', 'clone', 'copy')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_container_interfaces",
+    "description": "Get network interfaces and IPs of a running container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_container_pending",
+    "description": "Get pending configuration changes for a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_container_rrddata",
+    "description": "Get RRD statistics data for a container (CPU, memory, disk, network over time).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": "Time range: 'hour', 'day', 'week', 'month', 'year'.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "get_container_status",
+    "description": "Get the current runtime status of a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID (CTID)."
+      }
+    ]
+  },
+  {
+    "name": "list_container_snapshots",
+    "description": "List all snapshots of a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "list_containers",
+    "description": "List all LXC containers on a node with status, memory, CPU, and disk info.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "migrate_container",
+    "description": "Migrate a container to another node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The source node."
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": "Live migration.",
+        "optional": true
+      },
+      {
+        "name": "restart",
+        "type": "boolean",
+        "desc": "Restart container after migration (for non-live).",
+        "optional": true
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target node name."
+      },
+      {
+        "name": "target_storage",
+        "type": "string",
+        "desc": "Target storage mapping.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "move_container_volume",
+    "description": "Move a container volume to different storage or to another container.",
+    "arguments": [
+      {
+        "name": "delete_original",
+        "type": "boolean",
+        "desc": "Delete original after move.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage.",
+        "optional": true
+      },
+      {
+        "name": "target_vmid",
+        "type": "integer",
+        "desc": "Target container ID.",
+        "optional": true
+      },
+      {
+        "name": "target_volume",
+        "type": "string",
+        "desc": "Target volume slot.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "Volume name (e.g. 'rootfs', 'mp0')."
+      }
+    ]
+  },
+  {
+    "name": "reboot_container",
+    "description": "Reboot a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": "Timeout in seconds.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "resize_container_disk",
+    "description": "Resize a container disk/volume.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": "Disk name (e.g. 'rootfs', 'mp0')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "size",
+        "type": "string",
+        "desc": "New size or increment (e.g. '10G', '+2G')."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "resume_container",
+    "description": "Resume a suspended container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "rollback_container_snapshot",
+    "description": "Rollback a container to a previous snapshot.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "shutdown_container",
+    "description": "Gracefully shut down a container.",
+    "arguments": [
+      {
+        "name": "force_stop",
+        "type": "boolean",
+        "desc": "Force stop after timeout.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": "Timeout in seconds before force stop.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "start_container",
+    "description": "Start a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "stop_container",
+    "description": "Hard-stop a container (immediate, like power off).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "suspend_container",
+    "description": "Suspend (freeze) a container.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "update_container_config",
+    "description": "Update the configuration of an existing container.",
+    "arguments": [
+      {
+        "name": "cores",
+        "type": "integer",
+        "desc": "CPU cores.",
+        "optional": true
+      },
+      {
+        "name": "cpulimit",
+        "type": "number",
+        "desc": "CPU limit (0 = unlimited).",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated list of settings to delete.",
+        "optional": true
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "features",
+        "type": "string",
+        "desc": "Comma-separated features.",
+        "optional": true
+      },
+      {
+        "name": "hostname",
+        "type": "string",
+        "desc": "Container hostname.",
+        "optional": true
+      },
+      {
+        "name": "memory",
+        "type": "integer",
+        "desc": "Memory in MB.",
+        "optional": true
+      },
+      {
+        "name": "nameserver",
+        "type": "string",
+        "desc": "DNS nameserver.",
+        "optional": true
+      },
+      {
+        "name": "net0",
+        "type": "string",
+        "desc": "Network config.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "onboot",
+        "type": "boolean",
+        "desc": "Start on boot.",
+        "optional": true
+      },
+      {
+        "name": "searchdomain",
+        "type": "string",
+        "desc": "DNS search domain.",
+        "optional": true
+      },
+      {
+        "name": "swap",
+        "type": "integer",
+        "desc": "Swap in MB.",
+        "optional": true
+      },
+      {
+        "name": "tags",
+        "type": "string",
+        "desc": "Tags for the container.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The container ID."
+      }
+    ]
+  },
+  {
+    "name": "create_node_network_interface",
+    "description": "Create a network interface on a node.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "IP address (CIDR notation or IP).",
+        "optional": true
+      },
+      {
+        "name": "autostart",
+        "type": "boolean",
+        "desc": "Whether to start on boot.",
+        "optional": true
+      },
+      {
+        "name": "bridge_ports",
+        "type": "string",
+        "desc": "Bridge ports (for bridge type).",
+        "optional": true
+      },
+      {
+        "name": "comments",
+        "type": "string",
+        "desc": "Comments for the interface.",
+        "optional": true
+      },
+      {
+        "name": "gateway",
+        "type": "string",
+        "desc": "Default gateway.",
+        "optional": true
+      },
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": "Interface name (e.g. 'vmbr1')."
+      },
+      {
+        "name": "netmask",
+        "type": "string",
+        "desc": "Subnet mask.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Interface type (bridge, bond, eth, alias, vlan, OVSBridge, OVSPort, OVSIntPort, OVSBond)."
+      }
+    ]
+  },
+  {
+    "name": "download_appliance_template",
+    "description": "Download an appliance template to local storage.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage ID."
+      },
+      {
+        "name": "template",
+        "type": "string",
+        "desc": "Template name to download."
+      }
+    ]
+  },
+  {
+    "name": "get_disk_smart",
+    "description": "Get S.M.A.R.T. health data for a disk.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": "Disk device path (e.g. '/dev/sda')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_aplinfo",
+    "description": "List available appliance templates (LXC templates) that can be downloaded.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_apt_update",
+    "description": "List available package updates on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_capabilities_qemu",
+    "description": "Get QEMU capabilities for a node: supported CPU models, machine types, etc.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_config",
+    "description": "Get the configuration of a node (description, wakeonlan, etc.).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_disks",
+    "description": "List physical disks on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_dns",
+    "description": "Get DNS settings for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_hardware_pci",
+    "description": "List PCI hardware devices on a node (for passthrough).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_hardware_usb",
+    "description": "List USB hardware devices on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_hosts",
+    "description": "Get the /etc/hosts file content for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_journal",
+    "description": "Read systemd journal entries from a node.",
+    "arguments": [
+      {
+        "name": "lastentries",
+        "type": "integer",
+        "desc": "Max number of entries (default 50).",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "since",
+        "type": "string",
+        "desc": "Show entries since date/time.",
+        "optional": true
+      },
+      {
+        "name": "startcursor",
+        "type": "string",
+        "desc": "Start cursor for paging.",
+        "optional": true
+      },
+      {
+        "name": "until",
+        "type": "string",
+        "desc": "Show entries until date/time.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_node_netstat",
+    "description": "Get network statistics for a node (per-interface traffic).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_network",
+    "description": "Get network interface configuration for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_network_interface",
+    "description": "Get details for a specific network interface.",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": "Interface name (e.g. 'vmbr0', 'eth0')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_report",
+    "description": "Generate a system report for a node (useful for diagnostics).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_status",
+    "description": "Get detailed status of a specific node including CPU, memory, disk, uptime, and kernel info.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name (e.g. 'pve1')."
+      }
+    ]
+  },
+  {
+    "name": "get_node_storage_scan",
+    "description": "Scan for available storage targets (NFS, CIFS, iSCSI, LVM, ZFS, PBS).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "scan_type",
+        "type": "string",
+        "desc": "Type to scan: 'nfs', 'cifs', 'iscsi', 'lvm', 'lvmthin', 'zfs', 'pbs'."
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Server address (required for nfs, cifs, iscsi, pbs).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_node_subscription",
+    "description": "Get subscription status for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_syslog",
+    "description": "Read system log (syslog) entries from a node.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Max number of log lines to return (default 50).",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "since",
+        "type": "string",
+        "desc": "Only show entries since this date (YYYY-MM-DD).",
+        "optional": true
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": "Start line number.",
+        "optional": true
+      },
+      {
+        "name": "until",
+        "type": "string",
+        "desc": "Only show entries until this date (YYYY-MM-DD).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_node_time",
+    "description": "Get the current time and timezone of a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_node_version",
+    "description": "Get Proxmox VE version information for a specific node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_task_log",
+    "description": "Get log output of a specific task.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Max lines to return.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": "Start line number.",
+        "optional": true
+      },
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": "The task UPID string."
+      }
+    ]
+  },
+  {
+    "name": "get_task_status",
+    "description": "Get the status of a specific task by its UPID.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": "The task UPID string."
+      }
+    ]
+  },
+  {
+    "name": "list_node_services",
+    "description": "List all system services on a node (pve, ssh, cron, etc.).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_node_tasks",
+    "description": "List recent tasks on a node.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Max tasks to return (default 50).",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": "Offset for paging.",
+        "optional": true
+      },
+      {
+        "name": "statusfilter",
+        "type": "string",
+        "desc": "Filter by status ('running', 'ok', 'error', etc.).",
+        "optional": true
+      },
+      {
+        "name": "typefilter",
+        "type": "string",
+        "desc": "Filter by task type (e.g. 'qmstart', 'vzstart', 'vzcreate').",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "Filter by VM ID (0 = all).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_nodes",
+    "description": "List all nodes in the Proxmox cluster with their status, CPU, memory, and uptime."
+  },
+  {
+    "name": "manage_node_service",
+    "description": "Start, stop, restart, or reload a system service on a node.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": "One of 'start', 'stop', 'restart', 'reload'."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": "Service name (e.g. 'pvedaemon', 'pveproxy', 'ssh', 'cron', 'postfix')."
+      }
+    ]
+  },
+  {
+    "name": "run_apt_update",
+    "description": "Refresh the package index on a node (apt update).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "startall_node",
+    "description": "Start all VMs and containers on a node (respecting boot order).",
+    "arguments": [
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force start even if already running.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": "Comma-separated list of VMIDs to start (empty = all).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "stop_task",
+    "description": "Stop (abort) a running task.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": "The task UPID string."
+      }
+    ]
+  },
+  {
+    "name": "stopall_node",
+    "description": "Stop all VMs and containers on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": "Comma-separated list of VMIDs to stop (empty = all).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "wakeonlan_node",
+    "description": "Send a Wake-on-LAN magic packet to a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "create_pool",
+    "description": "Create a resource pool.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": "Pool ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_pool",
+    "description": "Delete a resource pool.",
+    "arguments": [
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": "Pool ID."
+      }
+    ]
+  },
+  {
+    "name": "get_acme_account",
+    "description": "Get ACME account details.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Account name (default: 'default').",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_acme_directories",
+    "description": "List known ACME directory URLs."
+  },
+  {
+    "name": "get_acme_plugin",
+    "description": "Get ACME plugin configuration.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "Plugin ID."
+      }
+    ]
+  },
+  {
+    "name": "get_acme_tos",
+    "description": "Get the ACME Terms of Service URL."
+  },
+  {
+    "name": "get_node_certificates",
+    "description": "Get certificate info for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "get_pool",
+    "description": "Get pool configuration and members.",
+    "arguments": [
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": "Pool ID."
+      }
+    ]
+  },
+  {
+    "name": "list_acme_accounts",
+    "description": "List ACME (Let's Encrypt) accounts."
+  },
+  {
+    "name": "list_acme_plugins",
+    "description": "List ACME DNS challenge plugins."
+  },
+  {
+    "name": "list_pools",
+    "description": "List all resource pools."
+  },
+  {
+    "name": "order_node_certificate",
+    "description": "Order/renew ACME certificate for a node.",
+    "arguments": [
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force renewal even if not due.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "register_acme_account",
+    "description": "Register a new ACME account.",
+    "arguments": [
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": "Contact email address."
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": "ACME directory URL (empty = Let's Encrypt production).",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Account name.",
+        "optional": true
+      },
+      {
+        "name": "tos_url",
+        "type": "string",
+        "desc": "Terms of service URL to accept.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "update_pool",
+    "description": "Update a resource pool (add/remove members).",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": "If true, remove the specified vms/storage from the pool instead of adding.",
+        "optional": true
+      },
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": "Pool ID."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Comma-separated storage IDs to add/remove.",
+        "optional": true
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": "Comma-separated VMIDs to add/remove.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "clone_vm",
+    "description": "Clone a VM to create a new one. Can be a full copy or linked clone.",
+    "arguments": [
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Description for the clone.",
+        "optional": true
+      },
+      {
+        "name": "full",
+        "type": "boolean",
+        "desc": "Full clone (True) or linked clone (False).",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Name for the clone.",
+        "optional": true
+      },
+      {
+        "name": "newid",
+        "type": "integer",
+        "desc": "The VMID for the new clone."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The source node name."
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": "Resource pool.",
+        "optional": true
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot name to clone from.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage for full clone.",
+        "optional": true
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target node for the clone (default: same node).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The source VM ID."
+      }
+    ]
+  },
+  {
+    "name": "convert_vm_to_template",
+    "description": "Convert a VM into a template (irreversible).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "create_vm",
+    "description": "Create a new QEMU virtual machine.",
+    "arguments": [
+      {
+        "name": "agent",
+        "type": "string",
+        "desc": "QEMU guest agent: '1' to enable, 'enabled=1,fstrim_cloned_disks=1'.",
+        "optional": true
+      },
+      {
+        "name": "bios",
+        "type": "string",
+        "desc": "BIOS type: seabios, ovmf (UEFI).",
+        "optional": true
+      },
+      {
+        "name": "boot",
+        "type": "string",
+        "desc": "Boot order, for example scsi0 then ide2 then net0.",
+        "optional": true
+      },
+      {
+        "name": "cdrom",
+        "type": "string",
+        "desc": "CD-ROM ISO image path.",
+        "optional": true
+      },
+      {
+        "name": "cores",
+        "type": "integer",
+        "desc": "Number of CPU cores per socket (default 1).",
+        "optional": true
+      },
+      {
+        "name": "cpu",
+        "type": "string",
+        "desc": "CPU type (default 'host').",
+        "optional": true
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "VM description.",
+        "optional": true
+      },
+      {
+        "name": "ide2",
+        "type": "string",
+        "desc": "IDE device, often used for CD-ROM (e.g. 'local:iso/ubuntu.iso,media=cdrom').",
+        "optional": true
+      },
+      {
+        "name": "machine",
+        "type": "string",
+        "desc": "Machine type (e.g. 'q35', 'i440fx').",
+        "optional": true
+      },
+      {
+        "name": "memory",
+        "type": "integer",
+        "desc": "Memory in MB (default 2048).",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "VM name.",
+        "optional": true
+      },
+      {
+        "name": "net0",
+        "type": "string",
+        "desc": "Network device (e.g. 'virtio,bridge=vmbr0').",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "onboot",
+        "type": "boolean",
+        "desc": "Start on host boot.",
+        "optional": true
+      },
+      {
+        "name": "ostype",
+        "type": "string",
+        "desc": "OS type: l26 (Linux 2.6+), win10, win11, wxp, other, etc.",
+        "optional": true
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": "Resource pool to add the VM to.",
+        "optional": true
+      },
+      {
+        "name": "scsi0",
+        "type": "string",
+        "desc": "First SCSI disk (e.g. 'local-lvm:32' for 32GB on local-lvm).",
+        "optional": true
+      },
+      {
+        "name": "scsihw",
+        "type": "string",
+        "desc": "SCSI controller: virtio-scsi-single, virtio-scsi-pci, lsi, megasas, pvscsi.",
+        "optional": true
+      },
+      {
+        "name": "sockets",
+        "type": "integer",
+        "desc": "Number of CPU sockets (default 1).",
+        "optional": true
+      },
+      {
+        "name": "start",
+        "type": "boolean",
+        "desc": "Start the VM after creation.",
+        "optional": true
+      },
+      {
+        "name": "tags",
+        "type": "string",
+        "desc": "Tags for the VM.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID number."
+      }
+    ]
+  },
+  {
+    "name": "create_vm_snapshot",
+    "description": "Create a snapshot of a VM.",
+    "arguments": [
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Snapshot description.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      },
+      {
+        "name": "vmstate",
+        "type": "boolean",
+        "desc": "Include RAM state (for running VMs).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "delete_vm",
+    "description": "Delete a VM. The VM must be stopped first.",
+    "arguments": [
+      {
+        "name": "destroy_unreferenced_disks",
+        "type": "boolean",
+        "desc": "Also destroy unreferenced disks owned by the VM.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "purge",
+        "type": "boolean",
+        "desc": "Remove from replication, HA, backup jobs and ACLs too.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_vm_snapshot",
+    "description": "Delete a VM snapshot.",
+    "arguments": [
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": "Force delete even if snapshot is in use.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "Snapshot name to delete."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "dump_vm_cloudinit",
+    "description": "Dump the Cloud-Init generated config file (user-data, network-data, or meta-data).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Config type: 'user', 'network', or 'meta'.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_cloudinit",
+    "description": "Get Cloud-Init configuration for a VM.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_config",
+    "description": "Get the configuration of a VM.",
+    "arguments": [
+      {
+        "name": "current",
+        "type": "boolean",
+        "desc": "If True, return current (runtime) config. If False, return pending config.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_feature",
+    "description": "Check if a specific feature is available/supported for a VM (e.g. snapshot, clone, copy).",
+    "arguments": [
+      {
+        "name": "feature",
+        "type": "string",
+        "desc": "Feature to check ('snapshot', 'clone', 'copy')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_pending",
+    "description": "Get pending configuration changes for a VM (not yet applied).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_rrddata",
+    "description": "Get RRD statistics data for a VM (CPU, memory, disk, network over time).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": "Time range: 'hour', 'day', 'week', 'month', 'year'.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_snapshot_config",
+    "description": "Get the configuration stored in a VM snapshot.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "The snapshot name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_spiceproxy",
+    "description": "Create a SPICE proxy connection for a VM console.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_status",
+    "description": "Get the current runtime status of a VM (state, CPU, memory, disk, network, uptime).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_vm_vncproxy",
+    "description": "Create a VNC proxy connection ticket for a VM (for console access).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      },
+      {
+        "name": "websocket",
+        "type": "boolean",
+        "desc": "Use WebSocket connection.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_vm_snapshots",
+    "description": "List all snapshots of a VM.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "list_vms",
+    "description": "List all QEMU virtual machines on a node with status, memory, CPU, and disk info.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "migrate_vm",
+    "description": "Migrate a VM to another node in the cluster.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The source node."
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": "Live migration (True) or offline (False).",
+        "optional": true
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "Target node name."
+      },
+      {
+        "name": "targetstorage",
+        "type": "string",
+        "desc": "Target storage mapping for migration (e.g. 'local-lvm').",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      },
+      {
+        "name": "with_local_disks",
+        "type": "boolean",
+        "desc": "Migrate local disks as well.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "move_vm_disk",
+    "description": "Move a VM disk to different storage or attach to another VM.",
+    "arguments": [
+      {
+        "name": "delete_original",
+        "type": "boolean",
+        "desc": "Delete the original disk after moving.",
+        "optional": true
+      },
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": "Source disk name (e.g. 'scsi0')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Target storage ID (for moving to different storage).",
+        "optional": true
+      },
+      {
+        "name": "target_disk",
+        "type": "string",
+        "desc": "Target disk slot on the target VM.",
+        "optional": true
+      },
+      {
+        "name": "target_vmid",
+        "type": "integer",
+        "desc": "Target VM ID (for moving disk to another VM).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "reboot_vm",
+    "description": "Reboot a VM via ACPI.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": "Wait timeout in seconds.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "reset_vm",
+    "description": "Hard reset a VM (like pressing the reset button).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "resize_vm_disk",
+    "description": "Resize a VM disk. Can only grow, not shrink.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": "Disk name (e.g. 'scsi0', 'virtio0', 'ide0')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "size",
+        "type": "string",
+        "desc": "New size or size increment (e.g. '50G', '+10G')."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "resume_vm",
+    "description": "Resume a suspended/paused VM.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "rollback_vm_snapshot",
+    "description": "Rollback a VM to a previous snapshot (current state will be lost).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": "The snapshot name to rollback to."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "send_vm_key",
+    "description": "Send a key event to a VM (e.g. ctrl-alt-del).",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": "Key combination (e.g. 'ctrl-alt-delete')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "send_vm_monitor_command",
+    "description": "Send a QEMU monitor command to a VM (advanced/low-level).",
+    "arguments": [
+      {
+        "name": "command",
+        "type": "string",
+        "desc": "The QEMU monitor command."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "shutdown_vm",
+    "description": "Gracefully shut down a VM via ACPI. Falls back to hard stop after timeout if force_stop is true.",
+    "arguments": [
+      {
+        "name": "force_stop",
+        "type": "boolean",
+        "desc": "Force stop after timeout (default True).",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": "Timeout in seconds before force stop.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "start_vm",
+    "description": "Start a VM.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": "Timeout in seconds (0 = default).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "stop_vm",
+    "description": "Hard-stop a VM (like pulling the power plug). Prefer shutdown_vm for graceful stop.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "skiplock",
+        "type": "boolean",
+        "desc": "Ignore locks (requires root).",
+        "optional": true
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": "Wait timeout in seconds.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "suspend_vm",
+    "description": "Suspend a VM (pause execution or hibernate to disk).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "todisk",
+        "type": "boolean",
+        "desc": "If True, hibernate to disk. If False, pause in RAM.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "update_vm_cloudinit",
+    "description": "Set Cloud-Init parameters for a VM (user, password, SSH keys, network).",
+    "arguments": [
+      {
+        "name": "cipassword",
+        "type": "string",
+        "desc": "Cloud-Init password.",
+        "optional": true
+      },
+      {
+        "name": "ciuser",
+        "type": "string",
+        "desc": "Cloud-Init user name.",
+        "optional": true
+      },
+      {
+        "name": "ipconfig0",
+        "type": "string",
+        "desc": "IP config for first interface (e.g. 'ip=dhcp' or 'ip=10.0.0.5/24,gw=10.0.0.1').",
+        "optional": true
+      },
+      {
+        "name": "nameserver",
+        "type": "string",
+        "desc": "DNS nameserver IP.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "searchdomain",
+        "type": "string",
+        "desc": "DNS search domain.",
+        "optional": true
+      },
+      {
+        "name": "sshkeys",
+        "type": "string",
+        "desc": "SSH public keys (URL-encoded, newline delimited).",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "update_vm_config",
+    "description": "Update the configuration of an existing VM. Only provided parameters are changed.",
+    "arguments": [
+      {
+        "name": "agent",
+        "type": "string",
+        "desc": "Guest agent config.",
+        "optional": true
+      },
+      {
+        "name": "boot",
+        "type": "string",
+        "desc": "Boot order.",
+        "optional": true
+      },
+      {
+        "name": "cores",
+        "type": "integer",
+        "desc": "CPU cores per socket.",
+        "optional": true
+      },
+      {
+        "name": "cpu",
+        "type": "string",
+        "desc": "CPU type.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated list of settings to delete.",
+        "optional": true
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": "Description.",
+        "optional": true
+      },
+      {
+        "name": "hotplug",
+        "type": "string",
+        "desc": "Hotplug features (disk, network, usb, memory, cpu).",
+        "optional": true
+      },
+      {
+        "name": "memory",
+        "type": "integer",
+        "desc": "Memory in MB.",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "VM name.",
+        "optional": true
+      },
+      {
+        "name": "net0",
+        "type": "string",
+        "desc": "Network config.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "onboot",
+        "type": "boolean",
+        "desc": "Start on boot.",
+        "optional": true
+      },
+      {
+        "name": "sockets",
+        "type": "integer",
+        "desc": "CPU sockets.",
+        "optional": true
+      },
+      {
+        "name": "tags",
+        "type": "string",
+        "desc": "Tags for the VM.",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "vm_agent_exec",
+    "description": "Execute a command inside a VM via the QEMU Guest Agent.",
+    "arguments": [
+      {
+        "name": "command",
+        "type": "string",
+        "desc": "The command to execute."
+      },
+      {
+        "name": "input_data",
+        "type": "string",
+        "desc": "Data to pass to stdin.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "vm_agent_exec_status",
+    "description": "Get the status/result of a command previously executed via the guest agent.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "pid",
+        "type": "integer",
+        "desc": "The PID returned by the exec call."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "vm_agent_file_read",
+    "description": "Read a file from inside a VM via the guest agent.",
+    "arguments": [
+      {
+        "name": "file",
+        "type": "string",
+        "desc": "Absolute file path inside the guest."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "vm_agent_file_write",
+    "description": "Write content to a file inside a VM via the guest agent.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "File content to write."
+      },
+      {
+        "name": "file",
+        "type": "string",
+        "desc": "Absolute file path inside the guest."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "vm_agent_get_info",
+    "description": "Get various system information from a VM via the guest agent.",
+    "arguments": [
+      {
+        "name": "info_type",
+        "type": "string",
+        "desc": "Info to retrieve: 'get-osinfo', 'get-host-name', 'get-time',",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "vm_agent_set_password",
+    "description": "Set a user password inside a VM via the guest agent.",
+    "arguments": [
+      {
+        "name": "crypted",
+        "type": "boolean",
+        "desc": "If True, password is already encrypted.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": "The new password."
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "desc": "The username."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "The VM ID."
+      }
+    ]
+  },
+  {
+    "name": "apply_sdn_changes",
+    "description": "Apply pending SDN configuration changes to all nodes."
+  },
+  {
+    "name": "create_sdn_subnet",
+    "description": "Create a subnet for an SDN VNet.",
+    "arguments": [
+      {
+        "name": "dnszoneprefix",
+        "type": "string",
+        "desc": "DNS zone prefix.",
+        "optional": true
+      },
+      {
+        "name": "gateway",
+        "type": "string",
+        "desc": "Gateway IP.",
+        "optional": true
+      },
+      {
+        "name": "snat",
+        "type": "boolean",
+        "desc": "Enable SNAT.",
+        "optional": true
+      },
+      {
+        "name": "subnet",
+        "type": "string",
+        "desc": "Subnet CIDR (e.g. '10.0.0.0/24')."
+      },
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": "VNet ID."
+      }
+    ]
+  },
+  {
+    "name": "create_sdn_vnet",
+    "description": "Create an SDN VNet.",
+    "arguments": [
+      {
+        "name": "alias",
+        "type": "string",
+        "desc": "Display alias.",
+        "optional": true
+      },
+      {
+        "name": "tag",
+        "type": "integer",
+        "desc": "VLAN tag.",
+        "optional": true
+      },
+      {
+        "name": "vlanaware",
+        "type": "boolean",
+        "desc": "Enable VLAN-aware bridge.",
+        "optional": true
+      },
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": "VNet ID."
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": "Zone ID."
+      }
+    ]
+  },
+  {
+    "name": "create_sdn_zone",
+    "description": "Create an SDN zone.",
+    "arguments": [
+      {
+        "name": "bridge",
+        "type": "string",
+        "desc": "Bridge name.",
+        "optional": true
+      },
+      {
+        "name": "dns",
+        "type": "string",
+        "desc": "DNS plugin name.",
+        "optional": true
+      },
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": "IPAM plugin name.",
+        "optional": true
+      },
+      {
+        "name": "mtu",
+        "type": "integer",
+        "desc": "MTU.",
+        "optional": true
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": "Comma-separated node list.",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Zone type: 'simple', 'vlan', 'qinq', 'vxlan', 'evpn'."
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": "Zone ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_sdn_vnet",
+    "description": "Delete an SDN VNet.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": "VNet ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_sdn_zone",
+    "description": "Delete an SDN zone.",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": "Zone ID."
+      }
+    ]
+  },
+  {
+    "name": "get_sdn_controller",
+    "description": "Get SDN controller configuration.",
+    "arguments": [
+      {
+        "name": "controller",
+        "type": "string",
+        "desc": "Controller ID."
+      }
+    ]
+  },
+  {
+    "name": "get_sdn_ipam",
+    "description": "Get IPAM plugin configuration.",
+    "arguments": [
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": "IPAM ID."
+      }
+    ]
+  },
+  {
+    "name": "get_sdn_vnet",
+    "description": "Get SDN VNet configuration.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": "VNet ID."
+      }
+    ]
+  },
+  {
+    "name": "get_sdn_zone",
+    "description": "Get SDN zone configuration.",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": "Zone ID."
+      }
+    ]
+  },
+  {
+    "name": "list_sdn_controllers",
+    "description": "List SDN controllers (e.g. EVPN controller)."
+  },
+  {
+    "name": "list_sdn_dns",
+    "description": "List SDN DNS plugins."
+  },
+  {
+    "name": "list_sdn_ipams",
+    "description": "List IPAM (IP Address Management) plugins."
+  },
+  {
+    "name": "list_sdn_subnets",
+    "description": "List subnets for an SDN VNet.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": "VNet ID."
+      }
+    ]
+  },
+  {
+    "name": "list_sdn_vnets",
+    "description": "List SDN virtual networks (VNets)."
+  },
+  {
+    "name": "list_sdn_zones",
+    "description": "List SDN zones."
+  },
+  {
+    "name": "update_sdn_vnet",
+    "description": "Update an SDN VNet.",
+    "arguments": [
+      {
+        "name": "alias",
+        "type": "string",
+        "desc": "Display alias.",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated properties to delete.",
+        "optional": true
+      },
+      {
+        "name": "tag",
+        "type": "integer",
+        "desc": "VLAN tag (-1 = don't change).",
+        "optional": true
+      },
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": "VNet ID."
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": "Zone ID.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "allocate_storage_volume",
+    "description": "Allocate a new disk volume in storage.",
+    "arguments": [
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Volume name."
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Disk format (raw, qcow2, vmdk). Auto-detected if empty.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "size",
+        "type": "string",
+        "desc": "Volume size (e.g. '10G')."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "VM ID to associate with."
+      }
+    ]
+  },
+  {
+    "name": "create_directory_storage",
+    "description": "Create a directory-based storage mount from a device.",
+    "arguments": [
+      {
+        "name": "add_to_storage",
+        "type": "boolean",
+        "desc": "Auto-add as Proxmox storage.",
+        "optional": true
+      },
+      {
+        "name": "device",
+        "type": "string",
+        "desc": "Block device path."
+      },
+      {
+        "name": "filesystem",
+        "type": "string",
+        "desc": "Filesystem type (ext4, xfs).",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Storage name."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "create_lvm",
+    "description": "Create a new LVM volume group on a device.",
+    "arguments": [
+      {
+        "name": "add_to_storage",
+        "type": "boolean",
+        "desc": "Auto-add as Proxmox storage.",
+        "optional": true
+      },
+      {
+        "name": "device",
+        "type": "string",
+        "desc": "Block device path (e.g. '/dev/sdb')."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "VG name."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "create_lvmthin",
+    "description": "Create a new LVM thin pool.",
+    "arguments": [
+      {
+        "name": "add_to_storage",
+        "type": "boolean",
+        "desc": "Auto-add as Proxmox storage.",
+        "optional": true
+      },
+      {
+        "name": "device",
+        "type": "string",
+        "desc": "Block device path."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Thin pool name."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "create_storage",
+    "description": "Create a new storage pool configuration.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Comma-separated content types (images, rootdir, vztmpl, iso, backup, snippets, import).",
+        "optional": true
+      },
+      {
+        "name": "datastore",
+        "type": "string",
+        "desc": "PBS datastore name.",
+        "optional": true
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": "Create disabled.",
+        "optional": true
+      },
+      {
+        "name": "export",
+        "type": "string",
+        "desc": "NFS export path.",
+        "optional": true
+      },
+      {
+        "name": "maxfiles",
+        "type": "integer",
+        "desc": "Max backup files (0 = unlimited).",
+        "optional": true
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": "Restrict storage to these nodes (comma-separated).",
+        "optional": true
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": "File system path (for dir, nfs mounts).",
+        "optional": true
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": "Pool name (for Ceph RBD/CephFS, ZFS).",
+        "optional": true
+      },
+      {
+        "name": "portal",
+        "type": "string",
+        "desc": "iSCSI portal.",
+        "optional": true
+      },
+      {
+        "name": "prune_backups",
+        "type": "string",
+        "desc": "Backup retention policy.",
+        "optional": true
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": "Server IP/hostname (for nfs, cifs, iscsi, pbs, glusterfs, rbd, cephfs).",
+        "optional": true
+      },
+      {
+        "name": "shared",
+        "type": "boolean",
+        "desc": "Mark as shared storage.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "Storage ID."
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": "iSCSI target.",
+        "optional": true
+      },
+      {
+        "name": "thinpool",
+        "type": "string",
+        "desc": "LVM thin pool name (for lvmthin).",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Storage type: dir, lvm, lvmthin, zfspool, nfs, cifs, iscsi, rbd, cephfs, pbs, glusterfs, btrfs."
+      },
+      {
+        "name": "vgname",
+        "type": "string",
+        "desc": "LVM volume group name.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_zfs_pool",
+    "description": "Create a new ZFS pool.",
+    "arguments": [
+      {
+        "name": "add_to_storage",
+        "type": "boolean",
+        "desc": "Auto-add as Proxmox storage.",
+        "optional": true
+      },
+      {
+        "name": "ashift",
+        "type": "integer",
+        "desc": "ashift value (default 12).",
+        "optional": true
+      },
+      {
+        "name": "compression",
+        "type": "string",
+        "desc": "Compression (on, off, lz4, zstd, etc.).",
+        "optional": true
+      },
+      {
+        "name": "devices",
+        "type": "string",
+        "desc": "Space-separated device paths (e.g. '/dev/sdb /dev/sdc')."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Pool name."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "raidlevel",
+        "type": "string",
+        "desc": "RAID level: single, mirror, raid10, raidz, raidz2, raidz3, draid, draid2, draid3."
+      }
+    ]
+  },
+  {
+    "name": "delete_storage",
+    "description": "Delete a storage pool configuration (does not delete data on the backend).",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      }
+    ]
+  },
+  {
+    "name": "delete_storage_volume",
+    "description": "Delete a volume from storage.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "The volume ID."
+      }
+    ]
+  },
+  {
+    "name": "download_url_to_storage",
+    "description": "Download a file from a URL directly to storage (ISO, template, etc.).",
+    "arguments": [
+      {
+        "name": "checksum",
+        "type": "string",
+        "desc": "Expected checksum.",
+        "optional": true
+      },
+      {
+        "name": "checksum_algorithm",
+        "type": "string",
+        "desc": "Checksum algorithm (sha256, sha512, md5).",
+        "optional": true
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content type: 'iso', 'vztmpl'."
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Target filename."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "URL to download from."
+      }
+    ]
+  },
+  {
+    "name": "get_node_storage_status",
+    "description": "Get usage status of a storage pool on a node (total, used, available).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      }
+    ]
+  },
+  {
+    "name": "get_storage_config",
+    "description": "Get configuration of a specific storage pool.",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      }
+    ]
+  },
+  {
+    "name": "get_storage_rrddata",
+    "description": "Get RRD statistics for a storage pool (usage over time).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": "Time range: 'hour', 'day', 'week', 'month', 'year'.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_storage_volume_info",
+    "description": "Get details about a specific volume in storage.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "The volume ID."
+      }
+    ]
+  },
+  {
+    "name": "get_zfs_pool",
+    "description": "Get details of a ZFS pool.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "ZFS pool name."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "initialize_gpt",
+    "description": "Initialize a disk with GPT partition table (WARNING: destroys all data).",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": "Disk device path (e.g. '/dev/sdb')."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_directory_storage",
+    "description": "List directory-based storage mounts on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_file_restore",
+    "description": "List files in a backup volume for file-level restore (PBS backups).",
+    "arguments": [
+      {
+        "name": "filepath",
+        "type": "string",
+        "desc": "Path inside the backup to list (default '/').",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "volume",
+        "type": "string",
+        "desc": "The backup volume ID."
+      }
+    ]
+  },
+  {
+    "name": "list_lvm_volumes",
+    "description": "List LVM volume groups on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_lvmthin_pools",
+    "description": "List LVM thin pools on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_node_storage",
+    "description": "List storage pools available on a specific node with usage info.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Filter by content type (images, rootdir, vztmpl, iso, backup).",
+        "optional": true
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Only show enabled storage.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "list_storage",
+    "description": "List all configured storage pools at the datacenter level.",
+    "arguments": [
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": "Only show enabled storage (default True).",
+        "optional": true
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Filter by type (dir, lvm, lvmthin, zfspool, nfs, cifs, iscsi, rbd, cephfs, pbs, glusterfs, btrfs).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_storage_content",
+    "description": "List content of a storage pool (disk images, ISOs, templates, backups).",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Filter by type: 'images', 'rootdir', 'vztmpl', 'iso', 'backup', 'snippets'.",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "Filter by VM ID.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_zfs_pools",
+    "description": "List ZFS pools on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      }
+    ]
+  },
+  {
+    "name": "prune_storage_backups",
+    "description": "Prune (delete) old backups from storage according to retention policy.",
+    "arguments": [
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": "If True, only simulate (default True for safety).",
+        "optional": true
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "prune_backups",
+        "type": "string",
+        "desc": "Retention spec (e.g. 'keep-last=3,keep-daily=7,keep-weekly=4').",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Guest type filter ('qemu' or 'lxc').",
+        "optional": true
+      },
+      {
+        "name": "vmid",
+        "type": "integer",
+        "desc": "Filter by VM ID.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "update_storage",
+    "description": "Update an existing storage pool configuration.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content types (images, rootdir, vztmpl, iso, backup, snippets, import).",
+        "optional": true
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": "Comma-separated list of settings to delete.",
+        "optional": true
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": "Disable this storage.",
+        "optional": true
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": "Allowed nodes (comma-separated).",
+        "optional": true
+      },
+      {
+        "name": "prune_backups",
+        "type": "string",
+        "desc": "Backup retention policy.",
+        "optional": true
+      },
+      {
+        "name": "shared",
+        "type": "boolean",
+        "desc": "Mark as shared.",
+        "optional": true
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID to update."
+      }
+    ]
+  },
+  {
+    "name": "upload_to_storage",
+    "description": "Upload a file (ISO, template, etc.) to storage. Note: actual file upload must go through the HTTP API directly.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Content type: 'iso', 'vztmpl', 'snippets', 'import'."
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": "Target filename."
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": "The node name."
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": "The storage ID."
+      },
+      {
+        "name": "tmpfilename",
+        "type": "string",
+        "desc": "Temporary filename for the upload.",
+        "optional": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** proxmox
**Repository URL:** https://github.com/GethosTheWalrus/proxmox-mcp
**Brief Description:** Manage Proxmox VE infrastructure including virtual machines, containers, storage, networking, firewall rules, and high availability.

## Summary

- Update the Proxmox MCP source pin to the current main commit: 4dd32f2b59ee5023e013b0defa3a5c41532ae1e2
- Add servers/proxmox/tools.json generated from the upstream bundled tool manifest so registry validation can list tools without requiring live Proxmox credentials

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using task validate -- --name proxmox
- [x] I have built the MCP Server using task build -- --tools --pull-community proxmox
- [ ] If the server requires credentials to test it, I have shared test credentials using this form

## Verification

- task validate -- --name proxmox passed; existing non-fatal warning: icon is larger than 512x512
- task build -- --tools --pull-community proxmox passed; 285 tools found from tools.json
- task catalog -- proxmox passed
- go test ./... passed
- scripts/ci-validation.sh --changed-servers with servers/proxmox/server.yaml passed; all servers processed successfully
- python3 -m json.tool servers/proxmox/tools.json passed
- generated tools metadata check passed: 285 tools and all argument desc fields present
