### PR TITLE
Add Proximo (self-provided pre-built image)

### DIFF
--- a/servers/proximo/server.yaml
+++ b/servers/proximo/server.yaml
@@ -1,0 +1,48 @@
+name: proximo
+image: ghcr.io/john-broadway/proximo
+type: server
+meta:
+  category: devops
+  tags:
+    - proxmox
+    - virtualization
+    - backup
+    - infrastructure
+    - devops
+about:
+  title: Proximo
+  description: "Proxmox VE/PBS/PMG/PDM administration with a governed mutation path: every change is planned with its blast radius before it runs, recorded in a hash-chained tamper-evident audit ledger, and undoable wherever the platform can snapshot. Read-only by default."
+  icon: https://raw.githubusercontent.com/john-broadway/proximo/main/docs/brand/proximo-avatar-256.png
+source:
+  project: https://github.com/john-broadway/proximo
+  commit: 62b69712f5b27cfd60fa2d44ef7aa8d6b3e8b73d
+run:
+  volumes:
+    - "{{proximo.token_file}}:/run/proximo/pve-token:ro"
+  env:
+    PROXIMO_TOKEN_PATH: /run/proximo/pve-token
+config:
+  description: "Configure the connection to your Proxmox cluster. The API token is passed by FILE REFERENCE rather than as an environment variable: point token_file at a file on your machine containing USER@REALM!TOKENID=SECRET, chmod 600. Proximo refuses to start if that file is group- or world-readable."
+  env:
+    - name: PROXIMO_API_BASE_URL
+      example: https://pve.example.com:8006/api2/json
+      value: "{{proximo.api_base_url}}"
+    - name: PROXIMO_NODE
+      example: pve
+      value: "{{proximo.node}}"
+  parameters:
+    type: object
+    properties:
+      api_base_url:
+        type: string
+        description: Base URL of the Proxmox VE API, including /api2/json
+      node:
+        type: string
+        description: Default Proxmox node name to operate against
+      token_file:
+        type: string
+        description: Path on your machine to a mode-600 file containing the Proxmox API token as USER@REALM!TOKENID=SECRET
+    required:
+      - api_base_url
+      - node
+      - token_file

