### PR TITLE
Add sms-florin-mcp to Communication

### DIFF
--- a/servers/sms-florin-mcp/server.yaml
+++ b/servers/sms-florin-mcp/server.yaml
@@ -1,0 +1,27 @@
+name: sms-florin-mcp
+image: mcp/sms-florin-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - sms
+    - otp
+    - phone-verification
+    - testing
+about:
+  title: sms-florin
+  description: |
+    Rent a real UK phone number and receive SMS/OTP verification codes directly from an AI coding
+    agent. Built for automated QA/testing of signup and verification flows (WhatsApp, Telegram,
+    Google, Discord, and more) — numbers are real SIM cards on UK carrier networks (EE/Three), not
+    VoIP, via sms-florin's own GOIP hardware.
+  icon: https://www.google.com/s2/favicons?domain=flo-voice1.com&sz=64
+source:
+  project: https://github.com/flovoice53-tech/sms-florin-mcp
+  commit: d5b64703adbfed4eee517e3742006aa7b13d7ec4
+config:
+  description: Configure your sms-florin API key (generate one at https://flo-voice1.com/api-access)
+  secrets:
+    - name: sms-florin-mcp.api_key
+      env: SMS_FLORIN_API_KEY
+      example: <SMS_FLORIN_API_KEY>

--- a/servers/sms-florin-mcp/server.yaml
+++ b/servers/sms-florin-mcp/server.yaml
@@ -15,7 +15,7 @@ about:
     agent. Built for automated QA/testing of signup and verification flows (WhatsApp, Telegram,
     Google, Discord, and more) — numbers are real SIM cards on UK carrier networks (EE/Three), not
     VoIP, via sms-florin's own GOIP hardware.
-  icon: https://www.google.com/s2/favicons?domain=flo-voice1.com&sz=64
+  icon: https://flo-voice1.com/icon.png
 source:
   project: https://github.com/flovoice53-tech/sms-florin-mcp
   commit: d5b64703adbfed4eee517e3742006aa7b13d7ec4


### PR DESCRIPTION
## MCP Server Information

**Server Name:** sms-florin-mcp
**Repository URL:** https://github.com/flovoice53-tech/sms-florin-mcp
**Brief Description:** Rent a real UK phone number and receive SMS/OTP verification codes directly from an AI coding agent — built for automated QA/testing of signup and verification flows. Numbers are real SIM cards on UK carrier networks (EE/Three), not VoIP.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (stdio transport, built on `@modelcontextprotocol/sdk`)
- [x] **Active Development**: Recent commits, published to npm and the official MCP Registry
- [x] **Docker Artifact**: Dockerfile present in the repo (already used to build/list this server on Glama's MCP directory)
- [x] **Documentation**: README with setup instructions for Claude Code/Desktop, Cursor, Windsurf
- [x] **Security Contact**: SECURITY.md added, points to florin@flo-voice.com / https://flo-voice1.com/.well-known/security.txt

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name sms-florin-mcp` — no Go/Taskfile toolchain available in my environment to run this locally; `server.yaml` was hand-written to mirror an existing merged entry (`servers/openweather/server.yaml`) field-for-field and validated as well-formed YAML. Happy to fix anything the CI/review flags.
- [ ] I have built the MCP Server using `task build -- --tools sms-florin-mcp` — same tooling limitation as above.
- [ ] N/A — server requires only an API key (`SMS_FLORIN_API_KEY`), no special test credentials needed beyond what's in `config.secrets`.

No tools.json/readme.md included per the local-server template (only required when the server needs configuration before listing tools, which isn't the case here — auth is a single API key).