### PR TITLE
Add SV Number (SMS verification numbers for AI agents)

### DIFF
--- a/servers/sv-number/server.yaml
+++ b/servers/sv-number/server.yaml
@@ -1,0 +1,23 @@
+name: sv-number
+image: mcp/sv-number
+type: server
+meta:
+  category: communication
+  tags:
+    - sms
+    - otp
+    - verification
+    - communication
+about:
+  title: SV Number
+  description: Phone numbers for AI agents. Order a private number for one service in one country, wait for the SMS verification code (returned already parsed out of the SMS), request another code on the same number, cancel for a refund, and compute TOTP codes locally (RFC 6238).
+  icon: https://raw.githubusercontent.com/sv-number/mcp-server/main/assets/logo-400.png
+source:
+  project: https://github.com/sv-number/mcp-server
+  commit: c30b31df4d05f39374e394a2b75a1c148b169fd0
+config:
+  description: Configure the SV Number API key
+  secrets:
+    - name: sv-number.api_key
+      env: SVN_API_KEY
+      example: your_api_key_here


### PR DESCRIPTION
Adds **SV Number** — phone numbers for AI agents over stdio (TypeScript, `@modelcontextprotocol/sdk`).

The agent orders a private number for a given service and country, waits for the SMS verification code (the server parses it out of the SMS), can request another code on the same number, cancel for a refund, and generate TOTP codes locally (RFC 6238). Nine tools.

- Source: https://github.com/sv-number/mcp-server (MIT, Dockerfile included)
- npm: https://www.npmjs.com/package/sv-number-mcp
- Official MCP Registry: `io.github.sv-number/mcp-server`
- Requires `SVN_API_KEY` (declared as secret in server.yaml)