### PR TITLE
Add LinkedIn MCP Local server

### DIFF
--- a/servers/linkedin-mcp-local/server.yaml
+++ b/servers/linkedin-mcp-local/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://raw.githubusercontent.com/prakharagarwal-dev/linkedin-mcp-server/main/assets/icon.png
 source:
   project: https://github.com/prakharagarwal-dev/linkedin-mcp-server
-  commit: b29d6707c548c1d17b3812c46260b16a0f52f3d2
+  commit: 0f147a960356eb8961e3bccccd64d761485735b8
 run:
   volumes:
     - "{{linkedin-mcp-local.data_path}}:/data/linkedin-mcp"

--- a/servers/linkedin-mcp-local/server.yaml
+++ b/servers/linkedin-mcp-local/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://raw.githubusercontent.com/prakharagarwal-dev/linkedin-mcp-server/main/assets/icon.png
 source:
   project: https://github.com/prakharagarwal-dev/linkedin-mcp-server
-  commit: 0f147a960356eb8961e3bccccd64d761485735b8
+  commit: 0e0d03e7078e4b79c274f6235874cf48a2f5471e
 run:
   volumes:
     - "{{linkedin-mcp-local.data_path}}:/data/linkedin-mcp"

--- a/servers/linkedin-mcp-local/server.yaml
+++ b/servers/linkedin-mcp-local/server.yaml
@@ -1,0 +1,68 @@
+name: linkedin-mcp-local
+image: mcp/linkedin-mcp-local
+type: server
+meta:
+  category: productivity
+  tags:
+    - automation
+    - linkedin
+    - model-context-protocol
+    - playwright
+    - python
+about:
+  title: LinkedIn Local
+  description: Typed, policy-enforced local LinkedIn capabilities over the visible web UI, with persistent browser authentication and confirmation-gated writes.
+  icon: https://raw.githubusercontent.com/prakharagarwal-dev/linkedin-mcp-server/main/assets/icon.png
+source:
+  project: https://github.com/prakharagarwal-dev/linkedin-mcp-server
+  commit: b29d6707c548c1d17b3812c46260b16a0f52f3d2
+run:
+  volumes:
+    - "{{linkedin-mcp-local.data_path}}:/data/linkedin-mcp"
+config:
+  description: Configure live LinkedIn access, a persistent browser profile directory, and explicit capability authorization. Create the profile first in an environment that can display Chromium, as described in the upstream README.
+  env:
+    - name: LINKEDIN_MCP_LIVE_ENABLED
+      example: "false"
+      value: "{{linkedin-mcp-local.live_enabled}}"
+    - name: LINKEDIN_MCP_BROWSER_HEADLESS
+      example: "true"
+      value: "{{linkedin-mcp-local.browser_headless}}"
+    - name: LINKEDIN_MCP_ALLOWED_SURFACES
+      example: '["job-search","job-detail","people-search","member-profile"]'
+      value: "{{linkedin-mcp-local.allowed_surfaces}}"
+    - name: LINKEDIN_MCP_ALLOWED_SCOPES
+      example: '["linkedin.jobs.search","linkedin.jobs.read","linkedin.people.search","linkedin.people.read"]'
+      value: "{{linkedin-mcp-local.allowed_scopes}}"
+    - name: LINKEDIN_MCP_ALLOWED_EFFECTS
+      example: '["read"]'
+      value: "{{linkedin-mcp-local.allowed_effects}}"
+  parameters:
+    type: object
+    properties:
+      data_path:
+        type: string
+        title: LinkedIn MCP data directory
+        description: Sensitive host directory containing the persistent Chromium profile and local attachment assets.
+      live_enabled:
+        type: boolean
+        title: Enable live LinkedIn access
+        default: false
+      browser_headless:
+        type: boolean
+        title: Run the authenticated capability browser headlessly
+        default: true
+      allowed_surfaces:
+        type: string
+        title: Authorized LinkedIn surfaces (JSON array)
+        default: '["job-search","job-detail","people-search","member-profile"]'
+      allowed_scopes:
+        type: string
+        title: Authorized LinkedIn capabilities (JSON array)
+        default: '["linkedin.jobs.search","linkedin.jobs.read","linkedin.people.search","linkedin.people.read"]'
+      allowed_effects:
+        type: string
+        title: Authorized effects (JSON array)
+        default: '["read"]'
+    required:
+      - data_path

