### PR TITLE
Add Google AI Search MCP server

### DIFF
--- a/servers/google-ai-search/server.yaml
+++ b/servers/google-ai-search/server.yaml
@@ -1,0 +1,28 @@
+name: google-ai-search
+image: mcp/google-ai-search
+type: server
+meta:
+  category: search
+  tags:
+    - gemini
+    - google-ai
+    - search
+    - documentation
+    - developer-tools
+about:
+  title: Google AI Search
+  description: Search the web, retrieve technical documentation, analyze code, compare technologies, and review architecture with Google Gemini.
+  icon: https://avatars.githubusercontent.com/u/196900129?v=4
+source:
+  project: https://github.com/shariqriazz/google-ai-search-mcp
+  commit: d47b6b838898a7745e0cd696c3536c56f2e1ad40
+config:
+  description: Configure the Gemini API connection. The source project also supports Vertex AI, while this catalog entry uses the Gemini API credential path.
+  secrets:
+    - name: google-ai-search.gemini_api_key
+      env: GEMINI_API_KEY
+      example: <GEMINI_API_KEY>
+  env:
+    - name: AI_PROVIDER
+      example: gemini
+      value: gemini


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Google AI Search
**Repository URL:** https://github.com/shariqriazz/google-ai-search-mcp
**Brief Description:** Seven MCP tools for web-grounded technical research, documentation retrieval, code analysis, technology comparisons, project guidance, and architecture review using Google Gemini.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements stdio MCP and returns seven tools
- [x] **Active Development**: Maintained source with a current `1.1.1` release
- [x] **Docker Artifact**: Multi-stage Dockerfile in the source repository
- [x] **Documentation**: README includes npm, local, client, and Docker setup
- [x] **Security Contact**: `SECURITY.md` documents private reporting and supported versions

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I tested the MCP Server using `go run ./cmd/validate --name google-ai-search`
- [x] I built the MCP Server using `go run ./cmd/build --tools google-ai-search`
- [ ] Test credentials were not shared. Image build and MCP tool introspection require no live credential; tool calls require the reviewer's Gemini API key.

## Validation

- registry validator passed all checks
- Docker-built image runs as the non-root `node` user
- packaged and containerized JSON-RPC handshakes both returned version `1.1.1`, seven tools, and protocol-clean stdout
- registry build discovered all seven tools from the commit pinned in `server.yaml`
