### PR TITLE
registry: add SavePinner MCP server

### DIFF
--- a/servers/savepinner/server.yaml
+++ b/servers/savepinner/server.yaml
@@ -1,0 +1,17 @@
+name: savepinner
+image: mcp/savepinner
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - pinterest
+    - url
+    - validation
+    - developer-tools
+about:
+  title: SavePinner
+  description: Parse, validate, classify, and normalize Pinterest URLs locally without network requests.
+  icon: https://www.google.com/s2/favicons?domain=savepinner.com&sz=64
+source:
+  project: https://github.com/jiankn/savepinner-mcp
+  commit: d6357749b995aa7dc399f8df87866ce1910828da


### PR DESCRIPTION
## MCP Server Information

**Server Name:** SavePinner
**Repository URL:** https://github.com/jiankn/savepinner-mcp
**Brief Description:** Local, read-only MCP tools that parse, validate, classify, and normalize Pinterest URLs without network requests.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements the MCP API with stdio transport
- [x] **Active Development**: Maintained source repository and CI
- [x] **Docker Artifact**: Multi-stage, non-root Dockerfile
- [x] **Documentation**: README includes npm, MCP client, and Docker usage
- [x] **Security Contact**: GitHub private vulnerability reporting is enabled and documented

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] `task validate -- --name savepinner` — delegated to the repository's pull-request CI because Docker and Go are unavailable on the submitter workstation
- [ ] `task build -- --tools savepinner` — delegated to the repository's pull-request CI; the source repository's Docker build has already passed in GitHub Actions
- [x] No credentials are required; all processing is local and no network requests are made
