### PR TITLE
Add Leteo, local-first persistent memory for coding agents

### DIFF
--- a/servers/leteo/server.yaml
+++ b/servers/leteo/server.yaml
@@ -14,8 +14,8 @@ about:
   icon: https://avatars.githubusercontent.com/u/10619419?v=4
 source:
   project: https://github.com/asanabrial/leteo
-  commit: 68475d300956de6caa6622a57ef8a0ef1c23976b
-  dockerfile: Dockerfile.mcp
+  commit: 14479b46643611eb011e2634da75e6e87033059f
+  dockerfile: docker/Dockerfile.mcp
 run:
   command:
     - --project={{leteo.project}}

--- a/servers/leteo/server.yaml
+++ b/servers/leteo/server.yaml
@@ -1,0 +1,34 @@
+name: leteo
+image: mcp/leteo
+type: server
+meta:
+  category: ai
+  tags:
+    - memory
+    - persistence
+    - sqlite
+    - ai
+about:
+  title: Leteo
+  description: Local-first persistent memory for AI coding agents. Decisions, fixes and conventions are saved as they happen and handed back when they are relevant, from one SQLite database on your machine.
+  icon: https://avatars.githubusercontent.com/u/10619419?v=4
+source:
+  project: https://github.com/asanabrial/leteo
+  commit: 68475d300956de6caa6622a57ef8a0ef1c23976b
+  dockerfile: Dockerfile.mcp
+run:
+  command:
+    - --project={{leteo.project}}
+  volumes:
+    - mcp-leteo:/home/leteo
+  disableNetwork: true
+config:
+  description: Memories are filed under a project. Run natively, Leteo takes that from the directory you are working in; a container cannot see it, so name it here.
+  parameters:
+    type: object
+    properties:
+      project:
+        type: string
+        default: workspace
+    required:
+      - project


### PR DESCRIPTION
[Leteo](https://github.com/asanabrial/leteo) is a single Rust binary over one SQLite database: an MCP server whose tools save decisions, fixes and conventions as an agent works, and hand them back when they are relevant. MIT licensed, no API key, no network.

It is on [crates.io](https://crates.io/crates/leteo) and in the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.asanabrial/leteo`.

## Built from a Dockerfile that exists for exactly this

`source.dockerfile` points at `Dockerfile.mcp` rather than the repository's `Dockerfile`. The sibling builds an HTTP cloud service that never reads stdin — handed that one, a directory's verification starts a server that answers nothing and fails for a reason invisible from the outside. `Dockerfile.mcp` is `ENTRYPOINT ["leteo", "mcp"]` over stdio, and it is built and run by the project's own CI on every pull request.

Built here from the pinned commit exactly as this catalog would:

```
docker build -f Dockerfile.mcp \
  https://github.com/asanabrial/leteo.git#68475d300956de6caa6622a57ef8a0ef1c23976b
```

## Two settings that came from running it, not from reasoning about it

**The volume mounts at `/home/leteo`, one level above the database.** The image runs as an unprivileged user (uid 10001) and `.leteo` does not exist inside it, so a named volume at `/home/leteo/.leteo` is created owned by root:

```
Error: open Leteo store
Caused by: unable to open database file: /home/leteo/.leteo/leteo.db
```

Mounted at `/home/leteo`, a directory the image does own, the database is created, written, and still there on the next run — verified by saving a memory in one container and finding it by search in a second.

**`--project` is configurable because a container cannot see the user's working directory.** Left to detect, the server reads its own:

```json
{"project": "leteo", "project_source": "dir_basename", "cwd": "/home/leteo"}
```

Every memory would be filed under a project named after the tool rather than after the work. With the parameter it reports `"project_source": "process_override"` and files where the user said.

## Verified

- `task validate --name leteo` — all 11 checks pass.
- Handshake against the built image: `initialize` returns `serverInfo` `leteo 0.1.0`, protocol `2025-06-18`.
- `disableNetwork: true` checked under `--network none`: 22 tools listed and search answering from the store.

No secrets and no credentials, so there is nothing to send to the test-credentials form.