### PR TITLE
Add Identity Forge MCP server

### DIFF
--- a/servers/identityforge-mcp/server.yaml
+++ b/servers/identityforge-mcp/server.yaml
@@ -1,0 +1,24 @@
+name: identityforge-mcp
+image: mcp/identityforge-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - design-systems
+    - design-tokens
+    - branding
+    - coding-agents
+about:
+  title: Identity Forge
+  description: Design systems, brand naming, and domain research for coding agents through MCP and CLI.
+  icon: https://identityforge.io/icon.svg
+source:
+  project: https://github.com/KasayoDotCom/identityforge-mcp
+  commit: 6d14fd97c27c634f85755df41766b2628203668a
+config:
+  description: Optionally provide an Identity Forge API key for Pro kits, saved work, naming boards, and writes. Public Free kits work without one.
+  secrets:
+    - name: identityforge-mcp.api_key
+      env: IDENTITYFORGE_API_KEY
+      example: <IDENTITYFORGE_API_KEY>
+      required: false


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Identity Forge
**Repository URL:** https://github.com/KasayoDotCom/identityforge-mcp
**Brief Description:** Design systems, brand naming, and domain research for coding agents through MCP and CLI.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP over stdio
- [x] **Active Development**: Current release is 0.3.11
- [x] **Docker Artifact**: Root Dockerfile
- [x] **Documentation**: README includes setup, tool, CLI, and Docker instructions
- [x] **Security Contact**: Public SECURITY.md

## Submitter Checklist

- [x] This server meets the basic requirements listed above.
- [x] I understand this will undergo automated and manual review.
- [x] I ran the repository's validator for `identityforge-mcp`; every check passed.
- [ ] The upstream CI still needs to run the exact `task build -- --tools identityforge-mcp` command. The pinned Dockerfile was built separately and an unauthenticated MCP handshake returned version 0.3.11 and 61 tools.
- [x] Test credentials are not needed for `initialize` or `tools/list`; `IDENTITYFORGE_API_KEY` is optional.

## Validation

- `go test ./...`
- Docker registry validator
- Local catalog generation
- Container build from commit `6d14fd97c27c634f85755df41766b2628203668a`
- MCP `initialize` and `tools/list` without credentials
