### PR TITLE
Add Resemble AI remote MCP server

### DIFF
--- a/servers/resemble-remote/server.yaml
+++ b/servers/resemble-remote/server.yaml
@@ -1,0 +1,24 @@
+name: resemble-remote
+type: remote
+meta:
+  category: ai
+  tags:
+    - ai
+    - deepfake-detection
+    - media
+    - watermarking
+    - remote
+about:
+  title: Resemble AI
+  description: Detect AI-generated audio, image, and video, trace synthetic audio back to the platform that generated it, extract media intelligence such as transcription and speaker identity, and apply or verify invisible provenance watermarks.
+  icon: https://avatars.githubusercontent.com/u/49844015?s=200&v=4
+remote:
+  transport_type: streamable-http
+  url: https://mcp.resemble.ai/mcp
+  headers:
+    Authorization: "Bearer ${RESEMBLE_REMOTE_API_KEY}"
+config:
+  secrets:
+    - name: resemble-remote.api_key
+      env: RESEMBLE_REMOTE_API_KEY
+      example: <YOUR_API_KEY>


### PR DESCRIPTION
## MCP Server Information

**Server Name:** resemble-remote
**Repository URL:** https://github.com/resemble-ai/resemble-mcp
**Brief Description:** Deepfake detection and media provenance. Analyzes audio, image, and video for AI generation, traces synthetic audio back to the platform that produced it, extracts media intelligence (transcription, speaker identity, emotion), and applies or verifies invisible watermarks.

## Basic Requirements

- [x] **Open Source**: MIT (`LICENSE` at repo root — note GitHub's license detector currently reports none, the file is a standard MIT text)
- [x] **MCP Compliant**: Streamable HTTP. Verified live — `initialize` returns `serverInfo: resemble-actions`, and `tools/list` returns seven tools
- [x] **Active Development**: last push today
- [ ] **Docker Artifact**: not applicable — this is a `type: remote` entry, matching the existing `dappier-remote` and `stripe-remote` pattern. A Dockerfile does exist in the repo for the self-hosted variant
- [x] **Documentation**: README plus `CONNECT.md` with per-client setup
- [ ] **Security Contact**: no `SECURITY.md` yet — will add one; reachable meanwhile at security@resemble.ai

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [ ] I have tested using `task validate` — not run locally. The endpoint was verified directly with an `initialize` handshake and a `tools/list` call against `https://mcp.resemble.ai/mcp`. Happy to run it if you'd like that confirmed before review
- [ ] Test credentials — the server authenticates with the user's own Resemble API key as a Bearer token. Free keys are self-serve at https://app.resemble.ai/account/api; I can supply a reviewer key through the form if that's easier

## Tools exposed

`detect_deepfake` · `get_detection` · `analyze_media` · `ask_about_detection` · `trace_audio_source` · `detect_watermark` · `apply_watermark`

Auth follows the `dappier-remote` shape: `remote.headers.Authorization` with a `config.secrets` entry, since this is a static API key rather than an OAuth flow. Also published to the official MCP registry as `io.github.resemble-ai/resemble-mcp`.
