### PR TITLE
Add mcp-prusaslicer: print time and material estimation from real G-code

### DIFF
--- a/servers/mcp-prusaslicer/server.yaml
+++ b/servers/mcp-prusaslicer/server.yaml
@@ -1,0 +1,23 @@
+name: mcp-prusaslicer
+image: ghcr.io/casys-ai/mcp-prusaslicer
+type: server
+meta:
+  category: tools
+  tags:
+    - engineering
+    - 3d-printing
+    - manufacturing
+    - slicing
+    - prusaslicer
+    - gcode
+about:
+  title: "PrusaSlicer Print Estimation"
+  description: "Print time and material estimation from real PrusaSlicer 2.9 G-code, not heuristics: slice an attested STL with a caller-owned profile (.ini) and get printing time, filament volume and length parsed from the produced G-code stats. Mass is reported only when a filament density is supplied — the server never invents physical values — and the G-code SHA-256 is returned for the audit trail."
+  icon: "https://avatars.githubusercontent.com/u/178150674?v=4"
+source:
+  project: "https://github.com/Casys-AI/mcp-prusaslicer"
+  commit: "dccb4abbcf460eea3b644e864149c3fd462865c6"
+run:
+  command:
+    - stdio
+  disableNetwork: true

--- a/servers/mcp-prusaslicer/tools.json
+++ b/servers/mcp-prusaslicer/tools.json
@@ -1,0 +1,48 @@
+[
+  {
+    "name": "prusaslicer_estimate_fff",
+    "description": "Slice an STL with a caller-supplied PrusaSlicer INI profile and return estimated print time and material consumption from the real G-code stats. The tool measures \u2014 it does not price. Pricing (filament cost, machine time) is handled downstream by erpnext. The profile_ini_path is the sole authority o",
+    "arguments": [
+      {
+        "name": "stl_path",
+        "type": "string",
+        "desc": "Absolute path to the STL file to slice. The file must be accessible on the server filesystem."
+      },
+      {
+        "name": "stl_sha256",
+        "type": "string",
+        "desc": "Optional SHA-256 hex digest of the STL file. When provided, the server verifies the file content before slicing \u2014 ensures the exact committed geometry was consumed."
+      },
+      {
+        "name": "profile_ini_path",
+        "type": "string",
+        "desc": "Absolute path to a PrusaSlicer INI profile file. The server reads this file and passes it to prusa-slicer via --load. The profile is the caller's authority on all print parameters (speeds, temperature"
+      },
+      {
+        "name": "profile_sha256",
+        "type": "string",
+        "desc": "Optional SHA-256 hex digest of the profile file. When provided, the server verifies the profile content before slicing."
+      },
+      {
+        "name": "layer_height_mm",
+        "type": "number",
+        "desc": "Override the layer height from the profile. Forwarded as --layer-height N to prusa-slicer (mm, positive)."
+      },
+      {
+        "name": "infill_percent",
+        "type": "number",
+        "desc": "Override the infill density from the profile (integer 0-100). Forwarded as --fill-density N% to prusa-slicer."
+      },
+      {
+        "name": "filament_density_g_cm3",
+        "type": "number",
+        "desc": "Override the filament density (g/cm\u00b3, positive). Forwarded as --filament-density N. When provided, filament_mass_g is always present in the output."
+      },
+      {
+        "name": "timeout_ms",
+        "type": "number",
+        "desc": "Maximum time in milliseconds to wait for prusa-slicer before aborting. Default: 120000 (2 minutes). Complex models may need more."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcp-prusaslicer
**Repository URL:** https://github.com/Casys-AI/mcp-prusaslicer
**Brief Description:** FDM print estimation from real PrusaSlicer 2.9 G-code (engine bundled in the image): slice an SHA-256-attested STL with a caller-owned profile and get print time, filament volume/length parsed from the produced G-code stats. Mass is reported only when a filament density is supplied — the server never invents physical values.

Part of an open-source engineering verification family, Deno/TypeScript, MIT.

## Basic Requirements

- [x] **Open Source**: MIT (server code; it invokes the PrusaSlicer AGPL binary as a subprocess inside the image, Debian-packaged)
- [x] **MCP Compliant**: stdio transport in the container (server-side adapter over a stateless HTTP core)
- [x] **Active Development**: daily commits
- [x] **Docker Artifact**: Dockerfile at repository root; community-built image at `ghcr.io/casys-ai/mcp-prusaslicer` (multi-arch amd64/arm64)
- [x] **Documentation**: README with setup and Docker instructions
- [x] **Security Contact**: SECURITY.md (hello@casys.ai)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcp-prusaslicer` — all checks pass
- [x] `task build -- --tools` not required per CONTRIBUTING: we provide our own image and a committed `tools.json` generated from the live server's `tools/list`
- [x] No credentials are required to test this server (stdio mode verified with `docker run -i --network=none ghcr.io/casys-ai/mcp-prusaslicer stdio`)