### PR TITLE
Add Radar

### DIFF
--- a/servers/radar/server.yaml
+++ b/servers/radar/server.yaml
@@ -1,0 +1,35 @@
+name: radar
+image: mcp/radar
+type: server
+meta:
+  category: devops
+  tags:
+    - kubernetes
+    - devops
+    - observability
+about:
+  title: Radar
+  description: Explore and troubleshoot Kubernetes clusters. Exposes topology, resources, events, logs, Helm releases, GitOps state and Prometheus metrics as correlated MCP tools.
+  icon: https://avatars.githubusercontent.com/u/235391474?v=4
+source:
+  project: https://github.com/skyhook-io/radar
+  commit: 10edb98ecbee37754318caa94e41ec851aa61dc1
+config:
+  description: Configure the location of the host Kubernetes config file
+  parameters:
+    type: object
+    properties:
+      config_path:
+        description: the path to the host .kube/config
+        type: string
+    required:
+      - config_path
+  env:
+    - name: KUBECONFIG
+      example: /kubeconfig
+      value: /kubeconfig
+run:
+  volumes:
+    - "{{radar.config_path}}:/kubeconfig:ro"
+  command:
+    - "--mcp-catalog-stdio"


### PR DESCRIPTION
## What

Adds [Radar](https://github.com/skyhook-io/radar), an open-source Kubernetes UI with an MCP server built into the binary.

- **License:** Apache-2.0
- **Dockerfile:** present at repo root, image published at `ghcr.io/skyhook-io/radar`
- **Category:** devops

Radar exposes cluster topology, resources, events, logs, Helm releases, GitOps state and Prometheus metrics as correlated MCP tools, so an agent gets structured cluster context rather than parsing `kubectl` output. 28 tools total (22 read, 6 write; reads carry `ReadOnlyHint`, writes carry `DestructiveHint`).

## Verification done before submitting

Tested against `ghcr.io/skyhook-io/radar:1.8.6` locally:

- `--mcp-catalog-stdio` completes `initialize` (`serverInfo: radar 1.8.6`) and returns **28 tools** from `tools/list` over stdio, **without requiring a reachable cluster**. Radar ships this mode specifically for registries and inspectors, which is why the entry sets it in `run.command`.
- `KUBECONFIG=/kubeconfig` with the host config mounted read-only is honoured by the container (confirmed by the context name appearing in startup logs).
- The container's default HTTP mode also serves MCP on `:9280/mcp` (HTTP 200 on `initialize`), but the stdio catalog mode is the one appropriate for this registry.

## Note on the config

`config.parameters.config_path` follows the pattern used by `servers/kubernetes` and `servers/aks`: the user points it at their host `.kube/config`. Radar reads it via `KUBECONFIG=/kubeconfig`.

Happy to adjust the entry if you'd prefer it generated through `task create` instead, or if the stdio-vs-http choice should be expressed differently.