### PR TITLE
Add rstream MCP server

### DIFF
--- a/servers/rstream/server.yaml
+++ b/servers/rstream/server.yaml
@@ -1,5 +1,5 @@
 name: rstream
-image: rstream/rstream:1.26.6
+image: rstream/rstream:1.29.1
 type: server
 meta:
   category: devops
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/142778867?s=200&v=4
 source:
   project: https://github.com/rstreamlabs/rstream-go
-  commit: b2311902d61e98f92f4327ec0f900f2c210c1ab1
+  commit: 2241c230f858981e03b806e8924a5d200174108a
 run:
   command:
     - mcp

--- a/servers/rstream/server.yaml
+++ b/servers/rstream/server.yaml
@@ -1,5 +1,5 @@
 name: rstream
-image: rstream/rstream:1.29.3
+image: rstream/rstream:1.29.1
 type: server
 meta:
   category: devops
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/142778867?s=200&v=4
 source:
   project: https://github.com/rstreamlabs/rstream-go
-  commit: 0693b1ffa9159586dba2cdd91c2b0b6ed20ccdc2
+  commit: 2241c230f858981e03b806e8924a5d200174108a
 run:
   command:
     - mcp

--- a/servers/rstream/server.yaml
+++ b/servers/rstream/server.yaml
@@ -1,5 +1,5 @@
 name: rstream
-image: rstream/rstream:1.29.1
+image: rstream/rstream:1.29.3
 type: server
 meta:
   category: devops
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/142778867?s=200&v=4
 source:
   project: https://github.com/rstreamlabs/rstream-go
-  commit: 2241c230f858981e03b806e8924a5d200174108a
+  commit: 0693b1ffa9159586dba2cdd91c2b0b6ed20ccdc2
 run:
   command:
     - mcp

--- a/servers/rstream/server.yaml
+++ b/servers/rstream/server.yaml
@@ -1,5 +1,5 @@
 name: rstream
-image: rstream/rstream:1.29.1
+image: rstream/rstream:1.30.0
 type: server
 meta:
   category: devops
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/142778867?s=200&v=4
 source:
   project: https://github.com/rstreamlabs/rstream-go
-  commit: 2241c230f858981e03b806e8924a5d200174108a
+  commit: 46c3d59f38e4d852ee35780534d61f32a3d27994
 run:
   command:
     - mcp

--- a/servers/rstream/server.yaml
+++ b/servers/rstream/server.yaml
@@ -1,0 +1,22 @@
+name: rstream
+image: rstream/rstream:1.26.6
+type: server
+meta:
+  category: devops
+  tags:
+    - rstream
+    - tunneling
+    - networking
+    - remote-access
+    - developer-tools
+about:
+  title: Secure Tunneling CLI
+  description: Local stdio MCP server for rstream setup, tunnels, WebTTY, and remote operations.
+  icon: https://avatars.githubusercontent.com/u/142778867?s=200&v=4
+source:
+  project: https://github.com/rstreamlabs/rstream-go
+  commit: b2311902d61e98f92f4327ec0f900f2c210c1ab1
+run:
+  command:
+    - mcp
+    - serve

--- a/servers/rstream/server.yaml
+++ b/servers/rstream/server.yaml
@@ -1,5 +1,5 @@
 name: rstream
-image: rstream/rstream:1.30.0
+image: rstream/rstream:1.31.0
 type: server
 meta:
   category: devops
@@ -15,7 +15,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/142778867?s=200&v=4
 source:
   project: https://github.com/rstreamlabs/rstream-go
-  commit: 46c3d59f38e4d852ee35780534d61f32a3d27994
+  commit: c91b25410993a3fa194075ce57d3ee473474568f
 run:
   command:
     - mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** rstream
**Repository URL:** https://github.com/rstreamlabs/rstream-go
**Brief Description:** Local stdio MCP server for rstream setup, tunnels, WebTTY, and remote operations. The entry references the existing publisher-provided image `docker.io/rstream/rstream:1.29.1` and runs `rstream mcp serve`.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP protocol version 2025-11-25
- [x] **Active Development**: Recent releases and commits
- [x] **Docker Artifact**: Existing Dockerfile and public multi-platform image
- [x] **Documentation**: README includes MCP setup and usage
- [x] **Security Contact**: SECURITY.md is available in the source repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] I validated the entry with `go run ./cmd/validate --name rstream`
- [x] I generated the test catalog with `go run ./cmd/catalog rstream`
- [x] I verified the published image by completing MCP initialize and tools/list over stdio; all 65 tools were discovered
- [x] This submission uses the existing publisher-provided image, so the contributing guide states that a registry-side image build is not required
- [x] The server can list tools without credentials, so no test credentials are required