### PR TITLE
Add agent-identity-mcp to Communication

### DIFF
--- a/servers/agent-identity-mcp/server.yaml
+++ b/servers/agent-identity-mcp/server.yaml
@@ -1,0 +1,28 @@
+name: agent-identity-mcp
+image: mcp/agent-identity-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - email
+    - sms
+    - otp
+    - testing
+    - disposable-email
+about:
+  title: agent-identity-mcp
+  description: |
+    Gives an AI agent a disposable email address and a real UK phone number so it can test a
+    signup/verification flow end to end — sign up, then read back the verification email or
+    SMS/OTP itself. Bundles two existing services: receivemail.dev for email, sms-florin for the
+    phone/SMS side (real SIM cards on UK carrier networks, not VoIP).
+  icon: https://www.google.com/s2/favicons?domain=flo-voice1.com&sz=64
+source:
+  project: https://github.com/flovoice53-tech/agent-identity-mcp
+  commit: 98d616d229e4fc8f4a85173a0e04ee187915a78d
+config:
+  description: Configure your sms-florin API key (generate one at https://flo-voice1.com/api-access)
+  secrets:
+    - name: agent-identity-mcp.api_key
+      env: SMS_FLORIN_API_KEY
+      example: <SMS_FLORIN_API_KEY>

--- a/servers/agent-identity-mcp/server.yaml
+++ b/servers/agent-identity-mcp/server.yaml
@@ -16,7 +16,7 @@ about:
     signup/verification flow end to end — sign up, then read back the verification email or
     SMS/OTP itself. Bundles two existing services: receivemail.dev for email, sms-florin for the
     phone/SMS side (real SIM cards on UK carrier networks, not VoIP).
-  icon: https://www.google.com/s2/favicons?domain=flo-voice1.com&sz=64
+  icon: https://flo-voice1.com/icon.png
 source:
   project: https://github.com/flovoice53-tech/agent-identity-mcp
   commit: 98d616d229e4fc8f4a85173a0e04ee187915a78d


### PR DESCRIPTION
Adds `agent-identity-mcp` — an MCP server that gives an AI agent a disposable email address and a real UK phone number so it can test a signup/verification flow end to end.

It bundles two existing, already-working services: receivemail.dev (email) and sms-florin (real UK SIM phone numbers, not VoIP). Published on npm (`agent-identity-mcp`) and on the official Anthropic MCP registry.

Disclosure: I don't have the `task`/Go toolchain locally to run the repo's own validator, so `server.yaml` was hand-written following the schema/format of an already-merged entry (`sms-florin-mcp`, same author) rather than generated.