### PR TITLE
Add Datadef (remote server)

### DIFF
--- a/servers/datadef/readme.md
+++ b/servers/datadef/readme.md
@@ -1,0 +1,9 @@
+# Datadef
+
+Generate, edit, and export data-architecture diagrams from any MCP client. Describe a pipeline ("Kafka → Flink → Iceberg with the marts on top") and the server returns an editable diagram — typed tables with columns, column-level lineage, 2,000+ real tool icons — plus a PNG inline in the chat.
+
+**Authentication:** the server requires `Authorization: Bearer dd_live_...`. Create an API key at [datadef.io/settings/mcp](https://datadef.io/settings/mcp) — the 7-day free trial includes MCP access.
+
+**Tools:** outcome-level (`create_diagram`, `list_diagrams`, `get_diagram`, `edit_diagram`, `export_diagram`, `get_design_guide`) plus 25 atomic `canvas_*` tools the calling model can drive directly. A `datadef_design_guide` prompt teaches any model the design standard before it draws.
+
+Documentation: [datadef.io/guides/en/mcp-diagram-server](https://datadef.io/guides/en/mcp-diagram-server)

--- a/servers/datadef/server.yaml
+++ b/servers/datadef/server.yaml
@@ -1,0 +1,17 @@
+name: datadef
+type: remote
+meta:
+  category: productivity
+  tags:
+    - diagrams
+    - data-engineering
+    - documentation
+    - design
+    - remote
+about:
+  title: Datadef
+  description: Generate, edit, and export data-architecture diagrams from your AI client — typed tables, column-level lineage, real tool icons, PNGs returned inline.
+  icon: https://datadef.io/datadef_logo.png
+remote:
+  transport_type: streamable-http
+  url: https://datadef.io/mcp

--- a/servers/datadef/tools.json
+++ b/servers/datadef/tools.json
@@ -1,0 +1,8 @@
+[
+  { "name": "create_diagram", "description": "Generate a diagram from a description, save it, return a PNG and an editable link" },
+  { "name": "list_diagrams", "description": "List the user's diagrams" },
+  { "name": "get_diagram", "description": "Read a diagram's full structure — nodes, columns, edges, groups" },
+  { "name": "edit_diagram", "description": "Change a diagram with a natural-language instruction" },
+  { "name": "export_diagram", "description": "Render a diagram to PNG or JPEG" },
+  { "name": "get_design_guide", "description": "The design standard any model should read before drawing" }
+]


### PR DESCRIPTION
Adds Datadef, a remote Streamable HTTP MCP server for data-architecture diagrams: generate, edit, and export diagrams (typed tables, column-level lineage, real tool icons) from any MCP client, PNGs returned inline. Official vendor implementation, listed in the MCP Registry as io.datadef/mcp. Auth is a bearer API key from datadef.io/settings/mcp, noted in the readme; happy to add a config/secrets block if you prefer that shape for key-based remotes. Test credentials available on request.