### PR TITLE
Add gisgp-mcp remote server (ArcGIS Online QA/audit MCP)

### DIFF
--- a/servers/gisgp-mcp/readme.md
+++ b/servers/gisgp-mcp/readme.md
@@ -1,0 +1,1 @@
+Docs: https://gisgp.com/api

--- a/servers/gisgp-mcp/server.yaml
+++ b/servers/gisgp-mcp/server.yaml
@@ -1,0 +1,16 @@
+name: gisgp-mcp
+type: remote
+meta:
+  category: geospatial
+  tags:
+    - geospatial
+    - gis
+    - arcgis
+    - remote
+about:
+  title: GISGP MCP
+  description: Hosted ArcGIS Online (AGOL) QA and audit toolkit for AI agents — feature service schema grading, health auditing, geometry/coordinate operations, hazard risk assessment, and format conversion (Shapefile/KML/GeoJSON/GPX/WKT).
+  icon: https://gisgp.com/favicon.ico
+remote:
+  transport_type: streamable-http
+  url: https://gisgp.com/mcp


### PR DESCRIPTION
## Summary
Adds a remote MCP server entry for GISGP — a hosted ArcGIS Online (AGOL) QA/audit toolkit for AI agents.

- **Type:** remote (streamable-http), no OAuth
- **Endpoint:** https://gisgp.com/mcp (publicly reachable, no auth required to list tools)
- **Docs:** https://gisgp.com/api
- **What it does:** feature service schema grading, health auditing, geometry/coordinate conversion (Shapefile/KML/GeoJSON/GPX/WKT), and paid composite hazard/site-risk assessment tools.
- No existing entry in the `geospatial` category covers ArcGIS Online administration/QA (existing entries — mapbox, google-maps — cover geocoding/routing, a different niche).

Followed the same shape as the existing no-OAuth remote example (`servers/cloudflare-docs`): `server.yaml` + `readme.md`, no `tools.json` (dynamic tool discovery).

## Test plan
- [x] Verified `https://gisgp.com/mcp` is publicly reachable (406 on bare GET is expected MCP streamable-http behavior for a non-POST request)
- [x] Verified `https://gisgp.com/api` docs page returns 200
- [ ] Docker team review/build verification (per CONTRIBUTING.md)