### PR TITLE
Add MIRASTACK Redfish MCP Server

### DIFF
--- a/servers/mirastack-redfish/server.yaml
+++ b/servers/mirastack-redfish/server.yaml
@@ -1,0 +1,27 @@
+name: mirastack-redfish
+image: mcp/mirastack-redfish
+type: server
+meta:
+  category: devops
+  tags:
+    - ai-agents
+    - bare-metal
+    - bmc
+    - data-center
+    - idrac
+    - ilo
+    - infrastructure
+    - model-context-protocol
+    - openbmc
+    - programmable-data-centers
+    - redfish
+    - sddc
+about:
+  title: MIRASTACK Redfish
+  description: Governed access to DMTF Redfish-compliant baseboard management controllers (iDRAC, iLO, XCC, OpenBMC). Provides inventory, thermal, power, sensor, log, firmware and BIOS data, plus tiered write operations for power state, boot override, BIOS attributes, firmware update and virtual media. Read-only by default — mutating tools are not registered at all unless write mode is explicitly raised (power, config, full), and every mutation runs as a dry-run until confirmed. Individual endpoints can be pinned read-only regardless of the global mode, and TLS verification is on by default. Tool descriptions are generated from the DMTF Redfish corpus pinned to a specific publication, so the advertised schema is reproducible against a known spec version.
+  icon: https://avatars.githubusercontent.com/u/263104162?v=4
+source:
+  project: https://github.com/mirastacklabs-ai/mirastack-redfish-mcp
+  commit: f059ae5fc628a20ae018ebc3ecf68c273756db08
+config:
+  description: Configure one or more Redfish endpoints. Each endpoint needs a base URL, username and password. Write operations are disabled by default; set the write mode explicitly to enable them.


### PR DESCRIPTION
Adds the MIRASTACK Redfish MCP Server — governed MCP access to DMTF Redfish-compliant baseboard management controllers (iDRAC, iLO, XCC, OpenBMC).

**Links**
- Repo: https://github.com/mirastacklabs-ai/mirastack-redfish-mcp
- PyPI: https://pypi.org/project/mirastack-redfish-mcp/
- MCP Registry: `ai.mirastacklabs/mirastack-redfish-mcp`
- Glama: https://glama.ai/mcp/servers/mirastacklabs-ai/mirastack-redfish-mcp (Grade A)
- Licence: Apache-2.0

**Validation**
- `task validate -- --name mirastack-redfish` — all checks pass
- `task build -- --tools mirastack-redfish` — 25 tools found, no `tools.json` needed
- Commit pinned to the v0.1.2 release tag

**Note on network access**

This server connects to baseboard management controllers on the user's own out-of-band management network. Target addresses are supplied entirely at runtime via configuration (`MIRASTACK_REDFISH_HOST` or an endpoints file) and are typically RFC 1918 addresses that cannot be enumerated in advance, so there is no fixed set of outbound domains to allowlist. The server makes no calls to any third-party service — no telemetry, no external APIs. Happy to adjust the network configuration if the registry expects a specific declaration for this case.

**Safety model**

Read-only by default: mutating tools are not registered at all unless write mode is explicitly raised (`power` → `config` → `full`), so the 25 tools listed above are the complete default surface. Every mutation additionally runs as a dry-run until confirmed, individual endpoints can be pinned read-only regardless of the global mode, and TLS verification is on by default.