### PR TITLE
Add generate-data MCP server

### DIFF
--- a/servers/generate-data/server.yaml
+++ b/servers/generate-data/server.yaml
@@ -1,0 +1,29 @@
+name: generate-data
+image: mcp/generate-data
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - testing
+    - synthetic-data
+    - data-generation
+about:
+  title: Generate-Data
+  description: >-
+    Generate synthetic datasets from a field schema, design schemas from
+    natural language, discover field types, and (Premium) manage multi-table
+    Projects — via the Generate-Data.com API. 7 curated tools: dataset
+    generation (CSV/JSON/XML/Parquet/ZIP, binary-safe), AI schema design,
+    field-type discovery, usage stats, and Premium Project listing/generation.
+  icon: https://avatars.githubusercontent.com/u/42181642?v=4
+source:
+  project: https://github.com/ns-3e/generate-data-mcp
+  commit: bfe0fd20b31159d5d88c2cc5480eda9215e3c922
+config:
+  description: >-
+    Requires a Generate-Data.com API key. Create one in Settings -> API
+    Access on generate-data.com.
+  secrets:
+    - name: generate-data.generate_data_api_key
+      env: GENERATE_DATA_API_KEY
+      example: <GENERATE_DATA_API_KEY>


### PR DESCRIPTION
## MCP Server Information

**Server Name:** generate-data
**Repository URL:** https://github.com/ns-3e/generate-data-mcp
**Brief Description:** MCP server for Generate-Data.com. Generate synthetic datasets from a field schema, design schemas from natural language, discover field types, and (Premium) manage multi-table Projects — 7 curated tools, binary-safe output (base64), server-side input validation, and one consistent response envelope across every tool.

## Basic Requirements

- [x] **Open Source:** Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license) — MIT
- [x] **MCP Compliant:** Implements MCP API specification — stdio transport via the official `mcp` Python SDK (`FastMCP`)
- [x] **Active Development:** Recent commits and maintained — v2.0.1, full rebuild against MCP design principles just landed
- [x] **Docker Artifact:** Dockerfile present at repo root — self-built local server (non-root user, `HEALTHCHECK`); `task build` builds it from the pinned source commit
- [x] **Documentation:** Basic README and setup instructions — README covers install (`uvx`/Claude Desktop/Cursor config), quickstart, full tool reference, troubleshooting
- [x] **Security Contact:** Method for reporting security issues — via GitHub Issues on the repo (open source, single maintainer, no dedicated security email yet)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name generate-data` (via `go run ./cmd/validate --name generate-data`) — all checks passed
- [x] I have built the MCP Server using `task build -- --tools generate-data` (via `go run ./cmd/build --tools generate-data`) — image built successfully from the source repo's Dockerfile; **7 tools auto-detected** by running the container
- [x] If the server requires credentials to test it, I have shared test credentials using this form — requires one secret, `GENERATE_DATA_API_KEY` (Generate-Data.com API key); will share a test key via the linked form if reviewers need one

## Notes

Local (containerized) entry, self-built image (no `--image` flag) — happy to have Docker build/sign it instead if preferred. `task catalog -- generate-data` also generates cleanly for local MCP Toolkit testing. Source repo's own test suite: 43/43 passing (`pytest tests/ -v`); Dockerfile independently smoke-tested (non-root uid 1000, `healthy` healthcheck, real stdio JSON-RPC round-trip verified).