### PR TITLE
Add PlantUML MCP server

### DIFF
--- a/servers/plantuml/server.yaml
+++ b/servers/plantuml/server.yaml
@@ -1,0 +1,18 @@
+name: plantuml
+image: mcp/plantuml
+type: server
+meta:
+  category: productivity
+  tags:
+    - plantuml
+    - uml
+    - diagrams
+about:
+  title: PlantUML
+  icon: https://avatars.githubusercontent.com/u/33107703?s=200&v=4
+  description: >-
+    Render PlantUML source to SVG or PNG through Model Context Protocol.
+    Community project, not affiliated with or endorsed by the PlantUML project.
+source:
+  project: https://github.com/potofo/plantuml-mcp-server
+  commit: a8ad36cd233be722bf737ca42755cafe54956c80


### PR DESCRIPTION
## What

Adds the PlantUML MCP server: renders PlantUML source to SVG or PNG over
MCP (stdio), in-process via the MIT-licensed `plantuml-mit` artifact —
no external PlantUML server required. Graphviz (EPL-1.0) is bundled in
the image as a separate external program for diagram layout.

- Source: https://github.com/potofo/plantuml-mcp-server
- License: MIT (`net.sourceforge.plantuml:plantuml-mit`; no GPL components)
- Tools: `render_svg`, `render_png` — no configuration or secrets required
- Docker-built image requested (`mcp/` namespace)
- Multi-arch proven: the v0.1.0 release publishes linux/amd64 + linux/arm64
- Community project; not affiliated with or endorsed by the PlantUML project

## Testing

- `task build -- --tools plantuml` discovers both tools
- `task catalog -- plantuml` + `docker mcp catalog import` verified locally
- The source repo runs an EARS-traced acceptance suite in CI
  (see `test/ACCEPTANCE.md` there)
