### PR TITLE
Add Compartment MCP server

### DIFF
--- a/servers/compartment/server.yaml
+++ b/servers/compartment/server.yaml
@@ -31,7 +31,7 @@ about:
   icon: https://raw.githubusercontent.com/MaxFreedomPollard/Compartment/main/docs/images/logo-400.png
 source:
   project: https://github.com/MaxFreedomPollard/Compartment
-  commit: 99b8fd3c1352b9500226b592ed41314c059acefa
+  commit: 344970c13cb5856144f1c5605594ea9b5bff7431
 run:
   volumes:
     - "{{compartment.vault_path}}:/data"

--- a/servers/compartment/server.yaml
+++ b/servers/compartment/server.yaml
@@ -31,7 +31,7 @@ about:
   icon: https://raw.githubusercontent.com/MaxFreedomPollard/Compartment/main/docs/images/logo-400.png
 source:
   project: https://github.com/MaxFreedomPollard/Compartment
-  commit: 5bf3b98d28f092ece53bc4900c52bfe68a55643f
+  commit: 99b8fd3c1352b9500226b592ed41314c059acefa
 run:
   volumes:
     - "{{compartment.vault_path}}:/data"

--- a/servers/compartment/server.yaml
+++ b/servers/compartment/server.yaml
@@ -31,7 +31,7 @@ about:
   icon: https://raw.githubusercontent.com/MaxFreedomPollard/Compartment/main/docs/images/logo-400.png
 source:
   project: https://github.com/MaxFreedomPollard/Compartment
-  commit: cd648c48922fc2a9d36d9e0907bf2c27ea22ea4d
+  commit: 5bf3b98d28f092ece53bc4900c52bfe68a55643f
 run:
   volumes:
     - "{{compartment.vault_path}}:/data"

--- a/servers/compartment/server.yaml
+++ b/servers/compartment/server.yaml
@@ -1,0 +1,52 @@
+name: compartment
+image: mcp/compartment
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - memory
+    - agent-memory
+    - encryption
+    - offline
+    - local-first
+    - vector-search
+    - privacy
+about:
+  title: Compartment
+  description: |
+    Durable memory for AI agents that is encrypted at rest and never leaves the machine.
+
+    Everything stored at rest is AEAD-encrypted, including the embedding vectors, so the vault file gives up nothing to anyone who copies it. Search is exact and RAM-resident rather than approximate, deletion is a per-record crypto-shred, and every mutation is written to a hash-chained audit log.
+
+    Features:
+    • Encrypted at rest, vectors included, with optional keyfile two-factor unlock
+    • Fully offline: the embedding model ships inside the package, so no API key, no account and no outbound connection
+    • stdio transport only, so the container publishes no port and opens no listener
+    • Exact vector search plus keyword search, held in RAM for the life of the process
+    • Per-record crypto-shred deletion and a hash-chained, tamper-evident audit log
+    • Namespaces, tags, importance and typed relations between memories
+
+    The vault is created on the host with `compartment init`, which prompts for a passphrase. That passphrase is the only key to the vault and cannot be recovered, so it is supplied to the container as a secret rather than baked into the image.
+  icon: https://raw.githubusercontent.com/MaxFreedomPollard/Compartment/main/docs/images/logo-400.png
+source:
+  project: https://github.com/MaxFreedomPollard/Compartment
+  commit: cd648c48922fc2a9d36d9e0907bf2c27ea22ea4d
+run:
+  volumes:
+    - "{{compartment.vault_path}}:/data"
+config:
+  description: Point Compartment at the vault directory on this machine and give it the passphrase that unlocks it
+  secrets:
+    - name: compartment.passphrase
+      env: COMPARTMENT_PASSPHRASE
+      example: <the passphrase you chose when running compartment init>
+  parameters:
+    type: object
+    properties:
+      vault_path:
+        type: string
+        description: Directory on the host holding memory.vault, created by running `compartment init` there first
+        default: /Users/local-test/.compartment
+    required:
+      - vault_path


### PR DESCRIPTION
Adds **Compartment** as a local (containerized) MCP server under `servers/compartment/server.yaml`.

## What it is

Compartment is durable memory for AI agents that is encrypted at rest and never leaves the machine. Everything at rest is AEAD-encrypted including the embedding vectors, so the vault file gives up nothing to anyone who copies it. Search is exact and RAM-resident rather than approximate, deletion is a per-record crypto-shred, and every mutation is written to a hash-chained audit log.

- Source: https://github.com/MaxFreedomPollard/Compartment
- License: **Apache-2.0**
- Language: Python 3.11+, pure-Python wheel (`py3-none-any`)
- Also published on PyPI as `compartment` and in the official MCP registry as `io.github.MaxFreedomPollard/compartment`

## Notes on the container

- **stdio only.** No port is published and no listener is opened, so there is no `EXPOSE` in the Dockerfile.
- **No network at runtime.** The embedding model ships inside the wheel, so the image needs the network only while it is being built. Nothing the user stores is sent anywhere.
- **Runs unprivileged** as uid 10001.
- **The vault is never baked into the image.** It is mounted at `/data` from a host directory the user chooses, which is why `run.volumes` is parameterized rather than a named volume.
- **The passphrase is a secret, not an env value.** It is the only key to the vault and cannot be recovered, so it is declared under `config.secrets` and read from `COMPARTMENT_PASSPHRASE`. The user creates the vault once on the host with `compartment init` before the first container run, because that command deliberately prompts rather than accepting a machine-generated passphrase.

## What I verified, and what I did not

Docker is not installed on the machine I prepared this on, so I could not run `task create` or `task validate`, and I have not built the image locally. I would rather say that than imply a build I did not run. What I did verify:

- The exact build step in the Dockerfile, `python -m build --wheel`, succeeds on the pinned source tree and produces `compartment-4.4.1-py3-none-any.whl`.
- That wheel installs clean into a fresh virtualenv, and the exact `ENTRYPOINT` argv (`compartment --vault /data/memory.vault --caller docker serve`) parses and runs.
- The bundled embedding model is present inside the installed wheel, which is what makes the runtime offline claim true.
- All runtime dependencies are Linux-clean: the only platform-specific ones are gated to `sys_platform == 'darwin'` and `'win32'` in `pyproject.toml`.
- `server.yaml` parses and uses no key outside the set already in use across the existing 329 server entries.

If CI turns up something in the image build, point me at it and I will fix it.
