### PR TITLE
Add gws MCP server

### DIFF
--- a/servers/gws/server.yaml
+++ b/servers/gws/server.yaml
@@ -21,7 +21,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/120674402?v=4
 source:
   project: https://github.com/conorbronsdon/gws-mcp-server
-  commit: 69b0e991660863d074b6d1cdfe8352d0e65d3ab6
+  commit: 4e969c30d6b6a45b839119499a2c2db5a203c98a
 config:
   description: Mount the directory holding your gws credentials, created by running `gws auth login` on the host
   parameters:

--- a/servers/gws/server.yaml
+++ b/servers/gws/server.yaml
@@ -1,0 +1,37 @@
+name: gws
+image: mcp/gws
+type: server
+meta:
+  category: communication
+  tags:
+    - ai-agents
+    - calendar
+    - claude
+    - claude-code
+    - developer-tools
+    - gmail
+    - google-calendar
+    - google-drive
+    - google-workspace
+    - model-context-protocol
+    - typescript
+about:
+  title: Google Workspace
+  description: Thirty-nine tools across Gmail, Calendar, Drive, Sheets, Docs and Tasks, running on top of Google's official gws CLI. A curated subset rather than a wrapper around every API method, so an agent picks from a list it can reason about.
+  icon: https://avatars.githubusercontent.com/u/120674402?v=4
+source:
+  project: https://github.com/conorbronsdon/gws-mcp-server
+  commit: 69b0e991660863d074b6d1cdfe8352d0e65d3ab6
+config:
+  description: Mount the directory holding your gws credentials, created by running `gws auth login` on the host
+  parameters:
+    type: object
+    properties:
+      config_path:
+        type: string
+        description: path to the gws config directory (eg $HOME/.config/gws)
+    required:
+      - config_path
+run:
+  volumes:
+    - "{{gws.config_path}}:/home/node/.config/gws"


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gws
**Repository URL:** https://github.com/conorbronsdon/gws-mcp-server
**Brief Description:** Thirty-nine tools across Gmail, Calendar, Drive, Sheets, Docs and Tasks, on top of Google's official `gws` CLI.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gws`
- [x] I have built the MCP Server using `task build -- --tools gws`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

The server shells out to Google's official `gws` CLI, so the Dockerfile installs `@googleworkspace/cli` alongside the Node server. That install deliberately skips `--ignore-scripts`: the npm package is a launcher whose postinstall fetches the matching Rust binary, and with scripts disabled it defers that fetch to the first tool call, which needs network at runtime and write access the runtime user does not have. Alpine works because upstream ships musl builds for both x86_64 and aarch64, so multi-arch is fine.

**The credential mount must be read-write, which is the opposite of my `gsc` entry in #4612, and the difference is deliberate.** `gws` treats `~/.config/gws` as state rather than input. The first thing it writes there is not a credential: it caches the API discovery document under `cache/` on the first tool call, before authentication is even attempted. A read-only mount therefore does not degrade gracefully, it fails every call:

```
RO mount, first tool call        -> error[discovery]: Read-only file system (os error 30)
mount the runtime user can't write -> error[discovery]: Permission denied (os error 13)
no mount at all                  -> error[auth]: Access denied. No credentials provided.
```

On Linux there is no OS keyring, so `gws` also keeps the credential encryption key in that directory as `.encryption_key`, next to `credentials.enc`. One consequence worth knowing before testing: a credential minted by `gws auth login` on macOS or Windows keeps its key in the OS keyring instead, so copying the directory alone into a container yields "Decryption failed. Credentials may have been created on a different machine." Test credentials need to come from a Linux `gws auth login`.

No secrets are declared, because nothing is passed by environment variable. The whole credential lives in the mounted directory.

## Validation

`task validate -- --name gws` passes all eleven checks at exit 0. `task create` built the image and confirmed 39 tools, matching what the server's own startup banner reports.

Credential-free startup works, which is what the automated check needs: the server answers `initialize` and `tools/list` with all 39 tools and no credentials present, and tool calls then return `isError: true` carrying the `gws` error rather than hanging.

Happy to mint a Linux-side credential for review through the form above.

This is the sixth server I have submitted. The others are #4609, #4610, #4611, #4612 and #4613.
