### PR TITLE
Add gsc MCP server

### DIFF
--- a/servers/gsc/server.yaml
+++ b/servers/gsc/server.yaml
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/gsc-mcp
-  commit: 8f11a4b97942691a7fc5775920e3832e1bc42aaa
+  commit: b9a31219b44310f18ccb64ef8ecd736adcf7a0b6
 config:
   description: Configure the path to a saved Google Search Console OAuth credential
   env:

--- a/servers/gsc/server.yaml
+++ b/servers/gsc/server.yaml
@@ -1,0 +1,35 @@
+name: gsc
+image: mcp/gsc
+type: server
+meta:
+  category: search
+  tags:
+    - claude
+    - google-search-console
+    - model-context-protocol
+    - seo
+    - typescript
+about:
+  title: Google Search Console
+  description: Seven tools over Google Search Console - search performance by query, page, country or device, striking-distance keywords sitting at average position 8 to 25, sitemap status, and URL index inspection. Five tools read; sitemap submit and delete write. Uses a saved installed-app OAuth credential, not a service account or an API key.
+  icon: https://avatars.githubusercontent.com/u/120674402?v=4
+source:
+  project: https://github.com/conorbronsdon/gsc-mcp
+  commit: 8f11a4b97942691a7fc5775920e3832e1bc42aaa
+config:
+  description: Configure the path to a saved Google Search Console OAuth credential
+  env:
+    - name: GSC_CREDENTIALS_PATH
+      value: "/app/.config/gws/searchconsole_credentials.json"
+      example: "/Users/you/.config/gws/searchconsole_credentials.json"
+  parameters:
+    type: object
+    properties:
+      credentials_path:
+        type: string
+        description: path to the saved installed-app OAuth credential (eg $HOME/.config/gws/searchconsole_credentials.json)
+    required:
+      - credentials_path
+run:
+  volumes:
+    - "{{gsc.credentials_path}}:/app/.config/gws/searchconsole_credentials.json:ro"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gsc
**Repository URL:** https://github.com/conorbronsdon/gsc-mcp
**Brief Description:** Google Search Console client: site list, search analytics by query, page, country and device, striking-distance keywords, sitemap list and URL inspection, plus sitemap submit and delete.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

Seven tools. Five read: site list, search analytics by query, page, country and device, striking-distance keywords, sitemap list, and URL inspection. Two write: sitemap submit and delete.

Category is `search`, license is MIT, and Docker builds the image from the Dockerfile at the repo root.

The configuration differs from the usual env-secret shape, so it is the part I would look at first. The server authenticates with a saved installed-app OAuth credential rather than an API key: a JSON file holding `client_id`, `client_secret` and a `refresh_token`. That is a file, not a string, so the entry follows the volume-mount pattern already used by `servers/cloud-run-mcp/server.yaml`. A `credentials_path` parameter mounts to a fixed path inside the container and `GSC_CREDENTIALS_PATH` points at it.

I mounted it `:ro`, and I read `src/auth.ts` before deciding that. The server refreshes access tokens against Google's token endpoint in memory and never writes the credential file back. The only `writeFileSync` anywhere in the repo is in a test helper.

I can supply a working credential for review through the form linked above.

## Validation

Generated with:

```
task create -- --category search https://github.com/conorbronsdon/gsc-mcp
```

`task build -- --tools gsc` listed 7 tools and built the image. `task validate -- --name gsc` passes all eleven checks and exits 0.

One of five servers I am submitting. The others are #4609, #4610, #4611 and #4613, filed separately because they are independent of each other.
