### PR TITLE
Fix short-io auth header: bare API key, not Bearer

### DIFF
--- a/servers/short-io/server.yaml
+++ b/servers/short-io/server.yaml
@@ -15,7 +15,7 @@ remote:
   transport_type: streamable-http
   url: https://ai-assistant.short.io/mcp
   headers:
-    Authorization: "Bearer ${SHORT_IO_API_KEY}"
+    Authorization: "${SHORT_IO_API_KEY}"
 config:
   secrets:
     - name: short-io.api_key


### PR DESCRIPTION
The `short-io` remote entry specifies a `Bearer` prefix on the API key. The Short.io MCP endpoint rejects that format, so the server fails to connect for anyone using this entry as-is.

`https://ai-assistant.short.io/mcp` expects the **bare** key in `Authorization`, the same format as the [Short.io REST API](https://developers.short.io/reference/getapidomains).

### Why this is easy to miss

The endpoint answers a malformed `Authorization` header with:

```json
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: No API key provided"},"id":null}
```

That is the same response it gives when no header is sent at all. A format error is therefore indistinguishable from an invalid or expired key, which sends people off checking their key rather than the header.

### Verification

Tested against the live endpoint with a valid `sk_` key on 4 August 2026, sending an `initialize` request over streamable HTTP:

| Authorization carrier | Result |
|---|---|
| `Authorization: sk_...` | **200**, `serverInfo` "Link shortener v0.0.1", 11 tools listed |
| `Authorization: Bearer sk_...` | 401 `No API key provided` |
| `Authorization: bearer sk_...` | 401 |
| `Authorization: ApiKey sk_...` | 401 |
| `x-api-key` / `X-API-KEY` / `apikey` | 401 |
| `?apiKey=` / `?api_key=` / `?key=` / `?token=` | 401 |

The bare key is the only carrier the endpoint accepts.

### Change

One line in `servers/short-io/server.yaml`:

```diff
   headers:
-    Authorization: "Bearer ${SHORT_IO_API_KEY}"
+    Authorization: "${SHORT_IO_API_KEY}"
```

No other fields touched. The endpoint URL, transport type and secret name are all correct as they stand.

I can share test credentials via the form in CONTRIBUTING.md if that helps with review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
