### PR TITLE
Add GadgetHumans API Hub MCP (remote, 46+300 tools)

### DIFF
--- a/servers/gadgethumans-mcp/server.yaml
+++ b/servers/gadgethumans-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: gadgethumans-mcp
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: development
+  tags:
+    - development
+    - utilities
+    - remote
+    - free-tier
+about:
+  title: GadgetHumans API Hub
+  description: One hosted MCP endpoint — 46 tools + 300+ REST endpoints covering weather, crypto prices, QR codes, passwords, UUIDs, hashing, currency, DNS, web search, RSS, finance calculators, text analysis, and persistent agent memory. Free tier, no API keys, no signup. Install with `curl -fsSL https://gadgethumans.com/install.sh | bash` or connect the endpoint directly from any MCP client (Claude Code, Cursor, Cline, Codex).
+  icon: https://www.google.com/s2/favicons?domain=gadgethumans.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://api.gadgethumans.com/mcp


### PR DESCRIPTION
## GadgetHumans API Hub MCP

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Full MCP spec — initialize handshake, tools/list, tools/call verified live
- [x] **Active Development**: Active, endpoint live at https://api.gadgethumans.com/mcp
- [x] **Docker Artifact**: Hosted remote server (type: remote, streamable-http)
- [x] **Documentation**: README at https://github.com/gadgethumans-dev/gadgethumans-mcp
- [x] **Security Contact**: scotia1973@gmail.com

46 MCP tools + 300+ REST endpoints. Free tier, no API keys. Install: `curl -fsSL https://gadgethumans.com/install.sh | bash`