### PR TITLE
Add GenieLocker MCP server

### DIFF
--- a/servers/genie-locker/server.yaml
+++ b/servers/genie-locker/server.yaml
@@ -1,0 +1,17 @@
+name: genie-locker
+image: ghcr.io/nhantour/genie-locker-mcp:0.1.0
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - inference
+    - private-ai
+    - pricing
+about:
+  title: GenieLocker
+  description: Read-only discovery, live quotes, and commercial availability for quality-gated private AI inference.
+  icon: https://github.com/nhantour.png?size=200
+source:
+  project: https://github.com/nhantour/genie-locker
+  commit: 8d526dfc261f3259d6fe76127316d9bc972564b0


### PR DESCRIPTION
## MCP Server Information

**Server Name:** GenieLocker
**Repository URL:** https://github.com/nhantour/genie-locker
**Brief Description:** Read-only MCP tools for service status, commercial inventory, live quotes, recipe discovery, and credit pricing for quality-gated private AI inference.

## Basic Requirements

- [x] **Open Source**: Public connector source is MIT-licensed under `LICENSE-MCP`
- [x] **MCP Compliant**: Implements MCP over stdio using the official TypeScript SDK
- [x] **Active Development**: Current release and commits are maintained
- [x] **Docker Artifact**: Root Dockerfile and public multi-architecture GHCR image
- [x] **Documentation**: README includes setup and client configuration
- [x] **Security Contact**: Private GitHub security advisory form documented in `SECURITY.md`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I tested the MCP Server using `task validate -- --name genie-locker`
- [x] I tested the published image using `task build -- --tools --pull-community genie-locker` (5 tools found)
- [x] The server requires no credentials to test

## Safety boundary

This connector is deliberately read-only. It cannot create accounts, buy credits, reserve GPUs, create lockers, or send prompts to an inference model.

The same release is discoverable in the official MCP Registry as `io.github.nhantour/genie-locker` and is published for linux/amd64 and linux/arm64 at `ghcr.io/nhantour/genie-locker-mcp:0.1.0`.
