### PR TITLE
Add op3 MCP server

### DIFF
--- a/servers/op3/server.yaml
+++ b/servers/op3/server.yaml
@@ -1,0 +1,27 @@
+name: op3
+image: mcp/op3
+type: server
+meta:
+  category: monitoring
+  tags:
+    - ai-agents
+    - analytics
+    - claude
+    - model-context-protocol
+    - op3
+    - podcast
+    - podcasting
+    - typescript
+about:
+  title: OP3
+  description: Reads podcast analytics from OP3, the Open Podcast Prefix Project - downloads over time, listener geography, app share, and per-episode breakdowns. OP3 logs each download at the redirect, so it has the geography and app data most podcast hosting APIs do not expose. Read-only.
+  icon: https://avatars.githubusercontent.com/u/120674402?v=4
+source:
+  project: https://github.com/conorbronsdon/op3-mcp
+  commit: 9cc86b7e3d56b5c0e2774797cdc5288f8077c048
+config:
+  description: Configure the OP3 API token, requested at op3.dev
+  secrets:
+    - name: op3.api_token
+      env: OP3_API_TOKEN
+      example: <OP3_API_TOKEN>

--- a/servers/op3/server.yaml
+++ b/servers/op3/server.yaml
@@ -14,7 +14,7 @@ meta:
     - typescript
 about:
   title: OP3
-  description: Reads podcast analytics from OP3, the Open Podcast Prefix Project - downloads over time, listener geography, app share, and per-episode breakdowns. OP3 logs each download at the redirect, so it has the geography and app data most podcast hosting APIs do not expose. Read-only.
+  description: Reads podcast analytics from OP3, the Open Podcast Prefix Project - downloads over time, app share, per-episode breakdowns, and listener geography. OP3 logs each download at the redirect, so it carries app and geography data many podcast hosting APIs do not expose. Geography has no native OP3 query and is aggregated client-side from a recent sample of download records, not a lifetime total. Read-only.
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/op3-mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** op3
**Repository URL:** https://github.com/conorbronsdon/op3-mcp
**Brief Description:** Read-only client for [OP3](https://op3.dev), the Open Podcast Prefix Project, covering downloads over time, listener geography, app share and per-episode breakdowns.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

OP3 logs each podcast download at the redirect, so it holds data most podcast hosting APIs never expose: downloads over time, listener geography, app share, and per-episode breakdowns.

Six tools, all of them reads. The server cannot change anything in OP3, which matters when you hand it to an agent.

Category is `monitoring`, license is MIT, and Docker builds the image from the Dockerfile at the repo root.

Configuration is a single secret, `OP3_API_TOKEN`. The stats pages on op3.dev are public, but the API wants a token.

I can supply a working token for review through the form linked above. Say the word and I will send one.

## Validation

Generated with:

```
task create -- --category monitoring https://github.com/conorbronsdon/op3-mcp -e OP3_API_TOKEN=test
```

`task build -- --tools op3` listed 6 tools and built the image. `task validate -- --name op3` passes all eleven checks and exits 0.

One of five servers I am submitting. The others are #4609, #4610, #4612 and #4613, filed separately because they are independent of each other.
