### PR TITLE
Add AI NetCafé (remote): publish apps to managed hosting + metered multi-LLM tools

### DIFF
--- a/servers/ai-netcafe/server.yaml
+++ b/servers/ai-netcafe/server.yaml
@@ -1,0 +1,20 @@
+name: ai-netcafe
+type: remote
+dynamic:
+    tools: true
+meta:
+    category: productivity
+    tags:
+        - hosting
+        - deployment
+        - llm
+        - pdf
+        - research
+        - remote
+about:
+    title: AI NetCafé
+    description: AI NetCafé is a launch and growth platform for AI-built web apps, exposed as a remote MCP server with a free anonymous quota. Agents can publish an app to managed hosting with one tool call (submit_project reviews the repo, builds it from source — plain static sites included — and deploys it on a dedicated subdomain, publicly listed or private with a password), then track it with project_status. It also runs one prompt across 20+ LLMs with actually metered USD cost and latency (compare_models), translates full PDFs while preserving formulas and layout, produces cited autonomous research reports, and generates downloadable .pptx files. Every call is metered; hosted app authors accrue a revenue share.
+    icon: https://raw.githubusercontent.com/mario03690/ai-netcafe/main/logo.png
+remote:
+    transport_type: streamable-http
+    url: https://ainetcafe.com/mcp


### PR DESCRIPTION
Adds **AI NetCafé** as a remote MCP server (streamable-http, `https://ainetcafe.com/mcp`).

- **No auth needed to try**: anonymous free quota; optional `Authorization: Bearer <AllRouter key>` for unlimited use
- 11 tools, dynamic discovery. Distinctive: `submit_project` — an agent publishes a web app (GitHub repo with a Dockerfile, an official image, or a plain static site) to managed hosting in one call: automated review → source build → dedicated subdomain + HTTPS → public listing or private (unlisted + password) → per-call metering with an author revenue share. `project_status` tracks it to live/rejected.
- Also: `compare_models` (one prompt across 20+ LLMs with actually-metered USD cost/latency), full-PDF translation preserving formulas/layout, cited autonomous research, real .pptx generation (async via `check_job`)
- Already listed on the official MCP registry (`com.ainetcafe/ai-netcafe` v1.2.0), Smithery (90/100), Glama; npm CLI `npx ai-netcafe`
- Manifest: https://ainetcafe.com/.well-known/mcp.json · Docs: https://ainetcafe.com/mcp.html

Verified live: `initialize` → `tools/list` (11 tools) → `list_apps` returns the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)