### PR TITLE
Add postlint MCP server

### DIFF
--- a/servers/postlint/server.yaml
+++ b/servers/postlint/server.yaml
@@ -13,7 +13,7 @@ meta:
     - typescript
 about:
   title: Postlint
-  description: Checks whether a social post fits before it ships, on X, Bluesky, LinkedIn, Threads, Mastodon and Discord. Counts grapheme clusters, bills every URL at 23 characters the way t.co does, and charges CJK, Hangul and emoji at double width, so the count is a measurement rather than a guess. Pure compute, no API and no auth.
+  description: Checks whether a social post fits before it ships, on X, X Premium, Bluesky, LinkedIn, Threads, Mastodon and Discord. Each platform is counted in its own unit rather than as characters - X weights CJK, Hangul and emoji at double and bills every URL at 23 through t.co, Bluesky counts grapheme clusters and counts URLs in full, Mastodon applies its own 23-character URL placeholder, and the rest count UTF-16 length. Pure compute, no API and no auth.
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/postlint-mcp

--- a/servers/postlint/server.yaml
+++ b/servers/postlint/server.yaml
@@ -1,0 +1,20 @@
+name: postlint
+image: mcp/postlint
+type: server
+meta:
+  category: productivity
+  tags:
+    - bluesky
+    - character-counter
+    - claude
+    - mastodon
+    - model-context-protocol
+    - social-media
+    - typescript
+about:
+  title: Postlint
+  description: Checks whether a social post fits before it ships, on X, Bluesky, LinkedIn, Threads, Mastodon and Discord. Counts grapheme clusters, bills every URL at 23 characters the way t.co does, and charges CJK, Hangul and emoji at double width, so the count is a measurement rather than a guess. Pure compute, no API and no auth.
+  icon: https://avatars.githubusercontent.com/u/120674402?v=4
+source:
+  project: https://github.com/conorbronsdon/postlint-mcp
+  commit: eff5a8039fa6427cd87201b612807bad28d4851d


### PR DESCRIPTION
## MCP Server Information

**Server Name:** postlint
**Repository URL:** https://github.com/conorbronsdon/postlint-mcp
**Brief Description:** Checks whether a social post fits a platform's limit before it ships, across X, x_premium, Bluesky, LinkedIn, Threads, Mastodon and Discord.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

Character limits are not character counts, which is the reason this is a tool call and not something a model can eyeball. X bills every URL at 23 characters through t.co no matter how long the URL is. Bluesky counts extended grapheme clusters, so a four-person family emoji costs 1 and not 11. CJK, Hangul and emoji each cost 2 on X.

Three tools: `check_post`, `check_post_all`, `platform_limits`.

This one is pure compute. No API, no auth, no network, no credentials, so the container needs no configuration and I left the `config` block out. That is also why the test-credentials box above is unchecked: there is nothing to hand over.

Category is `productivity`, license is Apache-2.0, and I have not supplied an image, so Docker builds it from the Dockerfile at the repo root.

## Validation

Generated with:

```
task create -- --category productivity https://github.com/conorbronsdon/postlint-mcp
```

`task build -- --tools postlint` listed 3 tools and built the image. `task validate -- --name postlint` passes all eleven checks and exits 0.

One of five servers I am submitting. The others are #4610, #4611, #4612 and #4613, filed separately because they are independent of each other.
