### PR TITLE
Add podcastindex MCP server

### DIFF
--- a/servers/podcastindex/server.yaml
+++ b/servers/podcastindex/server.yaml
@@ -19,7 +19,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/podcastindex-mcp
-  commit: cf03d953807ad3acaf80bf195e028628ab0caefe
+  commit: fd8298d7e90c825586c06f86d8fba13db0ba298b
 config:
   description: Configure the Podcast Index API credentials, issued free at api.podcastindex.org
   secrets:

--- a/servers/podcastindex/server.yaml
+++ b/servers/podcastindex/server.yaml
@@ -1,0 +1,31 @@
+name: podcastindex
+image: mcp/podcastindex
+type: server
+meta:
+  category: search
+  tags:
+    - ai-agents
+    - api-client
+    - claude
+    - claude-code
+    - developer-tools
+    - model-context-protocol
+    - podcast
+    - podcast-index
+    - typescript
+about:
+  title: Podcast Index
+  description: Searches the Podcast Index catalog over 18 tools - find shows and episodes, trace a person's guest appearances across podcasts, follow trending feeds, and check a feed's health. Podcast Index is an open, independent index of podcast feeds.
+  icon: https://avatars.githubusercontent.com/u/120674402?v=4
+source:
+  project: https://github.com/conorbronsdon/podcastindex-mcp
+  commit: cf03d953807ad3acaf80bf195e028628ab0caefe
+config:
+  description: Configure the Podcast Index API credentials, issued free at api.podcastindex.org
+  secrets:
+    - name: podcastindex.api_key
+      env: PODCASTINDEX_API_KEY
+      example: <PODCASTINDEX_API_KEY>
+    - name: podcastindex.api_secret
+      env: PODCASTINDEX_API_SECRET
+      example: <PODCASTINDEX_API_SECRET>

--- a/servers/podcastindex/server.yaml
+++ b/servers/podcastindex/server.yaml
@@ -15,7 +15,7 @@ meta:
     - typescript
 about:
   title: Podcast Index
-  description: Searches the Podcast Index catalog over 18 tools - find shows and episodes, trace a person's guest appearances across podcasts, follow trending feeds, and check a feed's health. Podcast Index is an open, independent index of podcast feeds.
+  description: Eighteen tools over the Podcast Index catalog - search shows and episodes, trace a person's guest appearances across podcasts, follow trending feeds, browse categories, read index-wide stats, check a feed's health, and look up a feed's value4value Lightning destinations. Podcast Index is an open, independent index of podcast feeds.
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/podcastindex-mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** podcastindex
**Repository URL:** https://github.com/conorbronsdon/podcastindex-mcp
**Brief Description:** Client for the [Podcast Index](https://podcastindex.org) API, an open and independent index of podcast feeds.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

Security contact: the repo has a `SECURITY.md` routing to GitHub's private vulnerability reporting.

## Notes

Eighteen tools: search shows and episodes, trace a person's guest appearances across podcasts, follow trending feeds, and check a feed's health.

Category is `search`, license is MIT, and Docker builds the image from the Dockerfile at the repo root.

Configuration is two secrets, `PODCASTINDEX_API_KEY` and `PODCASTINDEX_API_SECRET`. Keys are free from api.podcastindex.org.

Worth flagging for review: `task create` put the secret in the `env` block with a plaintext parameter. I moved it into `secrets` next to the key, since both halves of the credential pair are secret.

I can supply working API credentials for review through the form linked above.

## Validation

Generated with:

```
task create -- --category search https://github.com/conorbronsdon/podcastindex-mcp -e PODCASTINDEX_API_KEY=test -e PODCASTINDEX_API_SECRET=test
```

`task build -- --tools podcastindex` listed 18 tools and built the image. `task validate -- --name podcastindex` passes all eleven checks and exits 0.

One of five servers I am submitting. The others are #4609, #4611, #4612 and #4613, filed separately because they are independent of each other.

