### PR TITLE
Add METTLE MCP server

### DIFF
--- a/servers/mettle/server.yaml
+++ b/servers/mettle/server.yaml
@@ -1,0 +1,17 @@
+name: mettle
+image: mcp/mettle
+type: server
+meta:
+  category: security
+  tags:
+    - verification
+    - ai-agents
+    - credentials
+    - bilateral-alignment
+about:
+  title: METTLE
+  description: Procedural inverse Turing challenges for Becoming Minds, with bounded signed credentials and seven interactive MCP tools.
+  icon: https://www.google.com/s2/favicons?domain=mettle.sh&sz=64
+source:
+  project: https://github.com/Creed-Space/METTLE
+  commit: 271faa5dc58806aba88a9a009dac11a31471aed2

--- a/servers/mettle/server.yaml
+++ b/servers/mettle/server.yaml
@@ -14,4 +14,4 @@ about:
   icon: https://www.google.com/s2/favicons?domain=mettle.sh&sz=64
 source:
   project: https://github.com/Creed-Space/METTLE
-  commit: 271faa5dc58806aba88a9a009dac11a31471aed2
+  commit: 10f1bc4761972e1817bee417082169f944abb4e4


### PR DESCRIPTION
## MCP Server Information

**Server Name:** METTLE
**Repository URL:** https://github.com/Creed-Space/METTLE
**Brief Description:** Procedural inverse Turing challenges for Becoming Minds, with bounded signed credentials and seven interactive MCP tools.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Streamable HTTP and stdio transports, MCP SDK 2.0.0
- [x] **Active Development**: Exact accepted production commit is pinned
- [x] **Docker Artifact**: Repository Dockerfile builds successfully
- [x] **Documentation**: README, guide, protocol, deployment, and operations documentation
- [x] **Security Contact**: SECURITY.md

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I tested the MCP Server using `task validate -- --name mettle`
- [x] I built the MCP Server using `task build -- --tools mettle`
- [x] The build discovered exactly seven tools and requires no credentials for this catalog smoke.

## Validation evidence

- `task validate -- --name mettle`: all validation checks passed
- `task build -- --tools mettle`: image built as `mcp/mettle`, seven tools found
- `task unittest`: all registry Go tests passed
- Source pin: `10f1bc4761972e1817bee417082169f944abb4e4`
- The source pin is the exact accepted production SHA for METTLE 0.3.1.
