### PR TITLE
Add AsDecided MCP server

### DIFF
--- a/servers/asdecided/server.yaml
+++ b/servers/asdecided/server.yaml
@@ -1,0 +1,36 @@
+name: asdecided
+image: mcp/asdecided
+type: server
+meta:
+  category: development
+  tags:
+    - decisions
+    - documentation
+    - local
+    - read-only
+about:
+  title: AsDecided
+  description: Read-only access to deterministic engineering decisions stored in a local repository.
+  icon: https://avatars.githubusercontent.com/u/293429901?v=4
+source:
+  project: https://github.com/asdecided/core
+  commit: a2d64f3ae30a5754cda9fd83596f40e5fc218c22
+  buildTarget: asdecided-mcp
+run:
+  command:
+    - --root
+    - /work
+  volumes:
+    - "{{asdecided.repository|volume-target}}:/work"
+  disableNetwork: true
+config:
+  description: Select the local repository whose AsDecided corpus the server may read
+  parameters:
+    type: object
+    properties:
+      repository:
+        type: string
+        description: Local repository containing the decisions corpus
+        default: /Users/local-test
+    required:
+      - repository

--- a/servers/asdecided/server.yaml
+++ b/servers/asdecided/server.yaml
@@ -14,7 +14,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/293429901?v=4
 source:
   project: https://github.com/asdecided/core
-  commit: a2d64f3ae30a5754cda9fd83596f40e5fc218c22
+  commit: dbd2d02e525e277c6928cd3f5a63dba9d126db7f
   buildTarget: asdecided-mcp
 run:
   command:


### PR DESCRIPTION
## MCP Server Information

**Server Name:** AsDecided  
**Repository URL:** https://github.com/asdecided/core  
**Brief Description:** Read-only MCP access to deterministic engineering decisions stored in a local repository.

## Basic Requirements

- [x] **Open Source**: Apache-2.0 licensed
- [x] **MCP Compliant**: Implements the MCP API over stdio
- [x] **Active Development**: Maintained with recent releases and commits
- [x] **Docker Artifact**: Multi-stage Dockerfile with a dedicated `asdecided-mcp` target
- [x] **Documentation**: README and MCP setup instructions are included in the source repository
- [x] **Security Contact**: Security reports are accepted through the repository security policy

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using the registry validator (`go run ./cmd/validate --name asdecided`)
- [x] I have rebuilt the MCP Server locally using the registry builder
- [x] The server requires no credentials

## Current release pin

The entry now pins AsDecided `v0.26.2` at immutable commit `dbd2d02e525e277c6928cd3f5a63dba9d126db7f`.

That release also publishes the native MCP image as `ghcr.io/asdecided/core:mcp-v0.26.2` and is listed in the official MCP Registry as `io.github.asdecided/core`. Docker's catalogue entry continues to use Docker's own build pipeline and `mcp/asdecided` namespace.

## Validation evidence

- `go test ./...`: passed.
- `go run ./cmd/validate --name asdecided`: passed all local-entry checks.
- Mechanical contribution preflight against current upstream `main`: passed; one intentional changed path.
- A fresh local registry build is blocked because Docker Desktop's daemon is not currently reachable. Upstream CI is the independent build gate; this is not reported as a local pass.

The server mounts one user-selected repository at `/work`, runs with networking disabled, and exposes only AsDecided's read-only MCP surface.
