### PR TITLE
feat: add Bisibility MCP server

### DIFF
--- a/servers/bisibility/server.yaml
+++ b/servers/bisibility/server.yaml
@@ -1,0 +1,51 @@
+name: bisibility
+image: mcp/bisibility
+type: server
+meta:
+  category: analytics
+  tags:
+    - seo
+    - rank-tracking
+    - keyword-research
+about:
+  title: Bisibility
+  description: Track keyword rankings, research SEO opportunities, and manage bisibility projects.
+  icon: https://avatars.githubusercontent.com/u/290003437?v=4
+source:
+  project: https://github.com/CorgiCorner/bisibility-mcp
+  commit: 58a1cf25c285fa2296530ac6a6ab0c1c0d4f3d96
+config:
+  description: Configure bisibility API access and optional project defaults
+  secrets:
+    - name: bisibility.api_key
+      env: BISIBILITY_API_KEY
+      example: bsb_key_live_****
+  env:
+    - name: BISIBILITY_BASE_URL
+      example: https://eu.bisibility.com/api/v1
+      value: "{{bisibility.base_url}}"
+    - name: BISIBILITY_PROJECT_ID
+      example: prj_a00000000000000000000000
+      value: "{{bisibility.project_id}}"
+    - name: BISIBILITY_MCP_READ_ONLY
+      example: "false"
+      value: "{{bisibility.read_only}}"
+    - name: BISIBILITY_MCP_TOOLSETS
+      example: account,alerts,analytics,backlinks,checks,competitors,keywords,notifications,projects,providers,rank-history,saved-views,signals,sitemaps,system,team,tokens,webhooks
+      value: "{{bisibility.toolsets}}"
+  parameters:
+    type: object
+    properties:
+      base_url:
+        type: string
+        description: bisibility API v1 root; change this for a self-hosted instance
+        default: https://eu.bisibility.com/api/v1
+      project_id:
+        type: string
+        description: Optional default bisibility project ID
+      read_only:
+        type: boolean
+        description: Set to true to register only read-only tools
+      toolsets:
+        type: string
+        description: Optional comma-separated allowlist of bisibility MCP toolsets


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Bisibility
**Repository URL:** https://github.com/CorgiCorner/bisibility-mcp
**Brief Description:** Track keyword rankings, research SEO opportunities, and manage Bisibility projects through MCP.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name bisibility`
- [x] I have built the MCP Server using `task build -- --tools bisibility`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Verification

- Registry validation passed.
- The pinned v0.6.0 source commit built successfully.
- Tool discovery returned 84 tools.
