### PR TITLE
Add AI Economics MCP server

### DIFF
--- a/servers/ai-economics/server.yaml
+++ b/servers/ai-economics/server.yaml
@@ -15,4 +15,4 @@ about:
   icon: https://avatars.githubusercontent.com/u/549441?v=4
 source:
   project: https://github.com/pich/ai-economics-mcp
-  commit: a1293b3a28f9f9a540bc6b78a2e5aee40c988d57
+  commit: c875822b33b32ea85fd2aec07c78ab9f3b43228d

--- a/servers/ai-economics/server.yaml
+++ b/servers/ai-economics/server.yaml
@@ -1,0 +1,18 @@
+name: ai-economics
+image: mcp/ai-economics
+type: server
+meta:
+  category: cost-management
+  tags:
+    - ai
+    - cost
+    - energy
+    - finops
+    - llm
+about:
+  title: AI Economics
+  description: Twelve calculators that price AI work before it runs, by Michał Piszczek (https://piszczek.pl/tools). Token cost across GPT, Claude, Gemini and DeepSeek with prompt-cache discount; context-window sizing; fully-loaded agent-hour cost including human review; model-routing savings; LLM energy, cost and CO2; joules per verified task; and the reviewer capacity an agent fleet actually needs. Every response carries the formula it used. No API key, no account, inputs are never stored.
+  icon: https://avatars.githubusercontent.com/u/549441?v=4
+source:
+  project: https://github.com/pich/ai-economics-mcp
+  commit: a1293b3a28f9f9a540bc6b78a2e5aee40c988d57


### PR DESCRIPTION
Adds `servers/ai-economics/server.yaml` — a local (containerized) server under the **cost-management** category.

## What it does

[ai-economics-mcp](https://github.com/pich/ai-economics-mcp) by Michał Piszczek ([piszczek.pl/tools](https://piszczek.pl/tools)) gives an assistant twelve deterministic calculators for the economics of AI work, so questions like "what will this cost" and "which model is actually cheaper per task that passes review" get arithmetic instead of a guess:

- token cost across GPT, Claude, Gemini and DeepSeek, input and output priced separately with a prompt-cache discount
- context-window sizing — does this content fit, and what does carrying it cost per request
- fully-loaded agent-hour cost, compute plus the human verification it triggers
- model-routing savings for moving the routable share of a workload to a cheaper tier
- LLM energy, dollars and CO₂; joules per *verified* task, where a lighter model with a worse pass rate can still lose
- verification bottleneck — how many agents a given reviewer headcount can actually keep up with

The neighbouring entries in this category (AWS Pricing, Cost Explorer, Billing and Cost Management) price cloud resources after the fact; this one prices model usage before it is spent, and needs no credentials to do it.

## Notes for review

- **License:** MIT.
- **No secrets, no config.** The server takes no credentials — nothing to share via the test-credentials form. Every tool works out of the box; each returns the numeric result plus the formula it used.
- **Dockerfile** is at the repo root. The server speaks stdio, so the image exposes no ports.
- `go run ./cmd/create --category cost-management https://github.com/pich/ai-economics-mcp` built the image and confirmed `tools/list` returns all 12 tools; `go run ./cmd/validate --name ai-economics` passes every check.
- Commit is pinned to `a1293b3`.
- Also on npm as `@michalpiszczek/ai-economics-mcp` and in the official MCP Registry as `pl.piszczek/ai-economics`.