### PR TITLE
Add WebScraping.AI MCP server

### DIFF
--- a/servers/webscraping-ai/server.yaml
+++ b/servers/webscraping-ai/server.yaml
@@ -1,0 +1,32 @@
+name: webscraping-ai
+image: mcp/webscraping-ai
+type: server
+meta:
+  category: web-scraping
+  tags:
+    - web-scraping
+    - data-extraction
+    - scraping
+about:
+  title: WebScraping.AI
+  description: Web scraping with JavaScript rendering, rotating proxies, and AI-powered data extraction. Get pages as HTML or text, select fragments with CSS selectors, ask questions about page content, and extract structured fields via the WebScraping.AI API.
+  icon: https://avatars.githubusercontent.com/u/71596876?s=200&v=4
+source:
+  project: https://github.com/webscraping-ai/webscraping-ai-mcp-server
+  commit: be1edd17ccb67327244d5b6168809a825d025eb4
+config:
+  description: Configure the connection to WebScraping.AI
+  secrets:
+    - name: webscraping-ai.api_key
+      env: WEBSCRAPING_AI_API_KEY
+      example: YOUR-API-KEY
+      description: If you don't have an account, create one and get an API key at [webscraping.ai](https://webscraping.ai)
+  env:
+    - name: WEBSCRAPING_AI_CONCURRENCY_LIMIT
+      example: 5
+      value: "{{webscraping-ai.concurrency_limit}}"
+  parameters:
+    type: object
+    properties:
+      concurrency_limit:
+        type: integer


### PR DESCRIPTION
Adds [WebScraping.AI](https://webscraping.ai) — a web scraping API with JavaScript rendering (headless Chrome), rotating datacenter/residential proxies, and AI-powered extraction (question answering and structured fields).

- Source: https://github.com/webscraping-ai/webscraping-ai-mcp-server (MIT, Dockerfile at repo root, stdio transport)
- Also published in the official MCP registry as `io.github.webscraping-ai/webscraping-ai` (npm: `webscraping-ai-mcp`)
- Requires `WEBSCRAPING_AI_API_KEY` (free trial keys available at webscraping.ai); optional `WEBSCRAPING_AI_CONCURRENCY_LIMIT`

Submitted by the WebScraping.AI team (I'm in the `webscraping-ai` GitHub org). Happy to share test credentials via the form for review.