### PR TITLE
Add AIPCS

### DIFF
--- a/servers/aipcs/server.yaml
+++ b/servers/aipcs/server.yaml
@@ -1,0 +1,21 @@
+name: aipcs
+image: mcp/aipcs
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - memory
+    - persistent-memory
+about:
+  title: AIPCS
+  description: Durable structured memory for agents, with explicit schemas and exact retrieval.
+  icon: https://raw.githubusercontent.com/randallcmark/aipcs-mcp/60b5a943163ecabb4fc8189c7f8ae9ad61e30a6d/assets/aipcs-mark.svg
+source:
+  project: https://github.com/randallcmark/aipcs-mcp
+  commit: 60b5a943163ecabb4fc8189c7f8ae9ad61e30a6d
+config:
+  description: Stores local AIPCS data in a persistent Docker-managed volume.
+run:
+  volumes:
+    - aipcs-data:/app/.local/share/aipcs


### PR DESCRIPTION
## What changed

Adds AIPCS to the Docker MCP Registry as a Docker-built local MCP server.

## Why

AIPCS provides durable structured memory for agents. The default container runs the local SQLite-backed stdio MCP service as a non-root user and persists data in a Docker-managed volume.

## Validation

- `go run ./cmd/validate -name aipcs`
- `go run ./cmd/build -tools aipcs` — built the exact source pin and discovered 21 MCP tools

The registry's `catalog` preview currently cannot complete before Docker has created `mcp/aipcs`: it requests Docker Hub metadata for that not-yet-published image. The entry passes the registry validator and build/tool-discovery path.