--- a/servers/proximo/tools.json
+++ b/servers/proximo/tools.json
@@ -1,0 +1,22175 @@
+[
+  {
+    "name": "ct_exec",
+    "description": "MUTATION-CAPABLE: run a command inside an LXC (ssh -> pct exec).",
+    "arguments": [
+      {
+        "name": "ctid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "snapshot",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ct_psql",
+    "description": "MUTATION-CAPABLE: run SQL via psql inside a container (as the db OS user).",
+    "arguments": [
+      {
+        "name": "ctid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sql",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "db",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapshot",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "audit_entries",
+    "description": "READ-ONLY: WHO changed WHAT and WHEN \u2014 guest configuration changes and every other\naudited action, read back from the PROVE ledger.\n\nNewest first. This is how you answer \"who changed this guest\" or \"what has this caller\ndone\". `matched` cou",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "principal",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mutations_only",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "audit_verify",
+    "description": "Verify the tamper-evident audit ledger's hash chain \u2014 PROVE the log is intact.",
+    "arguments": [
+      {
+        "name": "expected_head",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_agent_exec",
+    "description": "MUTATION: run a command inside a guest via the qemu-agent (async, polls for result).",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "proximo_call",
+    "description": "Call any Proximo tool by exact name, including ones not in this server's listed tools.",
+    "arguments": [
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "arguments",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "proximo_recall",
+    "description": "READ-ONLY: the estate map from local Tier-1 memory \u2014 NOT a live PVE read.",
+    "arguments": [
+      {
+        "name": "since",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "detail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "journal",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "proximo_baseline",
+    "description": "READ-ONLY: what \"normal\" looks like for one guest \u2014 cpu/mem distribution rollups\n(n/mean/p50/p95/max) from PVE rrddata, stored in local Tier-1 memory. PVE-guest-only: on a\nPBS/PMG/PDM-only deployment this tool has nothing to report (a store",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "refresh",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastores_list",
+    "description": "List all PBS datastores (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_datastore_status",
+    "description": "Get runtime usage statistics for one PBS datastore (read-only).",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_gc_status",
+    "description": "Get garbage-collection status for one PBS datastore (read-only).",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_snapshots_list",
+    "description": "READ-ONLY: list backup snapshots in a PBS datastore with optional filters.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_namespaces_list",
+    "description": "List namespaces within a PBS datastore with optional hierarchical filtering (read-only).",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "parent",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_remotes_list",
+    "description": "READ-ONLY: list all PBS remote sync-sources.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_remote_get",
+    "description": "READ-ONLY: get the config of one PBS remote sync-source by name.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_traffic_controls_list",
+    "description": "READ-ONLY: list all PBS traffic-control bandwidth-limit rules.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_jobs_list",
+    "description": "READ-ONLY: list all PBS scheduled jobs of the given type.",
+    "arguments": [
+      {
+        "name": "job_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tasks_list",
+    "description": "READ-ONLY: list PBS tasks on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "errors",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_get",
+    "description": "Get full config of one PBS datastore by name (read).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_gc_start",
+    "description": "MUTATION (HIGH): start garbage collection on a PBS datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_verify_start",
+    "description": "MUTATION: start an integrity verification run on a PBS datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_prune",
+    "description": "MUTATION: prune backup snapshots per a retention policy.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "keep_last",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_daily",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_weekly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_monthly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_yearly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_snapshot_delete",
+    "description": "MUTATION (HIGH): delete a specific backup snapshot (a recovery point) from a PBS\ndatastore. Dry-run by default. Permanent \u2014 no undo. confirm=True to execute. Synchronous.\nTo shield a snapshot instead of deleting it use pbs_snapshot_protecte",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_namespace_create",
+    "description": "MUTATION: create a namespace within a PBS datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "parent",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_namespace_delete",
+    "description": "MUTATION: delete a namespace from a PBS datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_groups",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_create",
+    "description": "MUTATION (MEDIUM): create a new PBS datastore at the given path.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "gc_schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prune_schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notification_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_update",
+    "description": "MUTATION (MEDIUM): update PBS datastore configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "gc_schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prune_schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notification_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_delete",
+    "description": "MUTATION: delete a PBS datastore.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "destroy_data",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "keep_job_configs",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_snapshot_protected_set",
+    "description": "MUTATION: set or clear the protected flag on a PBS snapshot.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "protected",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_snapshot_notes_set",
+    "description": "MUTATION (LOW): annotate a PBS snapshot with notes.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_group_change_owner",
+    "description": "MUTATION (MEDIUM): reassign the owner of a PBS backup group.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "new_owner",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_remote_create",
+    "description": "MUTATION (MEDIUM): create a PBS remote sync-source.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "auth_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_remote_update",
+    "description": "MUTATION (MEDIUM): update an existing PBS remote.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "auth_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_remote_delete",
+    "description": "MUTATION (MEDIUM): remove a PBS remote and its stored credentials.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_traffic_control_upsert",
+    "description": "MUTATION: create or update a PBS traffic-control (bandwidth-limit) rule.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_in",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "rate_out",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "network",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_in",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "burst_out",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_traffic_control_delete",
+    "description": "MUTATION (MEDIUM): remove a PBS traffic-control (bandwidth-limit) rule.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_updates_list",
+    "description": "READ-ONLY: list available package updates (cached apt index) on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_changelog",
+    "description": "READ-ONLY: get a package's changelog text on a PBS node.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_repositories_get",
+    "description": "READ-ONLY: get the current APT repository configuration of a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_versions",
+    "description": "READ-ONLY: get installed versions of important Proxmox Backup Server packages on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_update_refresh",
+    "description": "MUTATION: resynchronize the APT package index on a PBS node (apt-get update).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "quiet",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_repository_set",
+    "description": "MUTATION: enable/disable one APT repository entry on a PBS node, by file path + index.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_apt_repository_add",
+    "description": "MUTATION: add a standard repository to the configuration on a PBS node.",
+    "arguments": [
+      {
+        "name": "handle",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_users_list",
+    "description": "READ-ONLY: list all PBS users.",
+    "arguments": [
+      {
+        "name": "include_tokens",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_user_get",
+    "description": "READ-ONLY: get a PBS user's config.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_user_create",
+    "description": "MUTATION (MEDIUM): create a PBS user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_user_update",
+    "description": "MUTATION (MEDIUM): update a PBS user (enable=False stops login immediately).",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_user_delete",
+    "description": "MUTATION (MEDIUM): delete a PBS user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_user_tokens_list",
+    "description": "READ-ONLY: list API tokens for a PBS user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_user_token_get",
+    "description": "READ-ONLY: get one PBS API token's metadata.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token_name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_token_create",
+    "description": "MUTATION (MEDIUM): create an API token for a PBS user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_token_update",
+    "description": "MUTATION: update a PBS API token's metadata.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "regenerate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_token_delete",
+    "description": "MUTATION (MEDIUM, IRREVERSIBLE): permanently revoke a PBS API token.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acl_get",
+    "description": "READ-ONLY: list PBS ACL entries.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exact",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acl_update",
+    "description": "MUTATION (HIGH): grant or revoke a PBS ACL entry (PUT /access/acl) \u2014 this GRANTS or\nREVOKES AUTHORITY, so it is treated as HIGH risk unconditionally on this plane (PBS's\nACL-inheritance/shadow semantics are not schema-documented or live-ver",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "role",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "auth_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "propagate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_roles_list",
+    "description": "READ-ONLY: list PBS's built-in roles.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_permissions_get",
+    "description": "READ-ONLY: resolve effective privileges for a PBS user/token.",
+    "arguments": [
+      {
+        "name": "auth_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ad_list",
+    "description": "READ-ONLY: list configured AD realms.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_realm_ad_get",
+    "description": "READ-ONLY: get one AD realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ad_create",
+    "description": "MUTATION (MEDIUM): create an AD authentication realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "base_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bind_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "capath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "server2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_attributes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_defaults_options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_classes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ad_update",
+    "description": "MUTATION (MEDIUM): update an AD realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "base_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bind_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "capath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "server1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_attributes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_defaults_options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_classes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ad_delete",
+    "description": "MUTATION (MEDIUM): permanently delete an AD realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ldap_list",
+    "description": "READ-ONLY: list configured LDAP realms.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_realm_ldap_get",
+    "description": "READ-ONLY: get one LDAP realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ldap_create",
+    "description": "MUTATION (MEDIUM): create an LDAP authentication realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "base_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_attr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bind_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "capath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "server2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_attributes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_defaults_options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_classes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ldap_update",
+    "description": "MUTATION (MEDIUM): update an LDAP realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "base_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bind_dn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "capath",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "server1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_attributes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_defaults_options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_attr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user_classes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_ldap_delete",
+    "description": "MUTATION (MEDIUM): permanently delete an LDAP realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_openid_list",
+    "description": "READ-ONLY: list configured OpenID realms.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_realm_openid_get",
+    "description": "READ-ONLY: get one OpenID realm's config (never includes client_key).",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_openid_create",
+    "description": "MUTATION (MEDIUM): create an OpenID authentication realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "issuer_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "acr_values",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "audiences",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autocreate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "prompt",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scopes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "username_claim",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_openid_update",
+    "description": "MUTATION (MEDIUM): update an OpenID realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "issuer_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "acr_values",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "audiences",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autocreate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "prompt",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scopes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_openid_delete",
+    "description": "MUTATION (MEDIUM): permanently delete an OpenID realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_pam_get",
+    "description": "READ-ONLY: get the built-in PAM realm's config (comment/default only).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_realm_pam_set",
+    "description": "MUTATION (MEDIUM): update the built-in PAM realm's comment/default-preselect flag.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_pbs_get",
+    "description": "READ-ONLY: get the built-in PBS-auth realm's config (comment/default only).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_realm_pbs_set",
+    "description": "MUTATION (MEDIUM): update the built-in PBS-auth realm's comment/default-preselect flag.",
+    "arguments": [
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_list",
+    "description": "READ-ONLY: list ALL users' TFA configuration (per-user entries + lock state).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tfa_user_get",
+    "description": "READ-ONLY: list one user's TFA entries.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_entry_get",
+    "description": "READ-ONLY: get one TFA entry.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_add",
+    "description": "MUTATION (MEDIUM): add a TFA entry for a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "totp",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "challenge",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_update",
+    "description": "MUTATION (MEDIUM): update a TFA entry's description/enabled flag.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_delete",
+    "description": "MUTATION (HIGH, IRREVERSIBLE): permanently remove one TFA factor from a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_unlock",
+    "description": "MUTATION (HIGH): clear a user's TOTP lockout (PUT /access/users/{userid}/unlock-tfa \u2014 note\nthe path lives under /access/users/, not /access/tfa/{userid}/). HIGH because it removes the\nanti-brute-force throttle guarding a 6-digit TOTP keyspa",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tfa_webauthn_get",
+    "description": "READ-ONLY: get the server-wide WebAuthn relying-party config (id/origin/rp/\nallow-subdomains). Needs PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tfa_webauthn_set",
+    "description": "MUTATION (MEDIUM): update the server-wide WebAuthn config.",
+    "arguments": [
+      {
+        "name": "rp_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "origin",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rp_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "allow_subdomains",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_account_list",
+    "description": "READ-ONLY: list registered PBS ACME account NAMES (the schema's own response item is\n`{\"name\": str}` only \u2014 use pbs_acme_account_get for full account detail). Needs\nPROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_acme_account_get",
+    "description": "READ-ONLY: get one PBS ACME account's full config (account/directory/location/tos).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_directories",
+    "description": "READ-ONLY: list PBS's built-in catalog of known ACME CA directory endpoints (name + URL\npairs, e.g. Let's Encrypt production/staging). No params. Needs PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_acme_tos",
+    "description": "READ-ONLY: get the Terms-of-Service URL for an ACME directory (or None if the CA\nadvertises no ToS). The PBS host fetches the given directory URL live (https-only,\nvalidated) and the response is authored by whoever controls that URL \u2014 class",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_challenge_schema",
+    "description": "READ-ONLY: list the catalog of known ACME challenge plugin types (id/name/schema/type per\nentry) \u2014 the parameter schema each plugin `type`+`data` pairing must satisfy. No params.\nNeeds PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_acme_plugins_list",
+    "description": "READ-ONLY: list all configured PBS ACME DNS challenge plugins, INCLUDING the raw `data`\ncredential blob for each (PBS does not strip it on read). Handle the result as sensitive.\nNeeds PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_acme_plugin_get",
+    "description": "READ-ONLY: get one PBS ACME plugin's full config, INCLUDING the raw `data` credential\nblob (PBS does not strip it on read). Handle the result as sensitive. Needs PROXIMO_PBS_*\nconfig.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_account_create",
+    "description": "MUTATION: register a new ACME account with the CA.",
+    "arguments": [
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eab_hmac_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eab_kid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tos_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_account_update",
+    "description": "MUTATION: update ACME account contact info.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_account_delete",
+    "description": "MUTATION: IRREVERSIBLE \u2014 DEACTIVATES an ACME account at the CA (not just local config\nremoval) and deletes the local record. Dry-run by default.\n\nHIGH risk: TLS lockout at cert expiry if this is the only account. The account key is\ndestroye",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_plugin_create",
+    "description": "MUTATION: create an ACME DNS challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "plugin_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_api",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "validation_delay",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_plugin_update",
+    "description": "MUTATION: update an ACME DNS challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_api",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "validation_delay",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_plugin_delete",
+    "description": "MUTATION: delete an ACME DNS challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_cert_order",
+    "description": "MUTATION: order a NEW ACME TLS certificate for a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_acme_cert_renew",
+    "description": "MUTATION: renew the existing ACME TLS certificate for a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_admin_gc_jobs_list",
+    "description": "READ-ONLY: job-level view of GC (garbage collection) jobs, max one per datastore, across\nALL datastores unless `store` filters to one. Distinct from the existing per-datastore\npbs_gc_status (single-store detail only, no schedule/next-run fi",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_admin_prune_jobs_list",
+    "description": "READ-ONLY: job-level view of prune jobs.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_admin_sync_jobs_list",
+    "description": "READ-ONLY: job-level view of sync jobs.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sync_direction",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_admin_verify_jobs_list",
+    "description": "READ-ONLY: job-level view of verification jobs.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_admin_traffic_control_status",
+    "description": "READ-ONLY: LIVE current traffic (cur-rate-in/cur-rate-out) per traffic-control rule, plus\nthe rule's own config. Distinct from the already-shipped pbs_traffic_controls_list (the\nCONFIG-CRUD view \u2014 use pbs_traffic_control_upsert there to cre",
+    "arguments": []
+  },
+  {
+    "name": "pbs_node_config_get",
+    "description": "READ-ONLY: PBS node-wide settings (description, email-from, http-proxy,\ntask-log-max-days, consent-text, default-lang, ciphers, location, acme/acmedomain0-4).\nhttp-proxy is defensively masked for any embedded userinfo credential (host:port ",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_identity",
+    "description": "READ-ONLY: unique server identity derived from /etc/machine-id.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_rrd",
+    "description": "READ-ONLY: node stats telemetry (host CPU/memory/network, I/O).",
+    "arguments": [
+      {
+        "name": "cf",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_report",
+    "description": "READ-ONLY: generate a free-text diagnostic report bundle for the node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_version",
+    "description": "READ-ONLY: PBS API version identity (release/repoid/version).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_node_config_set",
+    "description": "MUTATION: update PBS node-wide config.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acme",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain0",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain3",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain4",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ciphers_tls_1_2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ciphers_tls_1_3",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "consent_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default_lang",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email_from",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "http_proxy",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "location",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "task_log_max_days",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_pull",
+    "description": "MUTATION: pull backups from a remote PBS datastore into the LOCAL datastore `store`.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remote_store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remote_ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "decryption_keys",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "encrypted_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "group_filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "rate_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remove_vanished",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "resync_corrupt",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "transfer_last",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "verified_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "worker_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_push",
+    "description": "MUTATION: push backups from the LOCAL datastore `store` to a REMOTE PBS datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remote_store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remote_ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "encrypted_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "encryption_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group_filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "rate_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remove_vanished",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "transfer_last",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "verified_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "worker_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_groups_list",
+    "description": "READ-ONLY: list backup groups in a PBS datastore (backup-type/backup-id, snapshot count,\nlast-backup time, owner, files, comment). ADVERSARIAL: backup ids and the notes-derived\ncomment are guest/operator-influenced free text (pbs_snapshots_",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_group_notes_get",
+    "description": "READ-ONLY: get the full free-text notes body for a backup GROUP \u2014 distinct from the\nsnapshot-level pbs_snapshot_notes_set/get pair (group vs. individual snapshot). ADVERSARIAL\n(free text). Needs PROXIMO_PBS_* config.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_snapshot_protected_get",
+    "description": "READ-ONLY: query the protection flag for a specific backup snapshot \u2014 the READ half of\nthe shipped pbs_snapshot_protected_set. The live schema declares this endpoint's return\ntype null despite implying a real answer (the plausible return is",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_rrd",
+    "description": "READ-ONLY: datastore stats telemetry (I/O, usage over time) \u2014 the datastore-level\nparallel of pbs_node_rrd. The live schema declares returns:null despite real data \u2014\nbest-effort dict passthrough. REVIEWED_TRUSTED (rrddata precedent). Needs ",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cf",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_active_operations",
+    "description": "READ-ONLY: in-flight operation counts for a datastore (expected read/write counters \u2014\nthe live schema declares returns:null, and its description is a copy-paste artifact; see\nproximo.pbs_datastore_admin fact #9). Useful before pbs_datastore",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastores_usage",
+    "description": "READ-ONLY: capacity usage + estimated-full dates for every datastore (avail, error,\nestimated-full-date via linear regression over the last month's RRD data, gc-status).\nDistinct from pbs_metrics_status (performance samples) \u2014 this is capac",
+    "arguments": []
+  },
+  {
+    "name": "pbs_remote_scan",
+    "description": "READ-ONLY: list the datastores accessible on a configured remote PBS \u2014 discover what\nexists BEFORE pbs_pull/pbs_push instead of guessing remote_store blind. ADVERSARIAL: the\nreturned store names/comments/maintenance messages are authored on",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_remote_scan_groups",
+    "description": "READ-ONLY: list backup groups on a remote's datastore \u2014 discover what a pbs_pull would\ntransfer (or what a pbs_push group_filter should target) before running it. ADVERSARIAL\n(remote-authored group ids + comments). Needs PROXIMO_PBS_* confi",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "namespace",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_remote_scan_namespaces",
+    "description": "READ-ONLY: list namespaces on a remote's datastore \u2014 discover valid remote_ns values for\npbs_pull/pbs_push before running them. ADVERSARIAL (remote-authored namespace names +\ncomments). Needs PROXIMO_PBS_* config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_group_delete",
+    "description": "MUTATION: delete an ENTIRE backup group including ALL its snapshots.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "error_on_protected",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_group_notes_set",
+    "description": "MUTATION: set the notes body for a backup GROUP (distinct from the snapshot-level\npbs_snapshot_notes_set).\n\nRISK_LOW: annotation metadata only \u2014 no backup data, retention, or protection is changed.\nDry-run by default (CAPTUREs the current n",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_group_move",
+    "description": "MUTATION: move a backup group to a different namespace within the same datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "merge_group",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_namespace_move",
+    "description": "MUTATION: move a backup namespace INCLUDING ALL CHILD NAMESPACES AND GROUPS to a new\nlocation within the same datastore.\n\nRISK_HIGH \u2014 the widest-blast-radius non-deleting mutation on this plane: the whole tree\nrelocates (max_depth defaults ",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_source",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "merge_groups",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_mount",
+    "description": "MUTATION: mount a removable datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_unmount",
+    "description": "MUTATION: unmount the removable device backing a datastore.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_s3_refresh",
+    "description": "MUTATION: refresh a datastore's contents from its S3 backend into the local cache store.",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_datastore_prune",
+    "description": "MUTATION: prune EVERY backup group in a datastore/namespace tree per a retention policy \u2014\nthe WHOLE-DATASTORE prune, schema-distinct from the single-group pbs_prune (which scopes to\none backup-type+backup-id and cannot recurse namespaces).\n",
+    "arguments": [
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "keep_last",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_hourly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_daily",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_weekly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_monthly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_yearly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disks_list",
+    "description": "READ-ONLY: list physical disks on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "include_partitions",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "skipsmart",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "usage_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_smart",
+    "description": "READ-ONLY: get SMART attributes and health for one disk on a PBS node.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "healthonly",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_wipe",
+    "description": "MUTATION: wipe ALL data and the partition table on a PBS disk or partition.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_initgpt",
+    "description": "MUTATION: initialize a GPT partition table on a whole PBS disk.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "uuid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_directory_list",
+    "description": "READ-ONLY: list systemd datastore mount units (the directory backend) on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_directory_create",
+    "description": "MUTATION: format a disk and mount it as a directory datastore on a PBS node.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filesystem",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "add_datastore",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "removable_datastore",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_directory_delete",
+    "description": "MUTATION: remove a directory datastore's mount unit and config mapping on a PBS node.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_zfs_list",
+    "description": "READ-ONLY: list zpools (the zfs backend) on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_zfs_get",
+    "description": "READ-ONLY: get one zpool's status/vdev tree on a PBS node.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_disk_zfs_create",
+    "description": "MUTATION: create a zpool from disks and mount it as a zfs datastore on a PBS node.",
+    "arguments": [
+      {
+        "name": "devices",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "raidlevel",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ashift",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "compression",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "add_datastore",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_servers_list",
+    "description": "READ-ONLY: list ALL configured PBS metric servers (both influxdb-http and influxdb-udp) in\none unified view. Response is schema-enforced secret-free \u2014 no token field can appear here per\nthe schema's own closed shape. Needs PROXIMO_PBS_* con",
+    "arguments": []
+  },
+  {
+    "name": "pbs_metrics_status",
+    "description": "READ-ONLY: return PBS backup server metrics \u2014 host CPU/memory/network and per-datastore\nperformance telemetry. REVIEWED_TRUSTED: server-authored numeric telemetry, matching the\npve_node_rrddata/pmg_node_rrddata precedent (see proximo.pbs_me",
+    "arguments": [
+      {
+        "name": "history",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "start_time",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_http_list",
+    "description": "READ-ONLY: list configured PBS InfluxDB http metric servers.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_metrics_influxdb_http_get",
+    "description": "READ-ONLY: get one PBS InfluxDB http metric server's config, with `token` stripped at the\nREAD layer (required strip, not merely defensive \u2014 module docstring fact #1). Needs\nPROXIMO_PBS_* config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_udp_list",
+    "description": "READ-ONLY: list configured PBS InfluxDB udp metric servers.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_metrics_influxdb_udp_get",
+    "description": "READ-ONLY: get one PBS InfluxDB udp metric server's config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_http_create",
+    "description": "MUTATION: create a PBS InfluxDB http metrics server configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bucket",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_body_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "organization",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify_tls",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_http_update",
+    "description": "MUTATION: update a PBS InfluxDB http metrics server configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bucket",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_body_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "organization",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify_tls",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_http_delete",
+    "description": "MUTATION: delete a PBS InfluxDB http metrics server configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_udp_create",
+    "description": "MUTATION: create a PBS InfluxDB udp metrics server configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "mtu",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_udp_update",
+    "description": "MUTATION: update a PBS InfluxDB udp metrics server configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mtu",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_metrics_influxdb_udp_delete",
+    "description": "MUTATION: delete a PBS InfluxDB udp metrics server configuration.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_dns_get",
+    "description": "READ-ONLY: read a PBS node's DNS resolver configuration.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_dns_set",
+    "description": "MUTATION (MEDIUM): update DNS resolver configuration on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "search",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns3",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_time_get",
+    "description": "READ-ONLY: read a PBS node's current time and timezone.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_time_set",
+    "description": "MUTATION (LOW): set the timezone on a PBS node.",
+    "arguments": [
+      {
+        "name": "timezone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_list",
+    "description": "READ-ONLY: list network interfaces on a PBS node (with config digest).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_iface_get",
+    "description": "READ-ONLY: read one network interface's configuration on a PBS node.",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_iface_create",
+    "description": "MUTATION (MEDIUM): create a network interface configuration on a PBS node (staged, written\nto interfaces.new \u2014 NOT live until pbs_node_network_reload). Dry-run by default (checks for a\nname collision). confirm=True executes (POST /nodes/{no",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_iface_update",
+    "description": "MUTATION (MEDIUM): update a network interface's configuration on a PBS node (staged \u2014 NOT\nlive until pbs_node_network_reload). Dry-run by default \u2014 reads the interface's current\nconfig. Unlike PVE, PBS does not require re-sending 'type'. co",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_iface_delete",
+    "description": "MUTATION (MEDIUM): remove a network interface's staged configuration on a PBS node (NOT\nlive until pbs_node_network_reload). Dry-run by default \u2014 reads the interface's current\nconfig. confirm=True executes (DELETE /nodes/{node}/network/{ifa",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_reload",
+    "description": "MUTATION (HIGH): apply staged network configuration changes on a PBS node \u2014 makes\ninterfaces.new live. Dry-run by default. *** CONNECTIVITY-LOCKOUT RISK *** a misconfigured\ninterface can drop SSH/API access; recovery requires console/physic",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_network_revert",
+    "description": "MUTATION (LOW): discard staged network configuration changes on a PBS node (interfaces.new\nreverted) \u2014 the live config is untouched; safe. Dry-run by default. confirm=True executes\n(DELETE /nodes/{node}/network) and returns {\"status\": \"ok\",",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_certificates_list",
+    "description": "READ-ONLY: list TLS certificates configured on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_cert_upload",
+    "description": "MUTATION (HIGH, no undo): upload a custom TLS certificate to a PBS node.",
+    "arguments": [
+      {
+        "name": "certificates",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_cert_delete",
+    "description": "MUTATION (MEDIUM): delete the custom TLS certificate on a PBS node; PBS regenerates a\nself-signed one. Dry-run by default. NOTE: PBS's 'restart' param on this endpoint is\ndocumented as ignored \u2014 not exposed here. confirm=True executes (DELE",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_services_list",
+    "description": "READ-ONLY: list all systemd services on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_service_status",
+    "description": "READ-ONLY: get one systemd service's current state on a PBS node.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_service_control",
+    "description": "MUTATION: start/stop/restart/reload a service on a PBS node.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_subscription_get",
+    "description": "READ-ONLY: read a PBS node's subscription status.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_subscription_set",
+    "description": "MUTATION (MEDIUM): install and validate a subscription key on a PBS node.",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_subscription_check",
+    "description": "MUTATION (LOW): check and refresh a PBS node's subscription status by contacting Proxmox's\nserver. Dry-run by default. No key/identity change \u2014 status-cache refresh only. confirm=True\nexecutes (POST /nodes/{node}/subscription) and returns {",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_subscription_delete",
+    "description": "MUTATION (MEDIUM): delete the locally-stored subscription info on a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_status",
+    "description": "READ-ONLY: read a PBS node's memory/CPU/(root) disk usage.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_task_status",
+    "description": "READ-ONLY: get one PBS task's status by UPID (status/exitstatus/pid/starttime/...).",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_task_log",
+    "description": "READ-ONLY: retrieve a PBS task's log output by UPID, paginated via start/limit.",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_task_stop",
+    "description": "MUTATION (HIGH): stop (cancel) a running PBS task.",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_journal",
+    "description": "READ-ONLY: fetch systemd journal lines from a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastentries",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "since",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "until",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "startcursor",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "endcursor",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_node_syslog",
+    "description": "READ-ONLY: fetch syslog entries from a PBS node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "since",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "until",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_targets_list",
+    "description": "READ-ONLY: list all PBS notification targets (the unified list \u2014 name, type, comment,\ndisable, origin \u2014 across every endpoint type). For an endpoint's full type-specific config\nuse pbs_notification_endpoint_get. Needs PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_notification_endpoint_list",
+    "description": "READ-ONLY: list PBS notification endpoints with their full type-specific config.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_endpoint_get",
+    "description": "READ-ONLY: get one PBS notification endpoint's full type-specific config.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_matchers_list",
+    "description": "READ-ONLY: list all PBS notification matchers (alert routing rules).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_notification_matcher_get",
+    "description": "READ-ONLY: get one PBS notification matcher's full config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_matcher_fields",
+    "description": "READ-ONLY: list all known metadata field NAMES a matcher's match-field rule can target\n(e.g. 'type', 'datastore'). No params. Needs PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_notification_matcher_field_values",
+    "description": "READ-ONLY: list all known (field, value) pairs the system currently recognizes for\nmatcher rules. No params. Needs PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_notification_endpoint_create",
+    "description": "MUTATION: create a PBS notification endpoint.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_endpoint_update",
+    "description": "MUTATION: update a PBS notification endpoint.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_endpoint_delete",
+    "description": "MUTATION: delete a PBS notification endpoint.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_matcher_set",
+    "description": "MUTATION: create-or-update a PBS notification matcher (alert routing rule).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "match_severity",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "match_field",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "match_calendar",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "invert_match",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_matcher_delete",
+    "description": "MUTATION: delete a PBS notification matcher.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_notification_target_test",
+    "description": "MUTATION: send a REAL test notification to a PBS notification target.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_client_list",
+    "description": "READ-ONLY: list all PBS S3 client configurations.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_s3_client_get",
+    "description": "READ-ONLY: get one PBS S3 client config's full (secret-free) shape.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_list_buckets",
+    "description": "READ-ONLY: list buckets accessible by the given S3 client configuration.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_encryption_key_list",
+    "description": "READ-ONLY: list registered PBS client encryption keys.",
+    "arguments": [
+      {
+        "name": "include_archived",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_client_create",
+    "description": "MUTATION: create a PBS S3 client configuration.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "endpoint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "access_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "secret_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "path_style",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "provider_quirks",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_client_update",
+    "description": "MUTATION: update a PBS S3 client configuration.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "access_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "secret_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "endpoint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "path_style",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "provider_quirks",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_in",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "burst_out",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_client_delete",
+    "description": "MUTATION: delete a PBS S3 client configuration.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_check",
+    "description": "MUTATION: perform a basic sanity check for a PBS S3 client configuration.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bucket",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store_prefix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_s3_reset_counters",
+    "description": "MUTATION: reset S3 request counters for a matching endpoint/bucket/prefix.",
+    "arguments": [
+      {
+        "name": "s3_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bucket",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store_prefix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_encryption_key_create",
+    "description": "MUTATION: create a PBS client encryption key.",
+    "arguments": [
+      {
+        "name": "key_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_encryption_key_delete",
+    "description": "MUTATION: delete a PBS client encryption key.",
+    "arguments": [
+      {
+        "name": "key_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_encryption_key_toggle_archive",
+    "description": "MUTATION: toggle a PBS client encryption key's archive flag.",
+    "arguments": [
+      {
+        "name": "key_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_list",
+    "description": "READ-ONLY: list configured PBS tape drives (LTO SCSI, with config digest).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_drive_get",
+    "description": "READ-ONLY: get one PBS tape drive's config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_changer_list",
+    "description": "READ-ONLY: list configured PBS SCSI tape changers (with config digest).",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_changer_get",
+    "description": "READ-ONLY: get one PBS tape changer's config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_scan_drives",
+    "description": "READ-ONLY: autodetect tape drives attached to the PBS host (Linux SCSI-generic device\nnodes). Returns kind/major/minor/model/path/serial/vendor per device \u2014 device-reported, not\noperator config (same taint posture as pve_hardware_list / pbs",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_scan_changers",
+    "description": "READ-ONLY: autodetect SCSI tape changers attached to the PBS host.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_drive_create",
+    "description": "MUTATION: create a PBS tape drive config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "changer",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "changer_drivenum",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_update",
+    "description": "MUTATION: update a PBS tape drive config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "changer",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "changer_drivenum",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_delete",
+    "description": "MUTATION: delete a PBS tape drive config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_changer_create",
+    "description": "MUTATION: create a PBS tape changer config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eject_before_unload",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "export_slots",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_changer_update",
+    "description": "MUTATION: update a PBS tape changer config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eject_before_unload",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "export_slots",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_changer_delete",
+    "description": "MUTATION: delete a PBS tape changer config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_media_list",
+    "description": "READ-ONLY: list registered backup media, optionally filtered to one pool.",
+    "arguments": [
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "update_status",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "update_status_changer",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_media_content",
+    "description": "READ-ONLY: list media content \u2014 the snapshot inventory recorded across tape.",
+    "arguments": [
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "label_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "media",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "media_set",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_media_sets",
+    "description": "READ-ONLY: list media sets.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_media_status_get",
+    "description": "READ-ONLY: get one medium's current status.",
+    "arguments": [
+      {
+        "name": "uuid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_backup_job_list",
+    "description": "READ-ONLY: list configured PBS tape backup jobs.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_backup_job_get",
+    "description": "READ-ONLY: get one PBS tape backup job's full config.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_media_destroy",
+    "description": "MUTATION: COMPLETELY REMOVES a tape medium from PBS's database.",
+    "arguments": [
+      {
+        "name": "label_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "uuid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_media_status_set",
+    "description": "MUTATION: set (or clear) a tape medium's manual status override.",
+    "arguments": [
+      {
+        "name": "uuid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_media_move",
+    "description": "MUTATION: change a tape medium's LOCATION bookkeeping (to a vault, or to offline).",
+    "arguments": [
+      {
+        "name": "label_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "uuid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vault_name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_backup_job_create",
+    "description": "MUTATION: create a PBS tape backup job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eject_media",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "export_media_set",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "group_filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "latest_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "notification_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify_user",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "worker_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_backup_job_update",
+    "description": "MUTATION: update a PBS tape backup job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eject_media",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "export_media_set",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "group_filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "latest_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "notification_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify_user",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "worker_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_backup_job_delete",
+    "description": "MUTATION: delete a PBS tape backup job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_backup_job_run",
+    "description": "MUTATION: manually run a preconfigured tape backup job, right now.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_backup",
+    "description": "MUTATION: one-off tape backup \u2014 back up a datastore to a tape pool right now, no\nschedule/job-id involved.\n\nRISK_MEDIUM: writes datastore contents to tape, drive busy for the duration. Dry-run by\ndefault (returns a PLAN); confirm=True execu",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eject_media",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "export_media_set",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "force_media_set",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "group_filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "latest_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_depth",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "notification_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify_user",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "worker_threads",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_restore",
+    "description": "MUTATION: restore data from a tape media-set into a datastore.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "media_set",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "namespaces",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notification_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify_user",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "owner",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapshots",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_pool_list",
+    "description": "READ-ONLY: list configured PBS tape media pools.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_pool_get",
+    "description": "READ-ONLY: get one PBS tape media pool's config.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_key_list",
+    "description": "READ-ONLY: list existing PBS tape encryption keys \u2014 PUBLIC metadata only (created/\nfingerprint/hint/kdf/modified/path; PBS never returns the key material or password on this\nendpoint). Needs PROXIMO_PBS_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pbs_tape_key_get",
+    "description": "READ-ONLY: get one PBS tape encryption key's config \u2014 PUBLIC part only (created/\nfingerprint/hint/kdf/modified/path; PBS never returns the key material or password on this\nendpoint). Needs PROXIMO_PBS_* config.",
+    "arguments": [
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_pool_create",
+    "description": "MUTATION: create a PBS tape media pool.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "allocation",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "encrypt",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "retention",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "template",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_pool_update",
+    "description": "MUTATION: update a PBS tape media pool.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "allocation",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "encrypt",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "retention",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "template",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_pool_delete",
+    "description": "MUTATION: delete a PBS tape media pool.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_key_create",
+    "description": "MUTATION: create a PBS tape encryption key.",
+    "arguments": [
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kdf",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_key_update_password",
+    "description": "MUTATION: change a PBS tape encryption key's password (and hint).",
+    "arguments": [
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "new_password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kdf",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_key_delete",
+    "description": "MUTATION: delete a PBS tape encryption key.",
+    "arguments": [
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_status",
+    "description": "READ-ONLY: get one PBS tape drive's status (media-related fields only present if a medium\nis loaded). Pure device telemetry \u2014 no label-text field exists in this response at all. Needs\nPROXIMO_PBS_* config.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_read_label",
+    "description": "READ-ONLY: read the mounted media's label (label-text, media-set uuid/pool/ctime, encryption\nkey fingerprint if any). ADVERSARIAL: label-text is physical-media-authored free text (whoever\nlabeled the cartridge controls these bytes) \u2014 no ret",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "inventorize",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_cartridge_memory",
+    "description": "READ-ONLY: read the mounted media's LTO cartridge memory (MAM) attributes \u2014 id/name/value\ntriples. ADVERSARIAL: read directly off the physical medium's own onboard memory chip, no\npattern/enum constraint anywhere in the schema. Needs PROXIM",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_volume_statistics",
+    "description": "READ-ONLY: read the mounted media's SCSI log-page-17h volume statistics (byte counters,\nerror counters, a hardware-assigned serial). Device telemetry \u2014 no label-text field. Needs\nPROXIMO_PBS_* config.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_inventory",
+    "description": "READ-ONLY: list known media labels via the drive's associated changer (this read ALSO\nupdates PBS's media online-status bookkeeping, per the schema's own note \u2014 still a GET, no\nconfirm gate). ADVERSARIAL: carries physical media label-text, ",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_changer_status",
+    "description": "READ-ONLY: one status entry per drive/slot/import-export bay on the changer.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cache",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_load_media",
+    "description": "MUTATION: mount the cartridge carrying `label_text` into a drive via its associated changer.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "label_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_load_slot",
+    "description": "MUTATION: mount the cartridge in `source_slot` into a drive via its associated changer.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source_slot",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_unload",
+    "description": "MUTATION: return a drive's mounted media to a changer slot.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_slot",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_eject",
+    "description": "MUTATION: eject/unload a drive's mounted media.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_rewind",
+    "description": "MUTATION: rewind a drive's mounted tape to its beginning.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_clean",
+    "description": "MUTATION: run a cleaning cycle on a drive.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_inventory_update",
+    "description": "MUTATION: query the changer and load+read any unknown cartridge into this drive, storing\nresults to the media database.\n\nRISK_MEDIUM: can physically cycle through EVERY not-yet-inventoried cartridge in the attached\nlibrary, one at a time \u2014 ",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "catalog",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "read_all_labels",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_label_media",
+    "description": "MUTATION: write a NEW label to a drive's mounted media.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "label_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_barcode_label_media",
+    "description": "MUTATION: label a drive's mounted media using barcodes read from the changer device.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_format",
+    "description": "MUTATION: format (ERASE) a drive's mounted media.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fast",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "label_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "load_barcode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_catalog",
+    "description": "MUTATION: scan a drive's mounted media and (re)record its content into the local PBS\ncatalog database.\n\nRISK_MEDIUM: reads (does not modify) the tape; writes/updates local catalog metadata \u2014\nforce=True overrides an existing index, scan=True",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "scan",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_drive_restore_key",
+    "description": "MUTATION: try to restore a tape encryption key from a drive's mounted media.",
+    "arguments": [
+      {
+        "name": "drive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_tape_changer_transfer",
+    "description": "MUTATION: move media from one changer slot to another.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "from_slot",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "to_slot",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_ping",
+    "description": "READ-ONLY: health check the PDM appliance.",
+    "arguments": []
+  },
+  {
+    "name": "pdm_version",
+    "description": "READ-ONLY: get the PDM appliance's own version info.",
+    "arguments": []
+  },
+  {
+    "name": "pdm_node_status",
+    "description": "READ-ONLY: get resource stats for the PDM appliance's own node (not a managed remote's node).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_remotes_list",
+    "description": "READ-ONLY: list all PVE/PBS remotes registered in PDM (the datacenters/backup targets it manages).",
+    "arguments": []
+  },
+  {
+    "name": "pdm_remote_version",
+    "description": "READ-ONLY: get version info for one PDM-registered remote, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_remote_config_get",
+    "description": "READ-ONLY: get configuration for one PDM-registered remote.",
+    "arguments": [
+      {
+        "name": "remote_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_resources_list",
+    "description": "READ-ONLY: list every fleet resource (VMs, LXCs, storage, etc.) across ALL PDM-registered remotes.",
+    "arguments": []
+  },
+  {
+    "name": "pdm_resources_status",
+    "description": "READ-ONLY: aggregated fleet status counters (running VMs, LXCs, failed remotes, etc.)\nacross all PDM-registered remotes.\n\nNo state change. Returns a dict of counters. For the underlying per-resource list, use\npdm_resources_list. Needs PROXI",
+    "arguments": []
+  },
+  {
+    "name": "pdm_pve_resources",
+    "description": "READ-ONLY: list resources on ONE PDM-registered PVE remote, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_cluster_status",
+    "description": "READ-ONLY: get cluster status for ONE PDM-registered PVE remote, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_node_list",
+    "description": "READ-ONLY: list PVE nodes in a PDM-registered remote's cluster, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_list",
+    "description": "READ-ONLY: list VMs across a PDM-registered PVE remote (cluster-wide), proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_config",
+    "description": "READ-ONLY: get a VM's config from a PDM-registered PVE remote, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapshot",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "state",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_list",
+    "description": "READ-ONLY: list LXC containers across a PDM-registered PVE remote (cluster-wide), proxied\nthrough PDM.\n\nNo state change. Returns a list of dicts shaped like PVE's lxc list (live-proven 2026-06-27);\nnode optionally filters to one PVE node. F",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_config",
+    "description": "READ-ONLY: get an LXC container's config from a PDM-registered PVE remote, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapshot",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "state",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pbs_remote_status",
+    "description": "READ-ONLY: get node status (cpu/memory/uptime, etc.) for a PDM-registered PBS remote,\nproxied through PDM.\n\nNo state change. Returns a dict (live-verified, PDM 1.1 -> PBS 4.2). For the remote's\ndatastores, use pdm_pbs_datastores_list. Needs",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pbs_datastores_list",
+    "description": "READ-ONLY: list datastores on a PDM-registered PBS remote, proxied through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pbs_snapshots_list",
+    "description": "READ-ONLY: list backup snapshots in one datastore on a PDM-registered PBS remote, proxied\nthrough PDM.\n\nNo state change. Returns a list of snapshot dicts (empty list if the datastore has none);\nlive-verified (PDM 1.1 -> PBS 4.2). ns optiona",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "datastore",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_tasks_list",
+    "description": "READ-ONLY: list recent PDM tasks (queued/running/finished operations) across all\nregistered remotes.\n\nNo state change. Returns a list of task dicts. For a target remote's own task list directly\n(without going through PDM), use pve_tasks_lis",
+    "arguments": []
+  },
+  {
+    "name": "pdm_acl_list",
+    "description": "READ-ONLY: list PDM's own access control entries (who can use PDM, not a managed remote's ACL).",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exact",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_roles_list",
+    "description": "READ-ONLY: list PDM's own roles and their privileges (not a managed remote's roles).",
+    "arguments": []
+  },
+  {
+    "name": "pdm_users_list",
+    "description": "READ-ONLY: list PDM's own user accounts (not a managed remote's users).",
+    "arguments": [
+      {
+        "name": "include_tokens",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_power",
+    "description": "MUTATION: start/stop/shutdown/resume a VM on a PDM-registered remote (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_power",
+    "description": "MUTATION: start/stop/shutdown a container on a PDM-registered remote (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_migrate",
+    "description": "MUTATION: migrate a VM to another node within the remote's cluster (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_migrate",
+    "description": "MUTATION: relocate a container to another node within the same cluster, through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_remote_migrate",
+    "description": "MUTATION: migrate a VM to a DIFFERENT PDM-registered remote (datacenter-to-datacenter).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_bridge",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_remote_migrate",
+    "description": "MUTATION: migrate a container to a DIFFERENT PDM-registered remote\n(datacenter-to-datacenter).\n\nFor a VM use pdm_pve_qemu_remote_migrate; for a same-cluster move use pdm_pve_lxc_migrate.\ntarget_bridge and target_storage mappings are require",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_bridge",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_snapshot_create",
+    "description": "MUTATION: snapshot a VM on a PDM-registered remote (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmstate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_snapshot_create",
+    "description": "MUTATION: snapshot a container on a PDM-registered remote (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_snapshot_delete",
+    "description": "MUTATION: delete a named VM snapshot on a PDM-registered remote, through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_snapshot_delete",
+    "description": "MUTATION: delete a named container snapshot on a PDM-registered remote, through PDM.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_qemu_snapshot_rollback",
+    "description": "MUTATION: roll a VM back to a snapshot on a PDM-registered remote (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pdm_pve_lxc_snapshot_rollback",
+    "description": "MUTATION: roll a container back to a snapshot on a PDM-registered remote (through PDM).",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_updates_list",
+    "description": "READ-ONLY: list available package updates (cached apt index) on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_changelog",
+    "description": "READ-ONLY: get a package's changelog text on a PMG node.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_repositories_get",
+    "description": "READ-ONLY: get the current APT repository configuration of a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_versions",
+    "description": "READ-ONLY: get installed versions of important Proxmox packages on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_update_refresh",
+    "description": "MUTATION: resynchronize the APT package index on a PMG node (apt-get update).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "quiet",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_repository_set",
+    "description": "MUTATION: enable/disable one APT repository entry on a PMG node, by file path + index.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_apt_repository_add",
+    "description": "MUTATION: add a standard repository to the configuration on a PMG node.",
+    "arguments": [
+      {
+        "name": "handle",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_realm_list",
+    "description": "READ-ONLY: list configured PMG auth realms.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_access_realm_get",
+    "description": "READ-ONLY: get one PMG auth realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_realm_create",
+    "description": "MUTATION (MEDIUM): create a PMG auth realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "realm_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "issuer_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autocreate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "autocreate_role",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autocreate_role_assignment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acr_values",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "audiences",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prompt",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scopes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "username_claim",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_realm_update",
+    "description": "MUTATION (MEDIUM): update a PMG auth realm's config.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "default",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "issuer_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "client_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autocreate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "autocreate_role",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "autocreate_role_assignment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acr_values",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "audiences",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prompt",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scopes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_realm_delete",
+    "description": "MUTATION (MEDIUM): permanently delete a PMG auth realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_user_get",
+    "description": "READ-ONLY: get a PMG user's config.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_user_create",
+    "description": "MUTATION (RULING 3 \u2014 CONDITIONAL MEDIUM/HIGH): create a PMG local user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "role",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "crypt_pass",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "keys",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_user_update",
+    "description": "MUTATION (RULING 3 \u2014 CONDITIONAL MEDIUM/HIGH): update a PMG user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "role",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "crypt_pass",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "keys",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_user_delete",
+    "description": "MUTATION (MEDIUM): delete a PMG user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_user_unlock_tfa",
+    "description": "MUTATION (HIGH): clear a PMG user's TOTP lockout (PUT /access/users/{userid}/unlock-tfa).",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_tfa_list",
+    "description": "READ-ONLY: list ALL users' TFA configuration.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_access_tfa_user_list",
+    "description": "READ-ONLY: list one user's TFA entries (created/description/enable/id/type \u2014 no secret;\nrichly typed on this plane). Needs PROXIMO_PMG_* config.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_tfa_get",
+    "description": "READ-ONLY: get one TFA entry (created/description/enable/id/type \u2014 no secret; richly\ntyped on this plane, a divergence from the shipped PBS twin's `null`-typed equivalent). Needs\nPROXIMO_PMG_* config.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_tfa_add",
+    "description": "MUTATION (MEDIUM): add a TFA entry for a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "totp",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "challenge",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_tfa_update",
+    "description": "MUTATION (MEDIUM): update a TFA entry's description/enabled flag.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_access_tfa_delete",
+    "description": "MUTATION (HIGH, IRREVERSIBLE): permanently remove one TFA factor from a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_config_admin_get",
+    "description": "READ-ONLY: read PMG admin/appliance-wide config (mail-from banner, virus-scanner toggles,\nDKIM defaults, consent text, http_proxy, stats lifetime). Schema-thin on this plane \u2014 passed\nthrough best-effort. `http_proxy`, if present, is defensi",
+    "arguments": []
+  },
+  {
+    "name": "pmg_config_admin_update",
+    "description": "MUTATION (MEDIUM, digest-gated): update PMG admin/appliance-wide config.",
+    "arguments": [
+      {
+        "name": "admin_mail_from",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "advfilter",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "avast",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "clamav",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "consent_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "custom_check",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "custom_check_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dailyreport",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "demo",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "dkim_use_domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dkim_selector",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dkim_sign",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "dkim_sign_all_mail",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "http_proxy",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "statlifetime",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_config_clamav_get",
+    "description": "READ-ONLY: read PMG ClamAV config (archive-scan limits, DB mirror, scripted-updates\ntoggle). Schema-thin \u2014 passed through best-effort. Needs PROXIMO_PMG_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_config_clamav_update",
+    "description": "MUTATION (MEDIUM, digest-gated): update PMG ClamAV config.",
+    "arguments": [
+      {
+        "name": "archiveblockencrypted",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "archivemaxfiles",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "archivemaxrec",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "archivemaxsize",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "dbmirror",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "maxcccount",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "maxscansize",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "scriptedupdates",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_config_mail_update",
+    "description": "MUTATION (MEDIUM, digest-gated): update PMG mail/SMTP/relay/greylist/DNSBL config \u2014 the\nsingle richest config surface on the whole PMG plane (39 fields). Dry-run by default \u2014 the\nPLAN reuses the already-shipped `pmg_relay_config` read for C",
+    "arguments": [
+      {
+        "name": "accept_broken_mime",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "banner",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "before_queue_filtering",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "conn_count_limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "conn_rate_limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "dnsbl_sites",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dnsbl_threshold",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "dwarning",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ext_port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filter_timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "greylist",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "greylist6",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "greylistmask4",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "greylistmask6",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "helotests",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "hide_received",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "int_port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "log_headers",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "max_filters",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_policy",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_smtpd_in",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_smtpd_out",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "maxsize",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "message_rate_limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ndr_on_block",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "queue_lifetime",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "rejectunknown",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "rejectunknownsender",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "relay",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "relaynomx",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "relayport",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "relayprotocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "smarthost",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "smarthostport",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "smtputf8",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "spf",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "tls",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "tlsheader",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "tlslog",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verifyreceivers",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_config_spamquar_get",
+    "description": "READ-ONLY: read PMG spam-quarantine config (auth mode, lifetime, quarantine-link\nself-service toggle, report style). Schema-thin \u2014 passed through best-effort. Needs\nPROXIMO_PMG_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_config_spamquar_update",
+    "description": "MUTATION (MEDIUM, digest-gated): update PMG spam-quarantine config.",
+    "arguments": [
+      {
+        "name": "allowhrefs",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "authmode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hostname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lifetime",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "mailfrom",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "quarantinelink",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "reportstyle",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "viewimages",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_config_virusquar_get",
+    "description": "READ-ONLY: read PMG virus-quarantine config (hyperlink display, lifetime, image display).",
+    "arguments": []
+  },
+  {
+    "name": "pmg_config_virusquar_update",
+    "description": "MUTATION (MEDIUM, digest-gated): update PMG virus-quarantine config.",
+    "arguments": [
+      {
+        "name": "allowhrefs",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "lifetime",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "viewimages",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_config_tfa_webauthn_get",
+    "description": "READ-ONLY: read PMG webauthn config (relying-party id/origin/name, subdomain-allow flag).",
+    "arguments": []
+  },
+  {
+    "name": "pmg_config_tfa_webauthn_update",
+    "description": "MUTATION (MEDIUM, digest-gated \u2014 SHA1/40-char, NOT this chunk's usual SHA256/64-char):\nupdate PMG webauthn config. Dry-run by default \u2014 the PLAN reads the current config first and\nflags `id_`/`origin`/`rp` changes with upstream's own \"will\"",
+    "arguments": [
+      {
+        "name": "allow_subdomains",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "origin",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rp",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_cluster_join_info",
+    "description": "READ-ONLY: get the information a NEW node needs to join THIS cluster \u2014 the master's own\naddress + certificate fingerprint (meant to be base64-encoded and pasted into the new node's\nown join dialog). PUBLIC verification material only \u2014 no se",
+    "arguments": []
+  },
+  {
+    "name": "pmg_cluster_nodes_list",
+    "description": "READ-ONLY: list this PMG cluster's member nodes (cid/fingerprint/hostrsapubkey/ip/name/\nrootrsapubkey/type). PUBLIC verification material only \u2014 fingerprint and SSH host/root\nPUBLIC keys, not secrets. Needs PROXIMO_PMG_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_cluster_status",
+    "description": "READ-ONLY: get PMG cluster node status.",
+    "arguments": [
+      {
+        "name": "list_single_node",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_cluster_create",
+    "description": "MUTATION (RISK_HIGH, NO UNDO): bootstrap THIS PMG node as a NEW cluster's master (POST\n/config/cluster/create, no parameters). Dry-run by default \u2014 the PLAN's FIRST blast_radius\nline states plainly: Proximo has NO undo for this, and NO visi",
+    "arguments": [
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_cluster_join",
+    "description": "MUTATION (RISK_HIGH, NO UNDO, THIRD-PARTY CREDENTIAL): join THIS PMG node to an EXISTING\ncluster identified by `master_ip`/`fingerprint`. Dry-run by default \u2014 the PLAN's FIRST\nblast_radius line states plainly: Proximo has NO undo for this, ",
+    "arguments": [
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "master_ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_cluster_node_add",
+    "description": "MUTATION (RISK_MEDIUM, bookkeeping): register a node into THIS cluster's config (POST\n/config/cluster/nodes) \u2014 RULING 1's MEDIUM branch: cluster-membership bookkeeping, NOT\nidentity fusion (the actual fusion already happened via a prior pmg",
+    "arguments": [
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hostrsapubkey",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rootrsapubkey",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_cid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_cluster_update_fingerprints",
+    "description": "MUTATION (RISK_MEDIUM, bookkeeping): refresh API certificate fingerprints for every cluster\nnode, fetched via ssh (POST /config/cluster/update-fingerprints, no parameters) \u2014 RULING 1's\nMEDIUM branch: fingerprint bookkeeping, not identity fu",
+    "arguments": [
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_doctor",
+    "description": "READ-ONLY: PMG connectivity + credential/permission preflight \u2014 checks the global /version\nendpoint and /access/users. Needs PROXIMO_PMG_* config.\n\nReturns a dict with \"version\" and \"permissions\" keys; a successful call proves connectivity\n",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_status",
+    "description": "READ-ONLY: get PMG node cpu/mem/disk/uptime status.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_relay_config",
+    "description": "READ-ONLY: get PMG SMTP relay/smarthost configuration.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_domains_list",
+    "description": "READ-ONLY: list PMG managed mail domains.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_statistics_mail",
+    "description": "Get PMG mail delivery statistics (read).",
+    "arguments": []
+  },
+  {
+    "name": "pmg_quarantine_spam",
+    "description": "READ-ONLY: list PMG quarantined spam messages.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_statistics_domains",
+    "description": "READ-ONLY: get PMG per-domain mail statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_virus",
+    "description": "READ-ONLY: get PMG virus statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_spamscores",
+    "description": "READ-ONLY: get PMG spam score distribution statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_recent",
+    "description": "READ-ONLY: get PMG recent mail statistics.",
+    "arguments": [
+      {
+        "name": "hours",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_blocklist_list",
+    "description": "READ-ONLY: list PMG quarantine blocklist entries.",
+    "arguments": [
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_blocklist_add",
+    "description": "MUTATION (LOW): add an address to the quarantine blocklist.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_action",
+    "description": "MUTATION (MEDIUM; HIGH for action='delete' \u2014 permanent, irreversible).",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mail_ids",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_postfix_qshape",
+    "description": "READ-ONLY: get PMG Postfix queue shape.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_postfix_flush",
+    "description": "MUTATION (LOW): flush all Postfix queues (immediate re-delivery attempt).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_spam_config",
+    "description": "READ-ONLY: get PMG spam filter configuration.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_service_status",
+    "description": "READ-ONLY: get the status of a PMG system service.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_domain_create",
+    "description": "MUTATION (LOW): create a managed mail domain.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_domain_delete",
+    "description": "MUTATION (MEDIUM): delete a managed mail domain.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_transport_create",
+    "description": "MUTATION (LOW): create a mail transport rule.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "use_mx",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_transport_delete",
+    "description": "MUTATION (MEDIUM): delete a mail transport rule.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_mynetworks_add",
+    "description": "MUTATION (LOW): add a CIDR to the PMG mynetworks trusted relay list.",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_mynetworks_remove",
+    "description": "MUTATION (MEDIUM): remove a CIDR from the PMG mynetworks trusted relay list.",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_spam_config_update",
+    "description": "MUTATION (MEDIUM): update PMG spam filter configuration.",
+    "arguments": [
+      {
+        "name": "bounce_score",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "clamav_heuristic_score",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "extract_text",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "languages",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "maxspamsize",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "rbl_checks",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "use_awl",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "use_bayes",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "use_razor",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "wl_bounce_relays",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_welcomelist_list",
+    "description": "READ-ONLY: list PMG quarantine welcomelist entries.",
+    "arguments": [
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_welcomelist_add",
+    "description": "MUTATION (LOW): add an address to the quarantine welcomelist.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_welcomelist_remove",
+    "description": "MUTATION (LOW): remove an address from the quarantine welcomelist.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_blocklist_remove",
+    "description": "MUTATION (LOW): remove an address from the quarantine blocklist.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_service_control",
+    "description": "MUTATION (MEDIUM): start, stop, restart, or reload a PMG service.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tracker_list",
+    "description": "READ-ONLY: list mail tracking entries.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "from_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "xfilter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ndr",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "greylist",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tracker_detail",
+    "description": "READ-ONLY: get tracking detail for a specific mail ID.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_virus",
+    "description": "READ-ONLY: list virus quarantine entries.",
+    "arguments": [
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_attachment",
+    "description": "READ-ONLY: list attachment quarantine entries.",
+    "arguments": [
+      {
+        "name": "pmail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_virusstatus",
+    "description": "READ-ONLY: get virus quarantine status summary.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_quarantine_spamstatus",
+    "description": "READ-ONLY: get spam quarantine status summary.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_quarantine_spamusers",
+    "description": "READ-ONLY: list users with quarantined mail entries.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "quarantine_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_users_list",
+    "description": "READ-ONLY: list users with welcomelist/blocklist quarantine settings.",
+    "arguments": [
+      {
+        "name": "list_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_content_get",
+    "description": "READ-ONLY (ADVERSARIAL): get the full content of one quarantined email.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "images",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "raw",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_attachments_list",
+    "description": "READ-ONLY (ADVERSARIAL): list attachments on one quarantined email.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_link_get",
+    "description": "READ-ONLY: get a quarantine login link for a recipient's mailbox.",
+    "arguments": [
+      {
+        "name": "mail",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_quarantine_sendlink",
+    "description": "MUTATION (LOW): send a REAL quarantine login link email to a recipient.",
+    "arguments": [
+      {
+        "name": "mail",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_mailcount",
+    "description": "READ-ONLY: get per-bucket mail count statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "timespan",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_sender",
+    "description": "READ-ONLY: get per-sender mail statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filter_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "orderby",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_receiver",
+    "description": "READ-ONLY: get per-recipient mail statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filter_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "orderby",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_contact",
+    "description": "READ-ONLY (ADVERSARIAL): get per-contact-address mail statistics.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filter_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "orderby",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "day",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "month",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "year",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_detail",
+    "description": "READ-ONLY (ADVERSARIAL): get detailed per-message statistics for one address.",
+    "arguments": [
+      {
+        "name": "address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filter_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "orderby",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "day",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "month",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "year",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_maildistribution",
+    "description": "READ-ONLY: get spam-mail counts grouped by spam score.",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "day",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "month",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "year",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_recentreceivers",
+    "description": "READ-ONLY (ADVERSARIAL): get the top recent mail receivers (including spam).",
+    "arguments": [
+      {
+        "name": "hours",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_recentsenders",
+    "description": "READ-ONLY (ADVERSARIAL): get the top recent mail senders (including spam).",
+    "arguments": [
+      {
+        "name": "hours",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_statistics_rejectcount",
+    "description": "READ-ONLY: get early-SMTP-reject counts (RBL/PREGREET rejects with postscreen).",
+    "arguments": [
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "day",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "month",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "year",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "timespan",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_syslog",
+    "description": "READ-ONLY: get PMG node syslog entries.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "since",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "until",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_rrddata",
+    "description": "READ-ONLY: get PMG node RRD performance data.",
+    "arguments": [
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cf",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tasks_list",
+    "description": "READ-ONLY: list PMG tasks on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "userfilter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "errors",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "typefilter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "since",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "until",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "statusfilter",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_backup_create",
+    "description": "MUTATION (LOW): create a PMG configuration backup.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "statistic",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rules_list",
+    "description": "READ-ONLY: list all PMG RuleDB rules (hydrated rule list).",
+    "arguments": []
+  },
+  {
+    "name": "pmg_ruledb_rule_get",
+    "description": "READ-ONLY: get a PMG RuleDB rule's configuration.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_from_list",
+    "description": "READ-ONLY: list the 'from' objects attached to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_to_list",
+    "description": "READ-ONLY: list the 'to' objects attached to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_what_list",
+    "description": "READ-ONLY: list the 'what' objects attached to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_when_list",
+    "description": "READ-ONLY: list the 'when' objects attached to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_actions_list",
+    "description": "READ-ONLY: list the 'actions' objects attached to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_groups_list",
+    "description": "READ-ONLY: list all PMG RuleDB 'who' object groups.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_who_group_get",
+    "description": "READ-ONLY: get a PMG RuleDB 'who' object group's configuration.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_group_objects",
+    "description": "READ-ONLY: list the objects in a PMG RuleDB 'who' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_groups_list",
+    "description": "READ-ONLY: list all PMG RuleDB 'what' object groups.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_what_group_get",
+    "description": "READ-ONLY: get a PMG RuleDB 'what' object group's configuration.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_group_objects",
+    "description": "READ-ONLY: list the objects in a PMG RuleDB 'what' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_groups_list",
+    "description": "READ-ONLY: list all PMG RuleDB 'when' object groups.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_when_group_get",
+    "description": "READ-ONLY: get a PMG RuleDB 'when' object group's configuration.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_group_objects",
+    "description": "READ-ONLY: list the objects in a PMG RuleDB 'when' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_objects_list",
+    "description": "READ-ONLY: list all PMG RuleDB action objects, including non-editable.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_ruledb_digest",
+    "description": "READ-ONLY: get the PMG RuleDB digest (change-detection hash).",
+    "arguments": []
+  },
+  {
+    "name": "pmg_ldap_profiles_list",
+    "description": "READ-ONLY: list configured LDAP directory profiles.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_ldap_profile_config_get",
+    "description": "READ-ONLY: read one LDAP profile's full configuration.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_profile_create",
+    "description": "MUTATION (MEDIUM): add an LDAP directory profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "basedn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "binddn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bindpw",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "groupbasedn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "groupclass",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mailattr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "accountattr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cafile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "server2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_profile_delete",
+    "description": "MUTATION (MEDIUM): delete an LDAP directory profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_profile_config_update",
+    "description": "MUTATION (MEDIUM): update an LDAP profile's configuration.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "basedn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "binddn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bindpw",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "groupbasedn",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "groupclass",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mailattr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "accountattr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cafile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "server1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_profile_sync",
+    "description": "MUTATION (MEDIUM): synchronize LDAP users/groups to the local database for one profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_users_list",
+    "description": "READ-ONLY: list LDAP users cached for one profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_user_emails_get",
+    "description": "READ-ONLY: get all email addresses for one LDAP user.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_groups_list",
+    "description": "READ-ONLY: list LDAP groups cached for one profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ldap_group_members_get",
+    "description": "READ-ONLY: list one LDAP group's members.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "gid",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_fetchmail_list",
+    "description": "READ-ONLY: list configured fetchmail accounts.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_fetchmail_get",
+    "description": "READ-ONLY: read one fetchmail account's configuration.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_fetchmail_create",
+    "description": "MUTATION (MEDIUM): create a fetchmail account (periodic poll of a THIRD-PARTY mailbox).",
+    "arguments": [
+      {
+        "name": "server",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "interval",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ssl",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_fetchmail_update",
+    "description": "MUTATION (MEDIUM): update a fetchmail account's configuration.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "user",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "interval",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "ssl",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_fetchmail_delete",
+    "description": "MUTATION (MEDIUM): delete a fetchmail account.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_domain_get",
+    "description": "READ-ONLY: read a managed mail domain's comment.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_domain_update",
+    "description": "MUTATION (LOW): update a managed mail domain's comment.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_transport_list",
+    "description": "READ-ONLY: list mail transport map entries.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_transport_get",
+    "description": "READ-ONLY: read a single mail transport map entry.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_transport_update",
+    "description": "MUTATION (MEDIUM): update a mail transport rule.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "host",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "use_mx",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_mynetworks_list",
+    "description": "READ-ONLY: list PMG mynetworks (trusted relay) entries.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_mynetworks_get",
+    "description": "READ-ONLY: read a single mynetworks entry's comment.",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_mynetworks_update",
+    "description": "MUTATION (LOW): update a mynetworks entry's comment.",
+    "arguments": [
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tlspolicy_list",
+    "description": "READ-ONLY: list TLS policy entries (per-destination TLS enforcement overrides).",
+    "arguments": []
+  },
+  {
+    "name": "pmg_tlspolicy_get",
+    "description": "READ-ONLY: read a single TLS policy entry.",
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tlspolicy_create",
+    "description": "MUTATION (MEDIUM): add a TLS policy entry for a destination.",
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tlspolicy_update",
+    "description": "MUTATION (MEDIUM): update a TLS policy entry's policy value.",
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tlspolicy_delete",
+    "description": "MUTATION (MEDIUM): delete a TLS policy entry.",
+    "arguments": [
+      {
+        "name": "destination",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tls_inbound_domains_list",
+    "description": "READ-ONLY: list domains for which TLS is enforced on INCOMING connections.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_tls_inbound_domains_create",
+    "description": "MUTATION (LOW): require TLS on incoming connections for a domain.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_tls_inbound_domains_delete",
+    "description": "MUTATION (LOW mechanically \u2014 but LOOSENS security): remove a domain from the\nTLS-inbound-enforced list. Dry-run by default. confirm=True to execute. Needs PROXIMO_PMG_*\nconfig.\n\nIncoming mail for this domain is no longer required to arrive ",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_mimetypes_list",
+    "description": "READ-ONLY: get PMG's built-in MIME type list.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_regextest",
+    "description": "READ-ONLY (POST-verbed, classified by EFFECT not verb): test a regex against sample text,\nevaluated server-side by PMG. Needs PROXIMO_PMG_* config.\n\nNo PMG state is read or written and no outbound network call is made (unlike pbs_s3_check,\n",
+    "arguments": [
+      {
+        "name": "regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "text",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_dkim_domains_list",
+    "description": "READ-ONLY: list DKIM-sign domains.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_dkim_domain_get",
+    "description": "READ-ONLY: read a DKIM-sign domain's comment.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_dkim_selector_get",
+    "description": "READ-ONLY: get the PUBLIC key for the configured DKIM selector, rendered as a DNS TXT\nrecord. Needs PROXIMO_PMG_* config.\n\nReturns {\"keysize\": ..., \"record\": ..., \"selector\": ...}. The PRIVATE signing key never\nappears here (schema-confirme",
+    "arguments": []
+  },
+  {
+    "name": "pmg_dkim_selectors_list",
+    "description": "READ-ONLY: get a list of all existing DKIM selectors.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_customscores_list",
+    "description": "READ-ONLY: list custom SpamAssassin scores.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_customscores_get",
+    "description": "READ-ONLY: get a single custom SpamAssassin score.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_dkim_domain_create",
+    "description": "MUTATION (LOW): add a DKIM-sign domain.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_dkim_domain_update",
+    "description": "MUTATION (LOW): update a DKIM-sign domain's comment.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_dkim_domain_delete",
+    "description": "MUTATION (MEDIUM): delete a DKIM-sign domain.",
+    "arguments": [
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_dkim_selector_generate",
+    "description": "MUTATION (MEDIUM): generate a new DKIM private key for a selector.",
+    "arguments": [
+      {
+        "name": "selector",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "keysize",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_customscores_create",
+    "description": "MUTATION (LOW): create a custom SpamAssassin score.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "score",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_customscores_update",
+    "description": "MUTATION (MEDIUM): edit a custom SpamAssassin score.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "score",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_customscores_delete",
+    "description": "MUTATION (MEDIUM): delete a custom SpamAssassin score.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_customscores_revert_all",
+    "description": "MUTATION (MEDIUM): revert ALL custom SpamAssassin score changes at once \u2014 a step above the\nper-item delete. Dry-run by default. confirm=True to execute. Needs PROXIMO_PMG_* config.\n\nReverts EVERY custom score override back to SpamAssassin's",
+    "arguments": [
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_customscores_apply",
+    "description": "MUTATION (MEDIUM): apply staged custom SpamAssassin score changes.",
+    "arguments": [
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "restart_daemon",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_pbs_remote_list",
+    "description": "READ-ONLY: list all PBS remote instances PMG can back up its own config to.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_pbs_remote_get",
+    "description": "READ-ONLY: read one PBS remote's configuration.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_pbs_remote_create",
+    "description": "MUTATION (MEDIUM): register a new PBS remote instance PMG can back up its own config to \u2014\ncreates a PERSISTENT CREDENTIAL-BEARING link (mirrors pbs_remote_create/pbs_s3_client_create's\nown \"not LOW despite reading like additive config\" reas",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "datastore",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "encryption_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "include_statistics",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "keep_daily",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_hourly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_last",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_monthly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_weekly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_yearly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "master_pubkey",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "namespace",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_pbs_remote_update",
+    "description": "MUTATION (MEDIUM): update a PBS remote's connection/retention settings.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "datastore",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "encryption_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "include_statistics",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "keep_daily",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_hourly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_last",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_monthly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_weekly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "keep_yearly",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "master_pubkey",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "namespace",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_pbs_remote_delete",
+    "description": "MUTATION (MEDIUM): delete a PBS remote.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_jobs_list",
+    "description": "READ-ONLY: list all configured PBS backup jobs on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_snapshots_list",
+    "description": "READ-ONLY: list snapshots stored on a PBS remote.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_snapshot_create",
+    "description": "MUTATION (MEDIUM): trigger an immediate backup of this PMG's rule database/config to a PBS\nremote \u2014 PMG's own schema states this ALSO prunes the backup group afterward, if configured\n(adds a new backup AND may remove older ones per the remo",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "statistic",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_snapshot_get",
+    "description": "READ-ONLY: get all snapshots under one backup-id stored on a PBS remote.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_snapshot_forget",
+    "description": "MUTATION (HIGH, NO UNDO): permanently delete a snapshot on a PBS remote.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_snapshot_restore",
+    "description": "MUTATION (HIGH, NO UNDO): restore PMG state from a REMOTE PBS snapshot.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "config",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "database",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "statistic",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_snapshot_verify",
+    "description": "MUTATION (LOW): start an integrity verification run for a snapshot on a PBS remote \u2014\nnon-destructive, matches pbs_verify_start's identical precedent. Dry-run by default.\nconfirm=True executes (POST\n/nodes/{node}/pbs/{remote}/snapshot/{backu",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "backup_time",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_timer_get",
+    "description": "READ-ONLY: get the backup schedule (systemd timer spec) for a PBS remote.",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_timer_create",
+    "description": "MUTATION (LOW): create a recurring backup schedule for a PBS remote \u2014 additive scheduling\nconfig only, no backup data touched (matches pbs_job_create's precedent). Dry-run by default\n\u2014 the PLAN best-effort reads any existing timer and flags",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delay",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_pbs_timer_delete",
+    "description": "MUTATION (LOW): delete the backup schedule for a PBS remote \u2014 config-only, removes the\nSCHEDULE not backup data (matches pbs_job_delete's precedent). Dry-run by default \u2014 the PLAN\nbest-effort reads the current timer. confirm=True executes (",
+    "arguments": [
+      {
+        "name": "remote",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_account_list",
+    "description": "READ-ONLY: list registered PMG ACME account names.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_acme_account_get",
+    "description": "READ-ONLY: get one PMG ACME account's full config (account/directory/location/tos).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_plugin_list",
+    "description": "READ-ONLY: list all configured PMG ACME DNS/standalone challenge plugins.",
+    "arguments": [
+      {
+        "name": "plugin_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_plugin_get",
+    "description": "READ-ONLY: get one PMG ACME plugin's full config.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_tos",
+    "description": "READ-ONLY: get the Terms-of-Service URL for an ACME directory (or None if the CA\nadvertises no ToS). Deprecated by PMG in favor of pmg_acme_meta, per PMG's own schema \u2014 kept\nsince PMG still exposes it. The PMG host fetches the given directo",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_meta",
+    "description": "READ-ONLY: get ACME directory meta information (externalAccountRequired, termsOfService,\ncaaIdentities, website). PBS has NO equivalent endpoint \u2014 a genuinely new read this wave, not\na parity gap. Same caller-chosen-directory-URL fetch as p",
+    "arguments": [
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_directories",
+    "description": "READ-ONLY: list PMG's built-in catalog of known ACME CA directory endpoints (name + URL\npairs, e.g. Let's Encrypt production/staging). No params \u2014 static catalog, no caller-\ninfluenced URL fetch (unlike pmg_acme_tos/pmg_acme_meta). Needs PR",
+    "arguments": []
+  },
+  {
+    "name": "pmg_acme_challenge_schema",
+    "description": "READ-ONLY: list the catalog of known ACME challenge plugin types (id/name/schema/type per\nentry) \u2014 the parameter schema each plugin_type+dns_api+data combination must satisfy. No\nparams \u2014 static catalog. Needs PROXIMO_PMG_* config.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_acme_account_create",
+    "description": "MUTATION (MEDIUM): register a new ACME account with the CA.",
+    "arguments": [
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eab_hmac_key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "eab_kid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tos_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_account_update",
+    "description": "MUTATION: update ACME account contact info, or trigger a CA refresh if contact is\nomitted (PMG's own schema states this plainly \u2014 a deliberate exception to the usual\n\"at least one field\" guard). Dry-run by default.\n\nLOW risk \u2014 metadata upda",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_account_delete",
+    "description": "MUTATION: IRREVERSIBLE \u2014 DEACTIVATES an ACME account at the CA (not just local config\nremoval) and deletes the local record. Dry-run by default.\n\nHIGH risk: TLS lockout at cert expiry if this is the only account. The account key is\ndestroye",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_plugin_create",
+    "description": "MUTATION: create an ACME DNS/standalone challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "plugin_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_api",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "validation_delay",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_plugin_update",
+    "description": "MUTATION: update an ACME DNS/standalone challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_api",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "validation_delay",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_acme_plugin_delete",
+    "description": "MUTATION: delete an ACME DNS/standalone challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_cert_acme_order",
+    "description": "MUTATION (MEDIUM): order a NEW ACME TLS certificate for one of PMG's two cert slots\n('api' or 'smtp' \u2014 PMG runs two independent node certs, unlike PVE/PBS's single slot). Dry-\nrun by default.\n\nCA-validated: the cert is installed ONLY on a s",
+    "arguments": [
+      {
+        "name": "cert_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_cert_acme_renew",
+    "description": "MUTATION (MEDIUM): renew the existing ACME TLS certificate for one of PMG's two cert\nslots. Dry-run by default.\n\nSame install-on-success guarantee as pmg_node_cert_acme_order (a failure can't lock you\nout). Same bare-STRING-return honesty (",
+    "arguments": [
+      {
+        "name": "cert_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_cert_acme_revoke",
+    "description": "MUTATION: IRREVERSIBLE \u2014 revoke the node's ACME TLS certificate for one cert slot AT THE\nCA. Dry-run by default. PMG's own tool \u2014 PBS never shipped a cert-revoke tool at all.\n\nHIGH risk: a revoked cert cannot be un-revoked; only a new pmg_n",
+    "arguments": [
+      {
+        "name": "cert_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_cert_custom_upload",
+    "description": "MUTATION: upload/replace the custom TLS certificate for one of PMG's two cert slots.",
+    "arguments": [
+      {
+        "name": "cert_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "certificates",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "restart",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_cert_custom_delete",
+    "description": "MUTATION: delete the custom TLS certificate from one of PMG's two cert slots \u2014 PMG\nreverts to its self-signed cert for that slot. Dry-run by default.\n\nRISK_MEDIUM: recoverable by re-uploading (pmg_node_cert_custom_upload) or re-ordering\n(pm",
+    "arguments": [
+      {
+        "name": "cert_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "restart",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_list",
+    "description": "READ-ONLY: list network interfaces on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_get",
+    "description": "READ-ONLY: read one network interface's configuration on a PMG node.",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_create",
+    "description": "MUTATION (MEDIUM): create a network interface configuration on a PMG node (staged, written\nto interfaces.new \u2014 NOT live until pmg_node_network_reload). Dry-run by default (checks for a\nname collision). confirm=True executes (POST /nodes/{no",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_update",
+    "description": "MUTATION (MEDIUM): update a network interface's configuration on a PMG node (staged \u2014 NOT\nlive until pmg_node_network_reload). Dry-run by default \u2014 reads the interface's current\nconfig; if `iface_type` is given and differs from the interfac",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_props",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_delete",
+    "description": "MUTATION (MEDIUM): remove a network interface's staged configuration on a PMG node (NOT\nlive until pmg_node_network_reload). Dry-run by default \u2014 reads the interface's current\nconfig. confirm=True executes (DELETE /nodes/{node}/network/{ifa",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_revert",
+    "description": "MUTATION (LOW): discard staged network configuration changes on a PMG node (interfaces.new\nreverted) \u2014 the live config is untouched; safe. Dry-run by default. confirm=True executes\n(DELETE /nodes/{node}/network) and returns {\"status\": \"ok\",",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_network_reload",
+    "description": "MUTATION (HIGH): apply staged network configuration changes on a PMG node \u2014 makes\ninterfaces.new live. Dry-run by default. *** CONNECTIVITY-LOCKOUT RISK *** a misconfigured\ninterface can drop SSH/API/mail access; recovery requires console/p",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_dns_get",
+    "description": "READ-ONLY: read a PMG node's DNS resolver configuration.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_dns_set",
+    "description": "MUTATION (MEDIUM): update DNS resolver configuration on a PMG node.",
+    "arguments": [
+      {
+        "name": "search",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns3",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_time_get",
+    "description": "READ-ONLY: read a PMG node's current time and timezone.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_time_set",
+    "description": "MUTATION (LOW): set the timezone on a PMG node.",
+    "arguments": [
+      {
+        "name": "timezone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_config_get",
+    "description": "READ-ONLY: read a PMG node's ACME account/domain-mapping config.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_config_set",
+    "description": "MUTATION (MEDIUM, digest-gated): update a PMG node's ACME account/domain-mapping config.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acme",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain0",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain3",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "acmedomain4",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_certificates_info",
+    "description": "READ-ONLY: get information about a PMG node's TLS certificates (pem/fingerprint/subject/\nissuer/san/validity dates per certificate). PUBLIC cert data only \u2014 no private key field ever\nappears here. Needs PROXIMO_PMG_* config.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_services_list",
+    "description": "READ-ONLY: list systemd services on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_subscription_get",
+    "description": "READ-ONLY: read a PMG node's subscription status.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_subscription_set",
+    "description": "MUTATION (MEDIUM): install and validate a subscription key on a PMG node.",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_subscription_check",
+    "description": "MUTATION (LOW): check and refresh a PMG node's subscription status by contacting Proxmox's\nserver. Dry-run by default. No key/identity change \u2014 status-cache refresh only. confirm=True\nexecutes (POST /nodes/{node}/subscription) and returns {",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_subscription_delete",
+    "description": "MUTATION (MEDIUM): delete the locally-stored subscription info on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_task_stop",
+    "description": "MUTATION (HIGH): stop (cancel) a running PMG task.",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_task_log",
+    "description": "READ-ONLY: fetch a PMG task's log lines ({n: line number, t: line text} per entry).",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_task_status",
+    "description": "READ-ONLY: get a PMG task's status ({pid, status: running|stopped}).",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_report",
+    "description": "READ-ONLY: generate a free-text diagnostic report bundle for a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_journal",
+    "description": "READ-ONLY: fetch systemd journal lines from a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastentries",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "since",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "until",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "startcursor",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "endcursor",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_backup_list",
+    "description": "READ-ONLY: list stored PMG configuration backup files ({filename, size, timestamp}).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_backup_delete",
+    "description": "MUTATION (MEDIUM): delete a stored PMG backup file.",
+    "arguments": [
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_backup_restore",
+    "description": "MUTATION (HIGH, NO UNDO): restore PMG state from a stored backup file.",
+    "arguments": [
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "config",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "database",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "statistic",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_list",
+    "description": "READ-ONLY: list mail queued in one Postfix queue.",
+    "arguments": [
+      {
+        "name": "queue",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "sortfield",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sortdir",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_message_get",
+    "description": "READ-ONLY: get the contents of one queued mail message.",
+    "arguments": [
+      {
+        "name": "queue",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "queue_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "header",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "body",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "decode_header",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_action",
+    "description": "MUTATION (conditional HIGH/MEDIUM): apply delete or deliver to caller-enumerated queue\nIDs within one Postfix queue. Dry-run by default \u2014 RISK_HIGH for action='delete' (permanent,\nno undo), RISK_MEDIUM for action='deliver' (additive; mirror",
+    "arguments": [
+      {
+        "name": "queue",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ids",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_delete_all",
+    "description": "MUTATION (HIGH): delete ALL mail in ALL Postfix queues on a PMG node\n(deferred+active+incoming+hold in one call). Dry-run by default. *** DESTROYS EVERY QUEUED\nMESSAGE *** with no undo. confirm=True executes (DELETE /nodes/{node}/postfix/qu",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_delete_queue",
+    "description": "MUTATION (HIGH): delete ALL mail in one named Postfix queue on a PMG node.",
+    "arguments": [
+      {
+        "name": "queue",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_message_delete",
+    "description": "MUTATION (MEDIUM): delete one queued message by queue ID.",
+    "arguments": [
+      {
+        "name": "queue",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "queue_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_queue_message_deliver",
+    "description": "MUTATION (LOW): schedule immediate delivery of one deferred message by queue ID.",
+    "arguments": [
+      {
+        "name": "queue",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "queue_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_postfix_discard_verify_cache",
+    "description": "MUTATION (LOW): discard the Postfix address-verification cache on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_clamav_database_get",
+    "description": "READ-ONLY: get ClamAV virus database status (per-DB build_time/nsigs/type/version).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_clamav_database_update",
+    "description": "MUTATION (MEDIUM): fetch fresh ClamAV virus signature databases on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_spamassassin_rules_get",
+    "description": "READ-ONLY: get SpamAssassin rule-channel status (channel/last_updated/update_avail/\nupdate_version/version). REVIEWED_TRUSTED \u2014 structured version/count metadata. Use\npmg_node_spamassassin_rules_update to fetch fresh rule channels. Needs PR",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_spamassassin_rules_update",
+    "description": "MUTATION (MEDIUM): fetch fresh SpamAssassin rule channels on a PMG node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_service_start",
+    "description": "MUTATION (MEDIUM): start a PMG system service.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_service_stop",
+    "description": "MUTATION (conditional HIGH/MEDIUM): stop a PMG system service.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_service_restart",
+    "description": "MUTATION (MEDIUM): restart a PMG system service.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_node_service_reload",
+    "description": "MUTATION (MEDIUM): reload a PMG system service's configuration.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_group_create",
+    "description": "MUTATION (LOW): create a PMG RuleDB 'who' object group.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "and_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_group_update",
+    "description": "MUTATION (MEDIUM): update a PMG RuleDB 'who' object group config.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "and_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_group_delete",
+    "description": "MUTATION (MEDIUM): delete a PMG RuleDB 'who' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_group_create",
+    "description": "MUTATION (LOW): create a PMG RuleDB 'what' object group.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "and_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_group_update",
+    "description": "MUTATION (MEDIUM): update a PMG RuleDB 'what' object group config.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "and_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_group_delete",
+    "description": "MUTATION (MEDIUM): delete a PMG RuleDB 'what' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_group_create",
+    "description": "MUTATION (LOW): create a PMG RuleDB 'when' object group.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "and_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_group_update",
+    "description": "MUTATION (MEDIUM): update a PMG RuleDB 'when' object group config.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "and_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_group_delete",
+    "description": "MUTATION (MEDIUM): delete a PMG RuleDB 'when' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_object_add",
+    "description": "MUTATION (LOW): add an object to a PMG RuleDB 'who' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "account",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_object_update",
+    "description": "MUTATION (MEDIUM): update an object in a PMG RuleDB 'who' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "account",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_object_delete",
+    "description": "MUTATION (MEDIUM): delete an object from a PMG RuleDB 'who' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_who_object_get",
+    "description": "READ-ONLY: get a PMG RuleDB 'who' object's settings.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_object_add",
+    "description": "MUTATION (LOW): add an object to a PMG RuleDB 'what' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contenttype",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "only_content",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_part_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "spamlevel",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_object_update",
+    "description": "MUTATION (MEDIUM): update an object in a PMG RuleDB 'what' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contenttype",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "only_content",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "top_part_only",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "spamlevel",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_object_delete",
+    "description": "MUTATION (MEDIUM): delete an object from a PMG RuleDB 'what' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_what_object_get",
+    "description": "READ-ONLY: get a PMG RuleDB 'what' object's settings.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_object_add",
+    "description": "MUTATION (LOW): add a timeframe object to a PMG RuleDB 'when' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_object_update",
+    "description": "MUTATION (MEDIUM): update a timeframe object in a PMG RuleDB 'when' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "end",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_object_delete",
+    "description": "MUTATION (MEDIUM): delete a timeframe object from a PMG RuleDB 'when' object group.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_when_object_get",
+    "description": "READ-ONLY: get a PMG RuleDB 'when' (timeframe) object's settings.",
+    "arguments": [
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_bcc_create",
+    "description": "MUTATION (LOW): create a BCC action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "original",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_bcc_update",
+    "description": "MUTATION (MEDIUM): update a BCC action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "original",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_bcc_get",
+    "description": "READ-ONLY: get a BCC action object's settings from the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_field_create",
+    "description": "MUTATION (LOW): create a field-modification action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_field_update",
+    "description": "MUTATION (MEDIUM): update a field-modification action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "field",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_field_get",
+    "description": "READ-ONLY: get a field-modification action object's settings from the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_notification_create",
+    "description": "MUTATION (LOW): create a notification action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "body_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "attach",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_notification_update",
+    "description": "MUTATION (MEDIUM): update a notification action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subject",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "body_text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "attach",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_notification_get",
+    "description": "READ-ONLY: get a notification action object's settings from the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_disclaimer_create",
+    "description": "MUTATION (LOW): create a disclaimer action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disclaimer",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "position",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "add_separator",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_disclaimer_update",
+    "description": "MUTATION (MEDIUM): update a disclaimer action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disclaimer",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "position",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "add_separator",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_disclaimer_get",
+    "description": "READ-ONLY: get a disclaimer action object's settings from the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_removeattachments_create",
+    "description": "MUTATION (LOW): create a remove-attachments action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "all_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "quarantine",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_removeattachments_update",
+    "description": "MUTATION (MEDIUM): update a remove-attachments action object in the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "text",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "info",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "all_",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "quarantine",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_removeattachments_get",
+    "description": "READ-ONLY: get a remove-attachments action object's settings from the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_action_delete",
+    "description": "MUTATION (MEDIUM): delete an action object from the PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_create",
+    "description": "MUTATION (MEDIUM): create a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "priority",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "direction",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "from_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "from_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "to_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "to_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "what_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "what_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "when_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "when_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_update",
+    "description": "MUTATION (MEDIUM): update a PMG RuleDB rule configuration.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "priority",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "active",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "direction",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "from_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "from_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "to_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "to_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "what_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "what_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "when_and",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "when_invert",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_delete",
+    "description": "MUTATION (MEDIUM): delete a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_from_attach",
+    "description": "MUTATION (MEDIUM): attach a 'from' (sender/who) group to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_from_detach",
+    "description": "MUTATION (MEDIUM): detach a 'from' (sender/who) group from a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_to_attach",
+    "description": "MUTATION (MEDIUM): attach a 'to' (recipient/who) group to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_to_detach",
+    "description": "MUTATION (MEDIUM): detach a 'to' (recipient/who) group from a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_what_attach",
+    "description": "MUTATION (MEDIUM): attach a 'what' (content) group to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_what_detach",
+    "description": "MUTATION (MEDIUM): detach a 'what' (content) group from a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_when_attach",
+    "description": "MUTATION (MEDIUM): attach a 'when' (timeframe) group to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_when_detach",
+    "description": "MUTATION (MEDIUM): detach a 'when' (timeframe) group from a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_action_attach",
+    "description": "MUTATION (MEDIUM): attach an action group to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_action_detach",
+    "description": "MUTATION (MEDIUM): detach an action group from a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ogroup",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_rule_action_groups_list",
+    "description": "READ-ONLY: list the action-group ids DIRECTLY attached to a PMG RuleDB rule.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_ruledb_reset",
+    "description": "MUTATION (HIGH): factory-reset the ENTIRE PMG RuleDB.",
+    "arguments": [
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_welcomelist_objects_list",
+    "description": "READ-ONLY: list every entry across all 8 PMG global welcomelist typed families.",
+    "arguments": []
+  },
+  {
+    "name": "pmg_welcomelist_object_get",
+    "description": "READ-ONLY: get a PMG global welcomelist object's settings.",
+    "arguments": [
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_welcomelist_object_add",
+    "description": "MUTATION (MEDIUM): add an object to the PMG GLOBAL welcomelist.",
+    "arguments": [
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_welcomelist_object_update",
+    "description": "MUTATION (MEDIUM): update an object in the PMG GLOBAL welcomelist.",
+    "arguments": [
+      {
+        "name": "type_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "regex",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pmg_welcomelist_object_delete",
+    "description": "MUTATION (LOW): delete an object from the PMG GLOBAL welcomelist.",
+    "arguments": [
+      {
+        "name": "id_",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_users_list",
+    "description": "List all Proxmox users across every realm (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_roles_list",
+    "description": "List all Proxmox roles and their privileges (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_acl_list",
+    "description": "List all ACL entries on the Proxmox cluster (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_tokens_list",
+    "description": "List API tokens for a specific user (read-only).",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_overbroad_grants",
+    "description": "READ-ONLY: surface over-broad ACL grants \u2014 Administrator-role assignments or grants on the\nroot '/' path \u2014 as a least-privilege diagnostic.\n\nNo state change; this only reports, it does not revoke anything. Returns a list of the flagged ACL\n",
+    "arguments": []
+  },
+  {
+    "name": "pve_acl_modify",
+    "description": "MUTATION: grant or revoke an ACL entry (PUT /access/acl).",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "roles",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "propagate",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acl_prune",
+    "description": "MUTATION: prune (remove/narrow) an over-broad ACL grant flagged by pve_overbroad_grants.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "narrow_role",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "narrow_path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_token_create",
+    "description": "MUTATION: create an API token for a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tokenid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "privsep",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_token_revoke",
+    "description": "MUTATION (IRREVERSIBLE): permanently revoke an API token.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tokenid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_user_get",
+    "description": "Get a user's full config (read-only).",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_groups_list",
+    "description": "List all Proxmox groups (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_group_get",
+    "description": "Get a group's full config (read-only).",
+    "arguments": [
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_user_create",
+    "description": "MUTATION: create a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "groups",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_user_update",
+    "description": "MUTATION: update a user (enable=False stops login; group changes re-scope access).",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "expire",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "groups",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "firstname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "append",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_user_delete",
+    "description": "MUTATION (HIGH): delete a user.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_group_create",
+    "description": "MUTATION: create an (empty) group.",
+    "arguments": [
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_group_update",
+    "description": "MUTATION: update a group's comment.",
+    "arguments": [
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_group_delete",
+    "description": "MUTATION (HIGH): delete a group.",
+    "arguments": [
+      {
+        "name": "groupid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_realms_list",
+    "description": "List authentication realms/domains configured in Proxmox (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_realm_get",
+    "description": "Get a realm's full config (read-only).",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_tfa_list",
+    "description": "List all per-user TFA (two-factor) entries across the cluster (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_tfa_get",
+    "description": "Read a user's TFA entries (read-only).",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_tfa_delete",
+    "description": "MUTATION (HIGH RISK): delete a user's TFA factor.",
+    "arguments": [
+      {
+        "name": "userid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tfa_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_role_create",
+    "description": "MUTATION: create a custom role with an optional privilege set.",
+    "arguments": [
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "privs",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_role_update",
+    "description": "MUTATION: change a role's privileges.",
+    "arguments": [
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "privs",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "append",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_role_delete",
+    "description": "MUTATION (HIGH): delete a role.",
+    "arguments": [
+      {
+        "name": "roleid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_realm_create",
+    "description": "MUTATION: create an auth realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "realm_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_realm_update",
+    "description": "MUTATION: update a realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_realm_delete",
+    "description": "MUTATION (HIGH, lockout-class): delete an auth realm.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_agent_info",
+    "description": "READ-ONLY: query the qemu-agent on a guest (ping, osinfo, hostname, users, exec-status, \u2026).",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_agent_file_read",
+    "description": "READ-ONLY: read a file from inside the guest via the qemu-agent.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_agent_file_write",
+    "description": "MUTATION: write a file inside the guest via the qemu-agent.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "file",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_agent_fs",
+    "description": "MUTATION: fsfreeze-freeze, fsfreeze-thaw, or fstrim inside the guest via the qemu-agent.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "command",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_agent_set_password",
+    "description": "MUTATION: set a guest OS user's password via the qemu-agent.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "password",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_updates_list",
+    "description": "READ-ONLY: list available package updates (cached apt index) on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_changelog",
+    "description": "READ-ONLY: get a package's changelog text on a PVE node.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_repositories_get",
+    "description": "READ-ONLY: get the current APT repository configuration of a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_versions",
+    "description": "READ-ONLY: get installed versions of important Proxmox packages on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_update_refresh",
+    "description": "MUTATION: resynchronize the APT package index on a PVE node (apt-get update).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "notify",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "quiet",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_repository_set",
+    "description": "MUTATION: enable/disable one APT repository entry on a PVE node, by file path + index.",
+    "arguments": [
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "index",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_apt_repository_add",
+    "description": "MUTATION: add a standard repository to the configuration on a PVE node.",
+    "arguments": [
+      {
+        "name": "handle",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup",
+    "description": "MUTATION: back up a guest with vzdump.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "compress",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup_list",
+    "description": "READ-ONLY: list backup archives in a storage.",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup_freshness",
+    "description": "READ-ONLY: backup-freshness fence \u2014 walks ACTUAL backup archives per guest and compares\ntheir age against what enabled backup jobs promise; a job or task reporting OK is never\ntreated as evidence a backup exists. Verdicts per guest: fresh |",
+    "arguments": [
+      {
+        "name": "max_age_hours",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "grace_hours",
+        "type": "number",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup_delete",
+    "description": "MUTATION: delete a backup archive (removes a recovery point).",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "volid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_restore",
+    "description": "MUTATION (DESTRUCTIVE if it overwrites an existing guest): restore a guest from a backup\narchive. Dry-run by default \u2014 the PLAN reads live guest state and states whether it CREATES or\nOVERWRITES. confirm=True to execute. Async \u2014 returns a t",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "archive",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup_job_list",
+    "description": "READ-ONLY: list all PVE cluster backup jobs and guests not covered by any job.",
+    "arguments": []
+  },
+  {
+    "name": "pve_backup_job_create",
+    "description": "MUTATION: create a PVE cluster backup job \u2014 a persistent vzdump schedule, distinct from a\none-off pve_backup run. Dry-run by default; confirm=True to execute and returns synchronously\n(no task UPID). Config-only; existing backups are NOT af",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "compress",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "all_guests",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exclude",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup_job_update",
+    "description": "MUTATION: update a PVE cluster backup job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "compress",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_backup_job_delete",
+    "description": "MUTATION: delete a PVE cluster backup job.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_replication_create",
+    "description": "MUTATION: create a PVE replication job.",
+    "arguments": [
+      {
+        "name": "rep_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_replication_update",
+    "description": "MUTATION: update a PVE replication job.",
+    "arguments": [
+      {
+        "name": "rep_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rate",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_replication_delete",
+    "description": "MUTATION: delete a PVE replication job.",
+    "arguments": [
+      {
+        "name": "rep_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_job_create",
+    "description": "MUTATION: create a PBS scheduled job.",
+    "arguments": [
+      {
+        "name": "job_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "store",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_job_update",
+    "description": "MUTATION: update a PBS scheduled job.",
+    "arguments": [
+      {
+        "name": "job_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "schedule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_job_delete",
+    "description": "MUTATION: delete a PBS scheduled job.",
+    "arguments": [
+      {
+        "name": "job_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_job_run",
+    "description": "MUTATION: trigger a PBS scheduled job immediately, outside its normal schedule.",
+    "arguments": [
+      {
+        "name": "job_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pbs_realm_sync",
+    "description": "MUTATION: sync PBS auth realm (LDAP/AD) users into PBS.",
+    "arguments": [
+      {
+        "name": "realm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remove_vanished",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_status",
+    "description": "READ-ONLY: cluster-wide Ceph health/status.",
+    "arguments": []
+  },
+  {
+    "name": "pve_ceph_metadata",
+    "description": "READ-ONLY: per-daemon Ceph metadata (mon/mgr/mds/osd/node), keyed by instance.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_flags_list",
+    "description": "READ-ONLY: status of all 11 Ceph cluster flags (nobackfill, nodeep-scrub, nodown, noin,\nnoout, norebalance, norecover, noscrub, notieragent, noup, pause).\n\nGET /cluster/ceph/flags. Smoke-confirm: shape not live-verified \u2014 expected\n[{name, v",
+    "arguments": []
+  },
+  {
+    "name": "pve_ceph_flag_get",
+    "description": "READ-ONLY: current value of one Ceph cluster flag.",
+    "arguments": [
+      {
+        "name": "flag",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_cfg_db",
+    "description": "READ-ONLY: the Ceph configuration database (mon config-db entries).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_cfg_raw",
+    "description": "READ-ONLY: the raw ceph.conf file content for a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_cfg_value",
+    "description": "READ-ONLY: configured values for specific ceph.conf / mon-config-db keys.",
+    "arguments": [
+      {
+        "name": "config_keys",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_crush",
+    "description": "READ-ONLY: the OSD CRUSH map, decompiled to text.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_log",
+    "description": "READ-ONLY: Ceph log lines from a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_rules",
+    "description": "READ-ONLY: list configured Ceph CRUSH rules (names only).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_cmd_safety",
+    "description": "READ-ONLY: Ceph's own heuristic advisory on whether it is currently safe to stop or\ndestroy a mon/mds/osd instance. ADVISORY ONLY \u2014 never a gate: a plan citing this result must\nstill render when Ceph itself is unreachable/unhealthy (an unre",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "service_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mon_list",
+    "description": "READ-ONLY: Ceph monitors known to this node's view of the monmap.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mgr_list",
+    "description": "READ-ONLY: Ceph managers known to this node's view of the mgrmap.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mds_list",
+    "description": "READ-ONLY: Ceph metadata servers known to this node's view of the MDS map.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_flags_set",
+    "description": "MUTATION: set/unset multiple Ceph cluster flags at once (bulk).",
+    "arguments": [
+      {
+        "name": "nobackfill",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "nodeep_scrub",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "nodown",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "noin",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "noout",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "norebalance",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "norecover",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "noscrub",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "notieragent",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "noup",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pause",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_flag_set",
+    "description": "MUTATION: set or clear a single Ceph cluster flag.",
+    "arguments": [
+      {
+        "name": "flag",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mon_create",
+    "description": "MUTATION: create a Ceph Monitor.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "monid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mon_address",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mon_destroy",
+    "description": "MUTATION: destroy a Ceph Monitor.",
+    "arguments": [
+      {
+        "name": "monid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mgr_create",
+    "description": "MUTATION: create a Ceph Manager.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mgr_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mgr_destroy",
+    "description": "MUTATION: destroy a Ceph Manager.",
+    "arguments": [
+      {
+        "name": "mgr_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mds_create",
+    "description": "MUTATION: create a Ceph Metadata Server (MDS).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hotstandby",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_mds_destroy",
+    "description": "MUTATION: destroy a Ceph Metadata Server.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_init",
+    "description": "MUTATION: create the initial Ceph default configuration and set up symlinks on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cluster_network",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable_cephx",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "min_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "network",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pg_bits",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_service_start",
+    "description": "MUTATION: start Ceph service(s) (systemd unit(s) matching `service`).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_service_stop",
+    "description": "MUTATION: stop Ceph service(s) (systemd unit(s) matching `service`).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_service_restart",
+    "description": "MUTATION: restart Ceph service(s) (systemd unit(s) matching `service`).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_tree",
+    "description": "READ-ONLY: the Ceph OSD list/tree \u2014 a nested CRUSH bucket structure (root -> children ->\n... -> OSD leaves). ADVERSARIAL (taint.ADVERSARIAL_TOOLS): per-node properties (status/\nweight/in/usage/latencies/...) are daemon-self-reported and the",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_lv_info",
+    "description": "READ-ONLY: an OSD's logical-volume details (LVM-reported via `lvs`, on the SAME host\nadministering this OSD). REVIEWED_TRUSTED (argued, not asserted \u2014 see ceph.py module\ndocstring's Taint section): closed schema shape (no additionalProperti",
+    "arguments": [
+      {
+        "name": "osdid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lv_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_metadata",
+    "description": "READ-ONLY: per-OSD details (devices[] + an osd{} identity/address block).",
+    "arguments": [
+      {
+        "name": "osdid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_create",
+    "description": "MUTATION: create a new Ceph OSD, consuming and REFORMATTING `dev` as BlueStore storage.",
+    "arguments": [
+      {
+        "name": "dev",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "crush_device_class",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "db_dev",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "db_dev_size",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "wal_dev",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "wal_dev_size",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "encrypted",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "osds_per_device",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_destroy",
+    "description": "MUTATION: destroy a Ceph OSD.",
+    "arguments": [
+      {
+        "name": "osdid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cleanup",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_in",
+    "description": "MUTATION: mark a Ceph OSD 'in' \u2014 rejoins the CRUSH acting set; data rebalances BACK onto\nit.\n\nRISK_MEDIUM. No upstream cmd-safety check exists for the 'in' action (cmd-safety's action\nenum is {stop, destroy} only). CAPTURE-or-declare: reads",
+    "arguments": [
+      {
+        "name": "osdid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_out",
+    "description": "MUTATION: mark a Ceph OSD 'out' \u2014 excluded from the CRUSH acting set; triggers data\nrebalance/recovery AWAY from it.\n\nRISK_MEDIUM. No upstream cmd-safety check exists for the 'out' action (cmd-safety's action\nenum is {stop, destroy} only \u2014 ",
+    "arguments": [
+      {
+        "name": "osdid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_osd_scrub",
+    "description": "MUTATION: instruct a Ceph OSD to scrub.",
+    "arguments": [
+      {
+        "name": "osdid",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "deep",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_pool_list",
+    "description": "READ-ONLY: all Ceph pools + their current settings.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_pool_status",
+    "description": "READ-ONLY: one pool's current settings (+ usage/IO statistics when verbose=True).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_fs_list",
+    "description": "READ-ONLY: configured CephFS filesystems.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_pool_create",
+    "description": "MUTATION: create a Ceph pool.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "add_storages",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "application",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "crush_rule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "erasure_coding",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "min_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "pg_autoscale_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pg_num",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "pg_num_min",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "target_size",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_size_ratio",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_pool_set",
+    "description": "MUTATION: change an existing Ceph pool's settings.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "application",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "crush_rule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "min_size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "pg_autoscale_mode",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pg_num",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "pg_num_min",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "size",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "target_size",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_size_ratio",
+        "type": "number",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_pool_destroy",
+    "description": "MUTATION: destroy a Ceph pool.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "remove_ecprofile",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "remove_storages",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_fs_create",
+    "description": "MUTATION: create a Ceph filesystem (CephFS).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "add_storage",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pg_num",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ceph_fs_destroy",
+    "description": "MUTATION: destroy a Ceph filesystem.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "remove_pools",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "remove_storages",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_account_create",
+    "description": "MUTATION: register a new ACME account with the CA.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "tos_url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "directory",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_account_update",
+    "description": "MUTATION: update ACME account contact info.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "contact",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_account_delete",
+    "description": "MUTATION: IRREVERSIBLE \u2014 deactivate and delete an ACME account from the CA.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_plugin_create",
+    "description": "MUTATION: create an ACME DNS challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "plugin_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_api",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_plugin_update",
+    "description": "MUTATION: update an ACME DNS challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_api",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_plugin_delete",
+    "description": "MUTATION: delete an ACME DNS challenge plugin.",
+    "arguments": [
+      {
+        "name": "plugin_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_acme_domains_set",
+    "description": "MUTATION: set a node's ACME account + domains (PUT /nodes/{node}/config).",
+    "arguments": [
+      {
+        "name": "account",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "domains",
+        "type": "array",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "plugin",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_cert_order",
+    "description": "MUTATION: order a NEW ACME TLS certificate for the node's configured ACME domains.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_cert_renew",
+    "description": "MUTATION: renew the node's existing ACME TLS certificate.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_acme_cert_revoke",
+    "description": "MUTATION: IRREVERSIBLE \u2014 revoke the node's ACME TLS certificate at the CA.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_cluster_status",
+    "description": "Retrieve the cluster's overall status: nodes, quorum state, and the corosync\nconfig version (read-only). Returns a list of status dicts with node names, types, online\nstatus, and quorum info. Use pve_cluster_resources to list all resources ",
+    "arguments": []
+  },
+  {
+    "name": "pve_cluster_resources",
+    "description": "READ-ONLY: list all resources across the cluster (VMs, nodes, storage, SDN).",
+    "arguments": [
+      {
+        "name": "resource_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fields",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ha_groups_list",
+    "description": "READ-ONLY: list all HA resource groups.",
+    "arguments": []
+  },
+  {
+    "name": "pve_ha_rules_list",
+    "description": "READ-ONLY: list High-Availability rules on the cluster (PVE 9+).",
+    "arguments": []
+  },
+  {
+    "name": "pve_ha_resources_list",
+    "description": "List all guests managed by HA (High Availability) with their current HA settings\n(read-only). Returns a list of HA resource dicts with SID, type, state, group, and restart\nsettings. Use pve_ha_groups_list or pve_ha_rules_list to view HA pla",
+    "arguments": []
+  },
+  {
+    "name": "pve_guest_migrate",
+    "description": "MUTATION: migrate a guest to a different node.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "online",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ha_resource_add",
+    "description": "MUTATION: add a guest to HA management.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "group",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "state",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "max_restart",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "max_relocate",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ha_resource_remove",
+    "description": "MUTATION: remove a guest from HA management.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ha_rule_create",
+    "description": "MUTATION: create an HA rule (the PVE 9 replacement for HA groups).",
+    "arguments": [
+      {
+        "name": "rule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rule_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "resources",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "strict",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "affinity",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ha_rule_update",
+    "description": "MUTATION: update an HA rule.",
+    "arguments": [
+      {
+        "name": "rule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "resources",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rule_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "strict",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "affinity",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_ha_rule_delete",
+    "description": "MUTATION: delete an HA rule.",
+    "arguments": [
+      {
+        "name": "rule",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_tasks_list",
+    "description": "READ-ONLY: list recent tasks on a node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "errors",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "typefilter",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "statusfilter",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_task_log",
+    "description": "Retrieve a task's log output by UPID (read-only).",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "start",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_task_wait",
+    "description": "Block until an async Proxmox task reaches a terminal state \u2014 or the timeout \u2014 then report the\noutcome (read). The ergonomic complement to the submit-an-async-op tools (migrate / backup /\nrestore / clone / rollback / snapshot + guest create)",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeout",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "interval",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_pools_list",
+    "description": "List all resource pools defined cluster-wide (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_pool_get",
+    "description": "Retrieve a single resource pool's configuration and complete member list by pool ID\n(read-only). Returns the pool's config including all VMs and storage resources assigned.\nUse pve_pools_list to enumerate all pools.",
+    "arguments": [
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_task_stop",
+    "description": "MUTATION (HIGH): stop (cancel) a running task.",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_pool_create",
+    "description": "MUTATION: create an (empty) resource pool.",
+    "arguments": [
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_pool_update",
+    "description": "MUTATION: add (delete=False) or remove (delete=True) pool members.",
+    "arguments": [
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_pool_delete",
+    "description": "MUTATION: delete a resource pool.",
+    "arguments": [
+      {
+        "name": "poolid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_config_list",
+    "description": "READ-ONLY: list all storage definitions from storage.cfg cluster-wide.",
+    "arguments": []
+  },
+  {
+    "name": "pve_storage_config_get",
+    "description": "Retrieve a single storage definition from storage.cfg by storage ID (read-only).",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_create",
+    "description": "MUTATION: define a new cluster storage entry in storage.cfg (dir / nfs / pbs / cifs / \u2026).",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "path",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "export",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "shared",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_update",
+    "description": "MUTATION: update a storage definition.",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "nodes",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "shared",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_delete",
+    "description": "MUTATION (HIGH): remove a storage definition cluster-wide.",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_rules_list",
+    "description": "List firewall rules for the given scope (cluster, node, or guest) (read-only).",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_options_get",
+    "description": "READ-ONLY: get the firewall option block (enable flag, default in/out policy, log rate limit,\n\u2026) at cluster, node, or guest scope.\n\nNo state change. Pair with pve_firewall_options_set to change these, and pve_firewall_rules_list\nto read the",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_security_groups_list",
+    "description": "List the cluster's firewall security groups (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_ipset_list",
+    "description": "READ-ONLY: list IP sets for the given scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_rule_add",
+    "description": "MUTATION: add a new firewall rule.",
+    "arguments": [
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_rule_remove",
+    "description": "MUTATION: delete a firewall rule by position.",
+    "arguments": [
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_rule_update",
+    "description": "MUTATION: update an existing firewall rule at position `pos`.",
+    "arguments": [
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "direction",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_set_enabled",
+    "description": "MUTATION (HIGH RISK): toggle the firewall on or off for the given scope.",
+    "arguments": [
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_alias_list",
+    "description": "READ-ONLY: list firewall aliases (named CIDRs) for the given scope.",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_alias_create",
+    "description": "MUTATION: create a firewall alias (named CIDR).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_alias_update",
+    "description": "MUTATION: update a firewall alias.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "rename",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_alias_delete",
+    "description": "MUTATION: delete a firewall alias.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_ipset_create",
+    "description": "MUTATION: create an empty IP set.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_ipset_delete",
+    "description": "MUTATION: delete an IP set.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_ipset_entry_add",
+    "description": "MUTATION: add an IP/Network entry to an IP set.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "nomatch",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_ipset_entry_remove",
+    "description": "MUTATION: remove an IP/Network entry from an IP set.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cidr",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_security_group_create",
+    "description": "MUTATION: create an empty cluster security group.",
+    "arguments": [
+      {
+        "name": "group",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_security_group_delete",
+    "description": "MUTATION: delete a cluster security group.",
+    "arguments": [
+      {
+        "name": "group",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_firewall_options_set",
+    "description": "MUTATION: set firewall options for a scope (policy_in/out, log levels, ebtables, log_ratelimit,\n...). `options` is a key->value bag; `delete` unsets keys. Dry-run by default \u2014 the PLAN shows the\ncurrent values and flags lockout risk. RISK_H",
+    "arguments": [
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_status",
+    "description": "READ-ONLY: read Proxmox node health and resource status.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_list_guests",
+    "description": "READ-ONLY: list all VMs and LXC containers on a node with their current state.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fields",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_guest_status",
+    "description": "Read the operational status and current configuration of a single guest (kind='lxc' or\n'qemu') (read-only). Returns the guest's runtime state and resource utilization\n(CPU/memory/disk/network/uptime) \u2014 operational metrics, not its stored co",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_guest_power",
+    "description": "MUTATION: start/stop/reboot/shutdown a guest.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_snapshot_list",
+    "description": "List a guest's snapshots (read-only).",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_snapshot_create",
+    "description": "MUTATION: create a snapshot (a restore point).",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_rollback",
+    "description": "MUTATION (DESTRUCTIVE): roll a guest back to a snapshot \u2014 discards ALL changes since it.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_snapshot_delete",
+    "description": "MUTATION: delete a snapshot (removes a restore point) \u2014 you can't roll back to it afterward.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "snapname",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_task_status",
+    "description": "READ-ONLY: get an async Proxmox task's status by its UPID \u2014 running vs stopped, plus the\nexit status once it has finished.\n\nNo state change. Use it to poll long-running ops (migrate, snapshot, rollback, backup) that\nreturn a UPID. Returns a",
+    "arguments": [
+      {
+        "name": "upid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ct_logs",
+    "description": "READ-ONLY: tail journalctl for a systemd unit inside a container.",
+    "arguments": [
+      {
+        "name": "ctid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "unit",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lines",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ct_diagnose",
+    "description": "READ-ONLY: gather 'what's broken' evidence for a container \u2014 API status + a fixed read-only\nin-container battery (failed units, disk, recent errors, memory, listening ports) + advisory flags.\n\nNo mutation, no confirm. Returns a dict with th",
+    "arguments": [
+      {
+        "name": "ctid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_diagnose",
+    "description": "READ-ONLY: gather one node's health evidence in a single call \u2014 node status, storage usage,\nrecent failed tasks, and advisory flags \u2014 for triage.\n\nNo state change and no side effects. This inspects *node* health; to instead verify your toke",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_doctor",
+    "description": "READ-ONLY preflight: check API connectivity + the calling token's effective permissions, and\nreport what this token CAN and CANNOT do \u2014 with the privilege + role to grant for each gap. Run\nthis FIRST after install to verify your config/toke",
+    "arguments": []
+  },
+  {
+    "name": "pve_create_container",
+    "description": "MUTATION: create a new LXC container.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ostemplate",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_create_vm",
+    "description": "MUTATION: create a new QEMU VM.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_clone",
+    "description": "MUTATION: clone a guest to a new id.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "newid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "full",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pool",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_delete_guest",
+    "description": "MUTATION (DESTRUCTIVE, IRREVERSIBLE): permanently destroy a guest and its disks.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "purge",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_content",
+    "description": "READ-ONLY: list the volumes a storage holds \u2014 ISO images, container templates, backups, disks.",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_status",
+    "description": "Read a storage backend's capacity and state (read-only).",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_download",
+    "description": "MUTATION: download an ISO (content=iso) or CT template (content=vztmpl) from a URL into a\nstorage. Dry-run by default; confirm=True. Async \u2014 returns a UPID (poll with pve_task_status).\nThe URL and its content are operator-trusted \u2014 Proximo ",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "content",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "filename",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "checksum",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "checksum_algorithm",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_storage_content_delete",
+    "description": "MUTATION: delete a content volume (ISO / template / backup / disk image) from storage.",
+    "arguments": [
+      {
+        "name": "storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "volid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_guest_config_get",
+    "description": "READ-ONLY: read a guest's current configuration (kind='lxc' or 'qemu').",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_guest_config_set",
+    "description": "MUTATION: edit a guest's config (cores/memory/net/onboot/...).",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "changes",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_guest_config_revert",
+    "description": "MUTATION (UNDO): re-apply a previously captured guest config (the prior_config returned by\npve_guest_config_set). Dry-run by default; confirm=True to execute. Synchronous \u2014 returns\n{reverted_to_keys, deleted, skipped_unsettable}; computed/r",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prior_config",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_disk_resize",
+    "description": "MUTATION: grow a guest disk (e.g.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "size",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_disk_move",
+    "description": "MUTATION: move a guest disk to another storage.",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "target_storage",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete_source",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_cloudinit_get",
+    "description": "Read a QEMU guest's cloud-init configuration (read-only).",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_cloudinit_set",
+    "description": "MUTATION: set cloud-init fields (ciuser/sshkeys/ipconfigN/...) on a QEMU guest \u2014 kind='lxc'\nis refused (cloud-init is QEMU-only). Dry-run by default with secrets masked in the PLAN;\nconfirm=True to execute. Synchronous; the return carries a",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "changes",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_template_convert",
+    "description": "MUTATION (IRREVERSIBLE): convert a guest into a template \u2014 effectively one-way; kind='lxc'\nis refused (this endpoint is QEMU-only \u2014 LXC uses a separate, out-of-scope template endpoint).\nDry-run by default (the PLAN flags it HIGH/irreversibl",
+    "arguments": [
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_network_list",
+    "description": "READ-ONLY: list network interfaces (bridges/bonds/VLANs/etc) on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zones_list",
+    "description": "List SDN zones in the cluster (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_sdn_vnets_list",
+    "description": "List SDN vnets in the cluster (read-only).",
+    "arguments": []
+  },
+  {
+    "name": "pve_sdn_zone_get",
+    "description": "READ-ONLY: read one SDN zone's configuration (closes the pre-Wave-7a gap \u2014 only the\nzones LIST existed before). Use pve_sdn_zones_list to enumerate zone ids first.",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_get",
+    "description": "READ-ONLY: read one SDN vnet's configuration (closes the pre-Wave-7a gap \u2014 only the\nvnets LIST existed before). Use pve_sdn_vnets_list to enumerate vnet names first.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_subnet_get",
+    "description": "READ-ONLY: read one SDN subnet's configuration (closes the pre-Wave-7a gap \u2014 only the\nsubnets LIST existed before). Use pve_sdn_subnet_list to enumerate subnet ids first.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_dry_run",
+    "description": "READ-ONLY: preview what pve_sdn_apply would change \u2014 PVE's own rendered diff between the\nCURRENT and PENDING SDN configuration ({frr-diff?, interfaces-diff?}, either may be absent).\n\n`node` is required by PVE even though SDN config is clust",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_status_list",
+    "description": "READ-ONLY: get the per-zone APPLY status (available/pending/error) on one node \u2014\nnode-scoped, distinct from pve_sdn_zones_list (which lists CONFIG, not per-node status).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_bridges",
+    "description": "READ-ONLY: list the bridges (vnets) that are part of a zone on one node, with their\nmember ports (name, vmid/index for guest-attached ports, VLAN info on VLAN-aware bridges).",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_content",
+    "description": "READ-ONLY: list the vnets inside a zone with their per-vnet apply status on one node\n({vnet, status?, statusmsg?}).",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_ip_vrf",
+    "description": "READ-ONLY: get the IP VRF routing table of an EVPN zone on one node (CIDR + nexthops +\nprotocol per entry). ADVERSARIAL: nexthops are peer-announced over the running routing\nprotocol \u2014 a compromised BGP/EVPN peer controls these bytes.",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_mac_vrf",
+    "description": "READ-ONLY: get the MAC VRF of a VNet in an EVPN zone on one node (ip/mac/nexthop per\nentry). ADVERSARIAL: schema states this \"self-originates or has learned via BGP\" \u2014 a\ngenuinely mixed local/wire-learned channel.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_subnet_list",
+    "description": "READ-ONLY: list the subnets configured in a vnet.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_create",
+    "description": "MUTATION: create an SDN zone (PENDING \u2014 inert until pve_sdn_apply, NOT applied here).",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "zone_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_update",
+    "description": "MUTATION: update an SDN zone (PENDING).",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_zone_delete",
+    "description": "MUTATION: delete an SDN zone (PENDING).",
+    "arguments": [
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_create",
+    "description": "MUTATION: create an SDN vnet in a zone (PENDING).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_update",
+    "description": "MUTATION: update an SDN vnet (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_delete",
+    "description": "MUTATION: delete an SDN vnet (PENDING).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_subnet_create",
+    "description": "MUTATION: create an SDN subnet (PENDING).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_subnet_update",
+    "description": "MUTATION: update an SDN subnet (PENDING).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_subnet_delete",
+    "description": "MUTATION: delete an SDN subnet (PENDING).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "subnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_network_iface_create",
+    "description": "MUTATION: create a new network interface config (staged \u2014 not live until pve_network_apply).",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_network_iface_update",
+    "description": "MUTATION: update an existing network interface config (staged \u2014 not live until pve_network_apply).",
+    "arguments": [
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_network_apply",
+    "description": "MUTATION (HIGH RISK): apply staged network config changes to the live network stack.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_apply",
+    "description": "MUTATION (HIGH RISK): apply pending SDN config changes (cluster-scoped).",
+    "arguments": [
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "release_lock",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_lock_acquire",
+    "description": "MUTATION: acquire the global SDN configuration lock (RISK_MEDIUM).",
+    "arguments": [
+      {
+        "name": "allow_pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_lock_release",
+    "description": "MUTATION: release the global SDN configuration lock.",
+    "arguments": [
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_rollback",
+    "description": "MUTATION: discard ALL pending SDN configuration changes cluster-wide \u2014 the plane's REAL\nundo primitive (RISK_MEDIUM).\n\nBounded to the CONFIG plane only: never touches LIVE networking (that's pve_sdn_apply's job)\n\u2014 discards every staged zone",
+    "arguments": [
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "release_lock",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_disks_list",
+    "description": "READ-ONLY: list physical disks on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_disk_smart",
+    "description": "READ-ONLY: get SMART health data for one disk on a PVE node.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_disk_wipe",
+    "description": "MUTATION: wipe ALL data and the partition table on a node disk.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_disk_initgpt",
+    "description": "MUTATION: initialize a GPT partition table on a node disk.",
+    "arguments": [
+      {
+        "name": "disk",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_storage_backend_list",
+    "description": "READ-ONLY: list storage backends of a type on a PVE node.",
+    "arguments": [
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_storage_backend_create",
+    "description": "MUTATION: create a storage backend on the node (lvm/lvmthin/zfs/directory).",
+    "arguments": [
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "devices",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "kw",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_storage_backend_delete",
+    "description": "MUTATION: destroy a storage backend on the node.",
+    "arguments": [
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cleanup",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_time_get",
+    "description": "READ-ONLY: get the current time and timezone of a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_hosts_get",
+    "description": "READ-ONLY: get the /etc/hosts content of a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_time_set",
+    "description": "MUTATION: set the timezone on a PVE node.",
+    "arguments": [
+      {
+        "name": "timezone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_hosts_set",
+    "description": "MUTATION: replace the /etc/hosts file on a PVE node.",
+    "arguments": [
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_dns_set",
+    "description": "MUTATION: update DNS resolver configuration on a PVE node.",
+    "arguments": [
+      {
+        "name": "search",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns1",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns2",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns3",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_cert_upload",
+    "description": "MUTATION: upload a custom TLS certificate to a PVE node.",
+    "arguments": [
+      {
+        "name": "certificates",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "force",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "restart",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_cert_delete",
+    "description": "MUTATION: delete the custom TLS certificate from a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "restart",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_startall",
+    "description": "MUTATION: start all (or filtered) guests on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_stopall",
+    "description": "MUTATION: stop ALL (or filtered) running guests on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_migrateall",
+    "description": "MUTATION: migrate all (or filtered) guests from a node to a target node.",
+    "arguments": [
+      {
+        "name": "target",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vms",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "maxworkers",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_services_list",
+    "description": "READ-ONLY: list all services on a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_service_status",
+    "description": "READ-ONLY: get one systemd service's current state on a PVE node (e.g.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_rrddata",
+    "description": "READ-ONLY: fetch RRD (round-robin database) time-series telemetry for a PVE node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "timeframe",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cf",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_journal",
+    "description": "READ-ONLY: fetch systemd journal lines from a PVE node for log inspection.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lastentries",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "since",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "until",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_syslog",
+    "description": "READ-ONLY: fetch syslog entries from a PVE node for log inspection.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_dns",
+    "description": "Read a Proxmox node's DNS configuration (read-only).",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_subscription",
+    "description": "READ-ONLY: read a Proxmox node's subscription status.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_certificates",
+    "description": "READ-ONLY: list TLS certificates configured on a Proxmox node.",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_node_service_control",
+    "description": "MUTATION: start/stop/restart/reload a service on a PVE node.",
+    "arguments": [
+      {
+        "name": "service",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_notification_endpoint_list",
+    "description": "READ-ONLY: list all PVE notification endpoints.",
+    "arguments": []
+  },
+  {
+    "name": "pve_notification_endpoint_create",
+    "description": "MUTATION: create a PVE notification endpoint.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_notification_endpoint_update",
+    "description": "MUTATION: update a PVE notification endpoint.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_notification_endpoint_delete",
+    "description": "MUTATION: delete a PVE notification endpoint.",
+    "arguments": [
+      {
+        "name": "ep_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_notification_matcher_set",
+    "description": "MUTATION: create-or-update a PVE notification matcher (alert routing rule).",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_notification_matcher_delete",
+    "description": "MUTATION: delete a PVE notification matcher.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_notification_test",
+    "description": "MUTATION: send a test notification to a PVE notification target.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_metrics_server_list",
+    "description": "READ-ONLY: list all PVE metrics server definitions.",
+    "arguments": []
+  },
+  {
+    "name": "pve_metrics_server_set",
+    "description": "MUTATION: create-or-update a PVE metrics server definition.",
+    "arguments": [
+      {
+        "name": "metrics_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "metrics_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "server",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "port",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "disable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_metrics_server_delete",
+    "description": "MUTATION: delete a PVE metrics server definition.",
+    "arguments": [
+      {
+        "name": "metrics_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_hardware_list",
+    "description": "READ-ONLY: list physical PCI or USB devices attached to a PVE node\n(hw_type: 'pci' default or 'usb').\n\nNo state change. Returns {\"devices\": [...]} \u2014 the node's raw hardware inventory,\ndistinct from the cluster-scope passthrough mappings tha",
+    "arguments": [
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "hw_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_mapping_pci_list",
+    "description": "READ-ONLY: list all PCI device mappings at cluster scope.",
+    "arguments": []
+  },
+  {
+    "name": "pve_mapping_usb_list",
+    "description": "READ-ONLY: list all USB device mappings at cluster scope.",
+    "arguments": []
+  },
+  {
+    "name": "pve_mapping_pci_create",
+    "description": "MUTATION: create a PCI cluster passthrough mapping.",
+    "arguments": [
+      {
+        "name": "mapping_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "map",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_mapping_pci_update",
+    "description": "MUTATION: update a PCI cluster mapping.",
+    "arguments": [
+      {
+        "name": "mapping_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "map",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_mapping_pci_delete",
+    "description": "MUTATION: delete a PCI cluster mapping.",
+    "arguments": [
+      {
+        "name": "mapping_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_mapping_usb_create",
+    "description": "MUTATION: create a USB cluster passthrough mapping.",
+    "arguments": [
+      {
+        "name": "mapping_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "map",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_mapping_usb_update",
+    "description": "MUTATION: update a USB cluster mapping.",
+    "arguments": [
+      {
+        "name": "mapping_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "map",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_mapping_usb_delete",
+    "description": "MUTATION: delete a USB cluster mapping.",
+    "arguments": [
+      {
+        "name": "mapping_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabrics_all",
+    "description": "READ-ONLY: AGGREGATE read \u2014 every SDN fabric's config AND every node across every\nfabric, in ONE call ({fabrics: [...], nodes: [...]}). 100% reconstructable from\npve_sdn_fabrics_list + pve_sdn_fabric_nodes_list_all (2 calls) \u2014 built anyway ",
+    "arguments": [
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabrics_list",
+    "description": "READ-ONLY: list SDN fabrics (cluster-scoped, full objects).",
+    "arguments": [
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_get",
+    "description": "READ-ONLY: read one SDN fabric's configuration.",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_create",
+    "description": "MUTATION: create an SDN fabric (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_update",
+    "description": "MUTATION: update an SDN fabric (PENDING).",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_delete",
+    "description": "MUTATION: delete an SDN fabric (PENDING).",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_nodes_list_all",
+    "description": "READ-ONLY: list EVERY fabric node across EVERY fabric in one call \u2014 NOT scoped to one\nfabric. Use pve_sdn_fabric_nodes_list to scope to one fabric_id.",
+    "arguments": [
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_nodes_list",
+    "description": "READ-ONLY: list the nodes belonging to ONE SDN fabric.",
+    "arguments": [
+      {
+        "name": "fabric_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_node_get",
+    "description": "READ-ONLY: read a single fabric node's configuration.",
+    "arguments": [
+      {
+        "name": "fabric_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_node_create",
+    "description": "MUTATION: add a node to an SDN fabric (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "fabric_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_node_update",
+    "description": "MUTATION: update a fabric node (PENDING).",
+    "arguments": [
+      {
+        "name": "fabric_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "protocol",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_node_delete",
+    "description": "MUTATION: remove a node from an SDN fabric (PENDING).",
+    "arguments": [
+      {
+        "name": "fabric_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_status_interfaces",
+    "description": "READ-ONLY: get all interfaces for a fabric on one node (name/state/type \u2014 the fabric's\nOWN locally-rendered network interfaces, not peer-controlled).",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_status_neighbors",
+    "description": "READ-ONLY: get all neighbors for a fabric on one node \u2014 neighbor/status/uptime, all\nself-announced by the remote peer as reported by FRR. Wire-learned content: a\ncompromised/malicious peer controls these bytes.",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_fabric_status_routes",
+    "description": "READ-ONLY: get all routes for a fabric on one node \u2014 route (CIDR) + via (nexthop\nlist). The nexthops are wire-learned content: injected by whatever peer announces them\nover the running routing protocol.",
+    "arguments": [
+      {
+        "name": "fabric",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "node",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_options_get",
+    "description": "READ-ONLY: get vnet firewall options (enable, log_level_forward, policy_forward).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_rules_list",
+    "description": "READ-ONLY: list vnet firewall rules, in ruleset order (position 0 first).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_rule_get",
+    "description": "READ-ONLY: get one vnet firewall rule by position.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_options_set",
+    "description": "MUTATION (LIVE/IMMEDIATE): set vnet firewall options.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_rule_add",
+    "description": "MUTATION (LIVE/IMMEDIATE): add a new vnet firewall rule.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fw_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "icmp_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "log",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_rule_update",
+    "description": "MUTATION (LIVE/IMMEDIATE): update a vnet firewall rule at position `pos`.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fw_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "proto",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "icmp_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "iface",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "log",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "macro",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enable",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "moveto",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_firewall_rule_remove",
+    "description": "MUTATION (LIVE/IMMEDIATE): delete a vnet firewall rule by position.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pos",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_ip_create",
+    "description": "MUTATION: create an IP-to-MAC mapping in a vnet (IPAM record).",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mac",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_ip_update",
+    "description": "MUTATION: update an IP-to-MAC mapping in a vnet.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mac",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "vmid",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_vnet_ip_delete",
+    "description": "MUTATION: delete an IP-to-MAC mapping from a vnet.",
+    "arguments": [
+      {
+        "name": "vnet",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "zone",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ip",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "mac",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_controllers_list",
+    "description": "READ-ONLY: list SDN controllers (cluster-scoped).",
+    "arguments": [
+      {
+        "name": "controller_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_controller_get",
+    "description": "READ-ONLY: read one SDN controller's configuration.",
+    "arguments": [
+      {
+        "name": "controller",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_controller_create",
+    "description": "MUTATION: create an SDN controller (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "controller",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "controller_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_controller_update",
+    "description": "MUTATION: update an SDN controller (PENDING).",
+    "arguments": [
+      {
+        "name": "controller",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_controller_delete",
+    "description": "MUTATION: delete an SDN controller (PENDING).",
+    "arguments": [
+      {
+        "name": "controller",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_dns_list",
+    "description": "READ-ONLY: list SDN dns integrations (cluster-scoped).",
+    "arguments": [
+      {
+        "name": "dns_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_dns_get",
+    "description": "READ-ONLY: read one SDN dns integration's configuration.",
+    "arguments": [
+      {
+        "name": "dns",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_dns_create",
+    "description": "MUTATION: create an SDN dns integration (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "dns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "dns_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "reversemaskv6",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "reversev6mask",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "dns_ttl",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_dns_update",
+    "description": "MUTATION: update an SDN dns integration (PENDING).",
+    "arguments": [
+      {
+        "name": "dns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "reversemaskv6",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "dns_ttl",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_dns_delete",
+    "description": "MUTATION: delete an SDN dns integration (PENDING).",
+    "arguments": [
+      {
+        "name": "dns",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_ipams_list",
+    "description": "READ-ONLY: list SDN ipam integrations (cluster-scoped).",
+    "arguments": [
+      {
+        "name": "ipam_type",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_ipam_get",
+    "description": "READ-ONLY: read one SDN ipam integration's configuration.",
+    "arguments": [
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_ipam_status",
+    "description": "READ-ONLY, ADVERSARIAL: list the guest IP/MAC/hostname address entries a PVE-managed\nipam is currently tracking.\n\nThe schema gives ZERO item-shape documentation for this endpoint (bare array, no `items`\nkey at all \u2014 the most undocumented re",
+    "arguments": [
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_ipam_create",
+    "description": "MUTATION: create an SDN ipam integration (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ipam_type",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "section",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_ipam_update",
+    "description": "MUTATION: update an SDN ipam integration (PENDING).",
+    "arguments": [
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "section",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "fingerprint",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_ipam_delete",
+    "description": "MUTATION: delete an SDN ipam integration (PENDING).",
+    "arguments": [
+      {
+        "name": "ipam",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_lists_list",
+    "description": "READ-ONLY: list SDN prefix lists (cluster-scoped).",
+    "arguments": [
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "verbose",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_get",
+    "description": "READ-ONLY: read one SDN prefix list's configuration (including its entries).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_create",
+    "description": "MUTATION: create an SDN prefix list (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "entries",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_update",
+    "description": "MUTATION: update an SDN prefix list (PENDING).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "entries",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_delete",
+    "description": "MUTATION: delete an SDN prefix list (PENDING).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_entries_list",
+    "description": "READ-ONLY: list a prefix list's entries.",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_entry_get",
+    "description": "READ-ONLY: read a single prefix-list entry.",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "entry_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_entry_create",
+    "description": "MUTATION: create a prefix-list entry (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prefix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ge",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "le",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "seq",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_entry_update",
+    "description": "MUTATION: update a prefix-list entry (PENDING).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "entry_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "prefix",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "ge",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "le",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "seq",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_prefix_list_entry_delete",
+    "description": "MUTATION: delete a prefix-list entry (PENDING).",
+    "arguments": [
+      {
+        "name": "prefix_list",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "entry_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_maps_list",
+    "description": "READ-ONLY: list SDN route maps (cluster-scoped, id-only summaries).",
+    "arguments": [
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_map_entries_list_all",
+    "description": "READ-ONLY: list EVERY route-map entry across ALL route-maps in one call.",
+    "arguments": [
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_map_entries_list",
+    "description": "READ-ONLY: list every entry belonging to ONE route map.",
+    "arguments": [
+      {
+        "name": "route_map_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "pending",
+        "type": "boolean",
+        "desc": ""
+      },
+      {
+        "name": "running",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_map_entry_get",
+    "description": "READ-ONLY: read a single route-map entry by its (route_map_id, order) pair.",
+    "arguments": [
+      {
+        "name": "route_map_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "order",
+        "type": "integer",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_map_entry_create",
+    "description": "MUTATION: create a route-map entry (PENDING \u2014 inert until pve_sdn_apply).",
+    "arguments": [
+      {
+        "name": "route_map_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "order",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "match",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "set_clauses",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exit_action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "call",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_map_entry_update",
+    "description": "MUTATION: update a route-map entry (PENDING).",
+    "arguments": [
+      {
+        "name": "route_map_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "order",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "match",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "set_clauses",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "exit_action",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "call",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "delete",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "digest",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "pve_sdn_route_map_entry_delete",
+    "description": "MUTATION: delete a route-map entry (PENDING).",
+    "arguments": [
+      {
+        "name": "route_map_id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "order",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "lock_token",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "confirm",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "proximo_wiki",
+    "description": "READ-ONLY: search the LOCAL Proxmox documentation index \u2014 NOT a live fetch and NOT the\nlive estate. Returns a counted envelope {matched, returned, hits} where each hit is lean\n(id, title, source, score, snippet) \u2014 call proximo_wiki_read wit",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "k",
+        "type": "integer",
+        "desc": ""
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "proximo_wiki_read",
+    "description": "READ-ONLY: the full text of ONE indexed documentation section, with provenance \u2014 origin\nurl, per-source license, and the {source:'wiki-index', harvested_at, age_days} stamp so the\nanswer can be cited and aged. This is the escalation path fr",
+    "arguments": [
+      {
+        "name": "section_id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds Proximo, an MCP server for all four Proxmox products (Virtual Environment, Backup Server, Mail Gateway, Datacenter Manager) on one audited control plane. Read-only by default; every mutation dry-runs to a PLAN with its blast radius named, and lands in a keyed, tamper-evident audit ledger.

Self-provided pre-built image: `ghcr.io/john-broadway/proximo` (cosign-signed, provenance-attested, multi-arch). Source pinned per the contribution guide.

Notes for review:
- The API token is a file by design (Proximo refuses env-inline secrets and refuses a group/world-readable token file), so config uses a parameterized read-only bind mount, following the accepted arm-mcp entry's pattern.
- `tools.json` is provided because the server needs a configured API URL and token file before it will list tools.
- License: Apache-2.0. Security policy, threat model, and a verification doc (VERIFY.md) are in the repo.