### PR TITLE
Add mcp-spice: circuit verification through ngspice

### DIFF
--- a/servers/mcp-spice/server.yaml
+++ b/servers/mcp-spice/server.yaml
@@ -1,0 +1,23 @@
+name: mcp-spice
+image: ghcr.io/casys-ai/mcp-spice
+type: server
+meta:
+  category: tools
+  tags:
+    - engineering
+    - electronics
+    - spice
+    - ngspice
+    - circuit-simulation
+    - mechatronics
+about:
+  title: "SPICE Circuit Verification"
+  description: "Circuit verification through ngspice batch simulation: DC operating points (node voltages) and reduced transient analysis (min/max/final per requested node) from a SHA-256-attested SPICE netlist. The server owns the .control block — caller netlists are circuit-only, and .control/.include/.lib/shell directives are refused with typed errors — so simulation stays sandboxed and reproducible."
+  icon: "https://avatars.githubusercontent.com/u/178150674?v=4"
+source:
+  project: "https://github.com/Casys-AI/mcp-spice"
+  commit: "c9ee760e80f7781a969bc3d17b6d4625511ec400"
+run:
+  command:
+    - stdio
+  disableNetwork: true

--- a/servers/mcp-spice/tools.json
+++ b/servers/mcp-spice/tools.json
@@ -1,0 +1,64 @@
+[
+  {
+    "name": "spice_simulate_op",
+    "description": "Run an ngspice DC operating-point (.op) simulation on a caller-supplied circuit netlist (no .control block) and return requested node voltages. The server writes the .control block and validates the netlist for forbidden directives before running. The tool measures; it does not declare whether the c",
+    "arguments": [
+      {
+        "name": "netlist_path",
+        "type": "string",
+        "desc": "Absolute path to the SPICE netlist (.cir / .sp / .spi). The netlist must contain only circuit elements and a .op directive. Do NOT include a .control block \u2014 the server writes it. Forbidden: .control,"
+      },
+      {
+        "name": "netlist_sha256",
+        "type": "string",
+        "desc": "64-char hex SHA-256 of the netlist file. The server computes the digest of its private snapshot and raises NetlistArtifactError if it differs from this value."
+      },
+      {
+        "name": "nodes",
+        "type": "array",
+        "desc": "Node names whose DC voltages are requested (e.g. [\"out\", \"vdd\"]). Use bare names as they appear in the netlist, without the v() wrapper. The ground node is \"0\"."
+      },
+      {
+        "name": "timeout_s",
+        "type": "number",
+        "desc": "Simulation timeout in seconds (default 30, max 300)."
+      }
+    ]
+  },
+  {
+    "name": "spice_simulate_tran",
+    "description": "Run an ngspice transient (.tran) simulation on a caller-supplied circuit netlist (no .control block) and return per-node statistics (min, max, final voltage) over the full transient window. The full time series is never returned \u2014 only reduced statistics. The server writes the .control block and val",
+    "arguments": [
+      {
+        "name": "netlist_path",
+        "type": "string",
+        "desc": "Absolute path to the SPICE netlist (.cir / .sp / .spi). The netlist must contain only circuit elements and a .tran directive. Do NOT include a .control block \u2014 the server writes it. Forbidden: .contro"
+      },
+      {
+        "name": "netlist_sha256",
+        "type": "string",
+        "desc": "64-char hex SHA-256 of the netlist file. Raises NetlistArtifactError if the snapshot digest differs."
+      },
+      {
+        "name": "tstep_s",
+        "type": "number",
+        "desc": "Suggested time step in seconds (e.g. 1e-5 for 10 \u00b5s). ngspice uses this as a hint; the actual step is adaptive."
+      },
+      {
+        "name": "tstop_s",
+        "type": "number",
+        "desc": "Stop time in seconds (e.g. 6e-3 for 6 ms)."
+      },
+      {
+        "name": "nodes",
+        "type": "array",
+        "desc": "Node names whose transient statistics are requested (e.g. [\"out\", \"vdd\"]). Use bare names without the v() wrapper."
+      },
+      {
+        "name": "timeout_s",
+        "type": "number",
+        "desc": "Simulation timeout in seconds (default 30, max 300)."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcp-spice
**Repository URL:** https://github.com/Casys-AI/mcp-spice
**Brief Description:** SPICE circuit verification through ngspice 44 batch (engine bundled in the image): DC operating points and reduced transient statistics from an SHA-256-attested netlist. The server owns the .control block — caller netlists are circuit-only, and .control/.include/.lib/shell directives are refused with typed errors, keeping simulation sandboxed and reproducible.

Part of an open-source engineering verification family, Deno/TypeScript, MIT.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: stdio transport in the container (server-side adapter over a stateless HTTP core)
- [x] **Active Development**: daily commits
- [x] **Docker Artifact**: Dockerfile at repository root; community-built image at `ghcr.io/casys-ai/mcp-spice` (multi-arch amd64/arm64)
- [x] **Documentation**: README with setup and Docker instructions
- [x] **Security Contact**: SECURITY.md (hello@casys.ai)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcp-spice` — all checks pass
- [x] `task build -- --tools` not required per CONTRIBUTING: we provide our own image and a committed `tools.json` generated from the live server's `tools/list`
- [x] No credentials are required to test this server (stdio mode verified with `docker run -i --network=none ghcr.io/casys-ai/mcp-spice stdio`)