### PR TITLE
Add mcp-tolerance: ISO 286 dimensional tolerance verification

### DIFF
--- a/servers/mcp-tolerance/server.yaml
+++ b/servers/mcp-tolerance/server.yaml
@@ -1,0 +1,23 @@
+name: mcp-tolerance
+image: ghcr.io/casys-ai/mcp-tolerance
+type: server
+meta:
+  category: tools
+  tags:
+    - engineering
+    - mechanical-engineering
+    - tolerances
+    - iso-286
+    - manufacturing
+    - cad
+about:
+  title: "ISO 286 Tolerance Oracle"
+  description: "Dimensional tolerance verification from the ISO 286-1 normative formulas and tables: hole/shaft deviation limits (H7, g6, ...), fit analysis (clearance / transition / interference) and 1D tolerance stack-ups (worst-case and RSS). Pure computation, no external binary; every result carries an explicit provenance field, and unsupported tolerance classes are refused with a typed error instead of interpolated. The tools report limits — assessing fit suitability stays with the caller."
+  icon: "https://avatars.githubusercontent.com/u/178150674?v=4"
+source:
+  project: "https://github.com/Casys-AI/mcp-tolerance"
+  commit: "c2f0684e0681fed196fe08abad7f26ebb62935b9"
+run:
+  command:
+    - stdio
+  disableNetwork: true

--- a/servers/mcp-tolerance/tools.json
+++ b/servers/mcp-tolerance/tools.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "tolerance_fit",
+    "description": "Compute hole and shaft deviation limits and fit type for a hole/shaft tolerance designation pair at a given nominal diameter, using ISO 286-1:2010 formulas and tables. Returns EI/ES for the hole, ei/es for the shaft, fit type (clearance/transition/interference), and clearance/interference extremes i",
+    "arguments": [
+      {
+        "name": "hole_code",
+        "type": "string",
+        "desc": "Hole tolerance designation. Only letter 'H' is supported (ISO hole-basis system). Use tolerance_fit_analyze for other hole letters (C, D, E, F, G, JS, K, M, N, P, R, S). Grade must be 1\u201318."
+      },
+      {
+        "name": "shaft_code",
+        "type": "string",
+        "desc": "Shaft tolerance designation, e.g. 'g6'. Supported letters: c, d, e, f, g, h, js, k, m, n, p, r, s, u. Grade must be 1\u201318."
+      },
+      {
+        "name": "nominal_diameter_mm",
+        "type": "number",
+        "desc": "Nominal diameter of the fit in mm, in the range (0, 500]. The engine selects the ISO 286-1 diameter range automatically."
+      }
+    ]
+  },
+  {
+    "name": "tolerance_fit_analyze",
+    "description": "Analyse a hole/shaft fit by tolerance class pair at a given nominal diameter. Returns hole and shaft deviation limits and the fit characterisation: clearance_min_um (EI_hole \u2212 es_shaft), clearance_max_um (ES_hole \u2212 ei_shaft), and fit_type (clearance / transition / interference). Supports both the ho",
+    "arguments": [
+      {
+        "name": "hole_class",
+        "type": "string",
+        "desc": "Hole tolerance class, uppercase letter + grade. Supported hole letters: C, D, E, F, G, H, JS, K, M, N, P, R, S."
+      },
+      {
+        "name": "shaft_class",
+        "type": "string",
+        "desc": "Shaft tolerance class, lowercase letter + grade. Supported shaft letters: c, d, e, f, g, h, js, k, m, n, p, r, s, u."
+      },
+      {
+        "name": "nominal_diameter_mm",
+        "type": "number",
+        "desc": "Nominal diameter of the fit in mm, in the range (0, 500]."
+      }
+    ]
+  },
+  {
+    "name": "tolerance_it",
+    "description": "Return the fundamental tolerance value IT in \u00b5m for a given IT grade and nominal diameter, per ISO 286-1:2010. Grades 1\u201312 are from ISO 286-1:2010 Table 1 (tabulated normative values). Grades 13\u201318 are computed from the tolerance factor formula i=0.45\u00d7D^(1/3)+0.001\u00d7D with ISO tiered rounding. Proven",
+    "arguments": [
+      {
+        "name": "grade",
+        "type": "integer",
+        "desc": "IT grade number, 1\u201318."
+      },
+      {
+        "name": "nominal_diameter_mm",
+        "type": "number",
+        "desc": "Nominal diameter in mm, in (0, 500]."
+      }
+    ]
+  },
+  {
+    "name": "tolerance_limits",
+    "description": "Resolve a single ISO 286-1 tolerance class designation (e.g. 'H7', 'g6', 'JS9', 'P6') to upper and lower deviations in \u00b5m at a given nominal diameter. Returns upper_um, lower_um, IT_um, fundamental_deviation_um, and provenance. Uppercase letter = hole; lowercase letter = shaft. Provenance is declare",
+    "arguments": [
+      {
+        "name": "tolerance_class",
+        "type": "string",
+        "desc": "ISO 286-1 tolerance class designation. Uppercase letter(s) + grade for holes (e.g. 'H7', 'G6', 'JS9', 'P6'). Lowercase letter(s) + grade for shafts (e.g. 'g6', 'h6', 'js7', 'p6'). Supported hole lette"
+      },
+      {
+        "name": "nominal_diameter_mm",
+        "type": "number",
+        "desc": "Nominal diameter of the feature in mm, in the range (0, 500]."
+      }
+    ]
+  },
+  {
+    "name": "tolerance_stackup",
+    "description": "Compute worst-case and RSS (Root Sum Square) dimension chain stackup. Each contributor has a nominal_mm, plus_um (upper tolerance offset in \u00b5m), minus_um (lower tolerance offset in \u00b5m), and direction (+1 = adds to gap, \u22121 = subtracts). Returns worst_case_min/max_mm and rss_min/max_mm. Worst-case gua",
+    "arguments": [
+      {
+        "name": "contributors",
+        "type": "array",
+        "desc": "Ordered list of dimensions in the chain. Order does not affect results."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcp-tolerance
**Repository URL:** https://github.com/Casys-AI/mcp-tolerance
**Brief Description:** ISO 286-1 dimensional tolerance verification as a self-contained MCP oracle: hole/shaft deviation limits, fit analysis (clearance/transition/interference) and 1D tolerance stack-ups (worst-case + RSS), computed from the normative formulas — no external binary, no credentials, no network needed at runtime (`disableNetwork: true`).

Part of an open-source engineering verification family (FEA, DFM, slicing, SPICE) built on Deno/TypeScript, MIT.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: stdio transport in the container (server-side adapter over a stateless HTTP core)
- [x] **Active Development**: daily commits
- [x] **Docker Artifact**: Dockerfile at repository root; community-built image at `ghcr.io/casys-ai/mcp-tolerance` (multi-arch amd64/arm64)
- [x] **Documentation**: README with setup and Docker instructions
- [x] **Security Contact**: SECURITY.md (hello@casys.ai)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcp-tolerance` — all checks pass
- [x] `task build -- --tools` not required per CONTRIBUTING: we provide our own image and a committed `tools.json` generated from the live server's `tools/list`
- [x] No credentials are required to test this server (pure computation; the stdio mode was verified with `docker run -i --network=none ghcr.io/casys-ai/mcp-tolerance stdio`)