--- a/servers/linkedin-mcp-local/server.yaml
+++ b/servers/linkedin-mcp-local/server.yaml
@@ -11,20 +11,17 @@ meta:
     - python
 about:
   title: LinkedIn Local
-  description: Typed, policy-enforced local LinkedIn capabilities over the visible web UI, with persistent browser authentication and confirmation-gated writes.
+  description: A LinkedIn MCP server to find jobs, search people, research companies, manage your network, publish and engage with posts, and read or send messages.
   icon: https://raw.githubusercontent.com/prakharagarwal-dev/linkedin-mcp-server/main/assets/icon.png
 source:
   project: https://github.com/prakharagarwal-dev/linkedin-mcp-server
-  commit: 0e0d03e7078e4b79c274f6235874cf48a2f5471e
+  commit: ca89f000423b4bbfd7d2b912bf54403631cf2770
 run:
   volumes:
     - "{{linkedin-mcp-local.data_path}}:/data/linkedin-mcp"
 config:
-  description: Configure live LinkedIn access, a persistent browser profile directory, and explicit capability authorization. Create the profile first in an environment that can display Chromium, as described in the upstream README.
+  description: Configure a persistent browser profile and optional capability restrictions. Create the profile first in an environment that can display Chromium, as described in the upstream README.
   env:
-    - name: LINKEDIN_MCP_LIVE_ENABLED
-      example: "false"
-      value: "{{linkedin-mcp-local.live_enabled}}"
     - name: LINKEDIN_MCP_BROWSER_HEADLESS
       example: "true"
       value: "{{linkedin-mcp-local.browser_headless}}"
@@ -44,10 +41,6 @@ config:
         type: string
         title: LinkedIn MCP data directory
         description: Sensitive host directory containing the persistent Chromium profile and local attachment assets.
-      live_enabled:
-        type: boolean
-        title: Enable live LinkedIn access
-        default: false
       browser_headless:
         type: boolean
         title: Run the authenticated capability browser headlessly


### PR DESCRIPTION
## MCP Server Information

**Server Name:** linkedin-mcp-local
**Repository URL:** https://github.com/prakharagarwal-dev/linkedin-mcp-server
**Brief Description:** A LinkedIn MCP server to find jobs, search people, research companies, manage your network, publish and engage with posts, and read or send messages.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Uses the official Python MCP SDK and stdio transport
- [x] **Active Development**: Current public release is v0.16.0
- [x] **Docker Artifact**: Dockerfile pinned to the v0.16.0 release commit
- [x] **Documentation**: README includes setup, authorization, container, and client configuration
- [x] **Security Contact**: SECURITY.md and GitHub private vulnerability reporting

## Submitter Checklist

- [x] This server meets the basic requirements listed above.
- [x] I understand this will undergo automated and manual review.
- [x] I validated the catalog entry with `GITHUB_TOKEN=... go run ./cmd/validate --name linkedin-mcp-local` after pinning commit `ca89f000423b4bbfd7d2b912bf54403631cf2770`.
- [x] Test credentials were not shared. LinkedIn authentication is an individual's persistent browser profile created through an interactive login. The server never accepts a LinkedIn password, and sharing reusable account session data would violate the project's security boundary.

## Notes

The catalog ID is `linkedin-mcp-local` because `linkedin-mcp-server` is already occupied by an unrelated project. The catalog mounts a user-selected sensitive data directory and defaults to a read-only Jobs-and-People capability subset. The persistent Chromium profile must first be created in an environment that can display the interactive LinkedIn login, as documented upstream.

## Verified Official MCP Registry record

- Active metadata: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.prakharagarwal-dev%2Flinkedin-mcp-server
- Canonical version: `0.16.0`
- Public OCI package: `ghcr.io/prakharagarwal-dev/linkedin-mcp-server:0.16.0`