### PR TITLE
Add flint MCP server

### DIFF
--- a/servers/flint/readme.md
+++ b/servers/flint/readme.md
@@ -1,0 +1,1 @@
+Docs: https://microsoft.github.io/flint-chart/#/mcp

--- a/servers/flint/server.yaml
+++ b/servers/flint/server.yaml
@@ -1,0 +1,21 @@
+name: flint
+type: remote
+meta:
+  category: data-visualization
+  tags:
+    - visualization
+    - charts
+    - data-visualization
+    - vega-lite
+    - echarts
+    - chartjs
+    - remote
+about:
+  title: Flint
+  description: Compile a single semantic chart spec into Vega-Lite, ECharts, or Chart.js and render or preview it interactively
+  icon: https://www.google.com/s2/favicons?domain=data-formulator.ai&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://flint.data-formulator.ai/mcp
+source:
+  project: https://github.com/microsoft/flint-chart

--- a/servers/flint/tools.json
+++ b/servers/flint/tools.json
@@ -1,0 +1,194 @@
+[
+  {
+    "name": "compile_chart",
+    "description": "Compile a Flint chart spec to a backend-native spec object (Vega-Lite / ECharts / Chart.js) without rendering",
+    "arguments": [
+      {
+        "name": "data",
+        "type": "object",
+        "desc": "Data source; rows provided inline via values",
+        "required": true
+      },
+      {
+        "name": "chart_spec",
+        "type": "object",
+        "desc": "Chart type and channel encodings to draw",
+        "required": true
+      },
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "Rendering backend: vegalite, echarts, or chartjs",
+        "required": true
+      },
+      {
+        "name": "field_display_names",
+        "type": "object",
+        "desc": "Field name to display label map, used for axis titles and legend headers",
+        "required": false
+      },
+      {
+        "name": "semantic_types",
+        "type": "object",
+        "desc": "Field name to semantic type map",
+        "required": false
+      },
+      {
+        "name": "options",
+        "type": "object",
+        "desc": "Assembler options such as tooltips and layout tuning",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "create_chart_view",
+    "description": "Open an interactive Flint chart view rendered live with a customization panel for chart type, channel bindings, and properties",
+    "arguments": [
+      {
+        "name": "data",
+        "type": "object",
+        "desc": "Data source; rows provided inline via values",
+        "required": true
+      },
+      {
+        "name": "chart_spec",
+        "type": "object",
+        "desc": "Chart type and channel encodings to draw",
+        "required": true
+      },
+      {
+        "name": "field_display_names",
+        "type": "object",
+        "desc": "Field name to display label map, used for axis titles and legend headers",
+        "required": false
+      },
+      {
+        "name": "semantic_types",
+        "type": "object",
+        "desc": "Field name to semantic type map",
+        "required": false
+      },
+      {
+        "name": "options",
+        "type": "object",
+        "desc": "Assembler options such as tooltips and layout tuning",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "list_chart_types",
+    "description": "List the available chart types and their encoding channels for a backend, or for all backends when none is given",
+    "arguments": [
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "Rendering backend: vegalite, echarts, or chartjs",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "render_chart",
+    "description": "Compile a Flint chart spec for a backend and render it to a static PNG or SVG image",
+    "arguments": [
+      {
+        "name": "data",
+        "type": "object",
+        "desc": "Data source; rows provided inline via values",
+        "required": true
+      },
+      {
+        "name": "chart_spec",
+        "type": "object",
+        "desc": "Chart type and channel encodings to draw",
+        "required": true
+      },
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "Rendering backend: vegalite, echarts, or chartjs",
+        "required": true
+      },
+      {
+        "name": "format",
+        "type": "string",
+        "desc": "Output format, png or svg (chartjs supports png only)",
+        "required": false
+      },
+      {
+        "name": "scale",
+        "type": "number",
+        "desc": "Device scale for PNG raster, 1 = design size, 2 = retina",
+        "required": false
+      },
+      {
+        "name": "background",
+        "type": "string",
+        "desc": "Background color as a CSS color value",
+        "required": false
+      },
+      {
+        "name": "field_display_names",
+        "type": "object",
+        "desc": "Field name to display label map, used for axis titles and legend headers",
+        "required": false
+      },
+      {
+        "name": "semantic_types",
+        "type": "object",
+        "desc": "Field name to semantic type map",
+        "required": false
+      },
+      {
+        "name": "options",
+        "type": "object",
+        "desc": "Assembler options such as tooltips and layout tuning",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "validate_chart",
+    "description": "Validate a Flint chart spec for a backend without rendering, reporting warnings, errors, and computed layout size",
+    "arguments": [
+      {
+        "name": "data",
+        "type": "object",
+        "desc": "Data source; rows provided inline via values",
+        "required": true
+      },
+      {
+        "name": "chart_spec",
+        "type": "object",
+        "desc": "Chart type and channel encodings to draw",
+        "required": true
+      },
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "Rendering backend: vegalite, echarts, or chartjs",
+        "required": true
+      },
+      {
+        "name": "field_display_names",
+        "type": "object",
+        "desc": "Field name to display label map, used for axis titles and legend headers",
+        "required": false
+      },
+      {
+        "name": "semantic_types",
+        "type": "object",
+        "desc": "Field name to semantic type map",
+        "required": false
+      },
+      {
+        "name": "options",
+        "type": "object",
+        "desc": "Assembler options such as tooltips and layout tuning",
+        "required": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** flint
**Repository URL:** https://github.com/microsoft/flint-chart
**Brief Description:** Flint compiles a single semantic chart spec into Vega-Lite, ECharts, or Chart.js and renders it or opens an interactive preview. This entry is for the hosted remote server at https://flint.data-formulator.ai/mcp (no OAuth/credentials required).

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (streamable-http transport)
- [x] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: N/A — this is a `type: remote` entry (hosted server), not a local/Dockerized server, consistent with other remote entries in this registry (e.g. notion-remote, astro-docs)
- [x] **Documentation**: https://microsoft.github.io/flint-chart/#/mcp
- [x] **Security Contact**: Standard GitHub security advisories on microsoft/flint-chart

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name flint`
- [x] I have built the MCP Server using `task build -- --tools flint`
- [ ] If the server requires credentials to test it, I have shared test credentials using this form — N/A, no credentials required