### PR TITLE
Add Parseable MCP server

### DIFF
--- a/servers/parseable/server.yaml
+++ b/servers/parseable/server.yaml
@@ -1,0 +1,42 @@
+name: parseable
+image: quay.io/parseablehq/parseable-mcp-server:edge-stdio
+type: server
+
+meta:
+  category: monitoring
+  tags:
+    - parseable
+    - observability
+    - logs
+    - metrics
+    - monitoring
+
+about:
+  title: Parseable
+  description: Query and inspect Parseable observability datasets using MCP.
+  icon: https://www.parseable.com/parseable_icon.svg
+
+source:
+  project: https://github.com/parseablehq/parseable-mcp-server
+  commit: 39717ed71f8e3fc1b1ef408b1c672df707bb2114
+
+config:
+  description: Connect to a Parseable instance
+
+  secrets:
+    - name: parseable.api_key
+      env: PARSEABLE_API_KEY
+      example: <your-api-key>
+
+  env:
+    - name: PARSEABLE_URL
+      value: "{{parseable.url}}"
+      example: https://your-parseable.example.com
+
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+    required:
+      - url


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Parseable  
**Repository URL:** https://github.com/parseablehq/parseable-mcp-server  
**Brief Description:** Connects AI assistants to Parseable for discovering datasets, inspecting schemas, querying logs and metrics, managing alerts, and troubleshooting observability data through MCP tools.

## Basic Requirements

- [x] **Open Source**: Uses an acceptable permissive license
- [x] **MCP Compliant**: Implements the MCP API specification
- [x] **Active Development**: Actively maintained by Parseable
- [x] **Docker Artifact**: Includes a Dockerfile and a published container image
- [x] **Documentation**: Includes README and configuration instructions
- [x] **Security Contact**: Security issues can be reported through the Parseable project

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I tested the server using `task validate -- --name parseable`
- [x] I tested the published container image through Docker MCP Gateway
- [x] The gateway registered all 27 tools and successfully executed a live `ping` request
- [x] This submission uses the Parseable-maintained image: `quay.io/parseablehq/parseable-mcp-server:edge-stdio`
- [x] I have shared test credentials using the required form