### PR TITLE
Add Screenshot Scout MCP server

### DIFF
--- a/servers/screenshotscout/server.yaml
+++ b/servers/screenshotscout/server.yaml
@@ -1,0 +1,33 @@
+name: screenshotscout
+image: mcp/screenshotscout
+type: server
+meta:
+  category: web
+  tags:
+    - screenshotscout
+    - screenshots
+    - web
+    - pdf
+about:
+  title: Screenshot Scout
+  description: Capture screenshots of webpages as images or PDFs with Screenshot Scout.
+  icon: https://raw.githubusercontent.com/screenshotscout/screenshotscout-mcp/main/assets/icon-400.png
+source:
+  project: https://github.com/screenshotscout/screenshotscout-mcp
+  commit: 3448885566e7ace21d24d9057340a97cbcd2e7e4
+run:
+  allowHosts:
+    - api.screenshotscout.com:443
+config:
+  description: Configure Screenshot Scout API credentials.
+  secrets:
+    - name: screenshotscout.access_key
+      env: SCREENSHOTSCOUT_ACCESS_KEY
+      example: YOUR_ACCESS_KEY
+      description: Required access key from the Screenshot Scout API keys page.
+      required: true
+    - name: screenshotscout.secret_key
+      env: SCREENSHOTSCOUT_SECRET_KEY
+      example: YOUR_SECRET_KEY
+      description: Optional secret key for access keys that require signed requests.
+      required: false


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Screenshot Scout  
**Repository URL:** https://github.com/screenshotscout/screenshotscout-mcp  
**Brief Description:** Capture screenshots of webpages as images or PDFs with Screenshot Scout.

## Basic Requirements

- [x] **Open Source**: Uses the MIT license
- [x] **MCP Compliant**: Implements the MCP API specification
- [x] **Active Development**: The pinned source commit is current and maintained
- [x] **Docker Artifact**: The source repository contains a root Dockerfile
- [x] **Documentation**: The source repository contains setup and usage documentation
- [x] **Security Contact**: The source repository contains a SECURITY.md reporting policy

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using the repository validator (`go run ./cmd/validate --name screenshotscout`, the direct command behind the unavailable local `task` wrapper)
- [x] I have built the MCP Server using the repository builder (`go run ./cmd/build --tools --pull-community screenshotscout`, the direct command behind the unavailable local `task` wrapper)
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Validation

- The registry validator passed all checks.
- The pinned source build succeeded and discovered exactly one MCP tool.
- Registry Go tests passed.
- Local catalog generation succeeded.

Reviewer credentials were submitted through Docker's approved credential form and are not included in this pull request.
