### PR TITLE
Add diyan-research-mcp

### DIFF
--- a/servers/diyan-research-mcp/readme.md
+++ b/servers/diyan-research-mcp/readme.md
@@ -1,0 +1,6 @@
+﻿Documentation: https://github.com/mikeli20221102-ux/diyan-research-mcp
+
+PyPI: https://pypi.org/project/diyan-research-mcp/
+
+Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.mikeli20221102-ux/diyan-research-mcp
+

--- a/servers/diyan-research-mcp/server.yaml
+++ b/servers/diyan-research-mcp/server.yaml
@@ -1,0 +1,40 @@
+name: diyan-research-mcp
+image: mcp/diyan-research-mcp
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - research
+    - enterprise
+    - equity
+    - evidence
+    - read-only
+about:
+  title: Diyan Research Evidence Chain
+  description: |
+    Read-only enterprise research MCP for investment and industry research teams.
+    Serves research frameworks, frozen snapshots and historical factor summaries.
+    Every result carries its source, as-of date and falsification conditions.
+    Trading advice is stripped by policy. Requires a Diyan tenant API key.
+  icon: https://avatars.githubusercontent.com/u/288796250?s=200&v=4
+source:
+  project: https://github.com/mikeli20221102-ux/diyan-research-mcp
+  commit: 9850e7001ef3b762da7915fed7a8f305fa11d83c
+run:
+  allowHosts:
+    - api.diyan.example:443
+config:
+  description: Configure the Diyan research tenant credential
+  secrets:
+    - name: diyan-research-mcp.api_key
+      env: DIYAN_API_KEY
+      example: <DIYAN_API_KEY>
+      description: Tenant credential issued by Diyan. Fill this after connecting the server.
+  env:
+    - name: DIYAN_TRANSPORT
+      example: stdio
+      value: stdio
+  parameters:
+    type: object
+    properties: {}

--- a/servers/diyan-research-mcp/tools.json
+++ b/servers/diyan-research-mcp/tools.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "framework_excerpt",
+    "description": "Read an approved research framework excerpt. framework is one of enterprise/business/finance/people/brand.",
+    "arguments": [
+      {"name": "framework", "type": "string", "desc": "Framework id: enterprise, business, finance, people, or brand"},
+      {"name": "query", "type": "string", "desc": "Optional substring to locate within the framework"},
+      {"name": "max_chars", "type": "number", "desc": "Excerpt length between 200 and 8000"}
+    ]
+  },
+  {
+    "name": "stock_snapshot_latest",
+    "description": "Read the latest frozen equity research snapshot. Not real-time market data.",
+    "arguments": []
+  },
+  {
+    "name": "hypothesis_get",
+    "description": "Read a frozen hypothesis that passed the delivery evidence threshold.",
+    "arguments": [
+      {"name": "hypothesis_id", "type": "string", "desc": "Hypothesis id, e.g. stock-001"}
+    ]
+  },
+  {
+    "name": "cognition_radar_read",
+    "description": "Read the historical thematic research radar summary and its staleness notice.",
+    "arguments": []
+  },
+  {
+    "name": "ic_backtest_summary",
+    "description": "Read the frozen factor IC history summary. No raw market panel download.",
+    "arguments": []
+  },
+  {
+    "name": "research_analyze_safe",
+    "description": "Run a controlled single-name research enquiry. Trading language is rejected.",
+    "arguments": [
+      {"name": "symbol", "type": "string", "desc": "Security symbol or code"},
+      {"name": "question", "type": "string", "desc": "Research question without trading instructions"},
+      {"name": "market", "type": "string", "desc": "Market code, default A"}
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Adds **diyan-research-mcp**, a read-only enterprise research MCP for investment and industry research teams.

- Category: `finance`
- Source: https://github.com/mikeli20221102-ux/diyan-research-mcp
- PyPI: https://pypi.org/project/diyan-research-mcp/
- Official MCP Registry: `io.github.mikeli20221102-ux/diyan-research-mcp`
- License: MIT
- Requires secret: `DIYAN_API_KEY`
- Includes `tools.json` so CI does not need a live backend to list tools

## Notes
The shell is a forwarding MCP. Research data stays on the Diyan backend behind the tenant key. Trading advice is policy-stripped.