### PR TITLE
Add substack MCP server

### DIFF
--- a/servers/substack/server.yaml
+++ b/servers/substack/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/substack-mcp
-  commit: 336c4485bd0c9ee626748fd4d24fcba85f22278d
+  commit: df0202c4e859e13274e409cf09d4427214255070
 config:
   description: Configure the Substack publication and session credential
   secrets:

--- a/servers/substack/server.yaml
+++ b/servers/substack/server.yaml
@@ -1,0 +1,41 @@
+name: substack
+image: mcp/substack
+type: server
+meta:
+  category: productivity
+  tags:
+    - ai-agents
+    - claude
+    - claude-code
+    - content-creation
+    - developer-tools
+    - model-context-protocol
+    - substack
+    - typescript
+about:
+  title: Substack
+  description: Fourteen tools over a Substack publication - read published posts, drafts, comments, sections, scheduled posts, per-post analytics and subscriber count, and create or update long-form drafts. Long-form posts are draft-only by design, so the server cannot publish or delete them. The exception is Substack Notes - create_note and create_note_with_link publish short-form Notes immediately, because Notes have no draft state, which means no preview and no undo. Uses Substack's unofficial API.
+  icon: https://avatars.githubusercontent.com/u/120674402?v=4
+source:
+  project: https://github.com/conorbronsdon/substack-mcp
+  commit: 336c4485bd0c9ee626748fd4d24fcba85f22278d
+config:
+  description: Configure the Substack publication and session credential
+  secrets:
+    - name: substack.session_token
+      env: SUBSTACK_SESSION_TOKEN
+      example: <SUBSTACK_SESSION_TOKEN>
+  env:
+    - name: SUBSTACK_PUBLICATION_URL
+      example: https://example.substack.com
+      value: "{{substack.substack_publication_url}}"
+    - name: SUBSTACK_USER_ID
+      example: "1"
+      value: "{{substack.substack_user_id}}"
+  parameters:
+    type: object
+    properties:
+      substack_publication_url:
+        type: string
+      substack_user_id:
+        type: string


### PR DESCRIPTION
## MCP Server Information

**Server Name:** substack
**Repository URL:** https://github.com/conorbronsdon/substack-mcp
**Brief Description:** Client for a Substack publication: read posts, drafts, comments, sections, scheduled posts, per-post analytics and subscriber count, and create or update long-form drafts.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [ ] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

Security contact: the repo has a `SECURITY.md` routing to GitHub's private vulnerability reporting. It also states what the session cookie grants, that it lasts about 90 days, and how to revoke it, since this server holds a live credential rather than a read-only API key.

## Notes

Fourteen tools: read published posts, drafts, comments, sections, scheduled posts, per-post analytics and subscriber count, plus create and update long-form drafts and upload images.

Category is `productivity`, following the existing `notion` and `notion-remote` entries. License is MIT.

The description carries a safety boundary on purpose and I would like it to survive review. Long-form posts are draft-only by design: there is no publish tool and no delete tool, so a person reviews and publishes through Substack's editor. Substack Notes are the exception. `create_note` and `create_note_with_link` publish immediately, because Notes have no draft state on Substack, so there is no preview and no undo. The upstream README says so in three places and its contributing guidance asks that the Note tools keep saying so. Docker Desktop shows the catalog description without the README next to it, so the exception is spelled out in the description rather than left implied by "no publish, no delete."

Configuration is one secret, `SUBSTACK_SESSION_TOKEN`, which is the `connect.sid` cookie value, plus two non-secret parameters: the publication URL and the numeric user id.

The server talks to Substack's unofficial API, so endpoints can change without notice. The upstream README says this too.

I can supply a working credential for review through the form linked above.

## One thing you may want to fix in this repo

`task create` writes the generated `config.env` values in single quotes, for example `value: '{{substack.substack_publication_url}}'`, and `task validate`'s prettier check then rejects the file `task create` just wrote. Every generated entry that keeps an `env:` block hits this and needs a manual `prettier --write` before it will validate. Happy to send a separate PR against `cmd/create` if that is useful.

## Validation

Generated with:

```
task create -- --category productivity https://github.com/conorbronsdon/substack-mcp -e SUBSTACK_PUBLICATION_URL=... -e SUBSTACK_SESSION_TOKEN=test -e SUBSTACK_USER_ID=1
```

`task build -- --tools substack` listed 14 tools and built the image. `task validate -- --name substack` passes all eleven checks and exits 0.

One of five servers I am submitting. The others are #4609, #4610, #4611 and #4612, filed separately because they are independent of each other.

