### PR TITLE
Add Filingrail MCP server

### DIFF
--- a/servers/filingrail/server.yaml
+++ b/servers/filingrail/server.yaml
@@ -14,7 +14,7 @@ about:
   icon: https://raw.githubusercontent.com/adamhudson777/filingrail-mcp/main/assets/filingrail-logo-400.png
 source:
   project: https://github.com/adamhudson777/filingrail-mcp
-  commit: 3d474d587620a7acd6685869b03c6373848a2349
+  commit: 1dd92815cf14e4546add94cc9ae13625a2e7fbb7
 config:
   description: Configure your Filingrail API key (free tier is 50 requests/day)
   secrets:

--- a/servers/filingrail/server.yaml
+++ b/servers/filingrail/server.yaml
@@ -1,0 +1,23 @@
+name: filingrail
+image: mcp/filingrail
+type: server
+meta:
+  category: data-analytics
+  tags:
+    - sec-edgar
+    - financial-data
+    - fintech
+    - xbrl
+about:
+  title: Filingrail
+  description: SEC EDGAR filings as MCP tools - XBRL financials, Form 4 insider trades, 8-K events, 13F holdings, and filing search. Every record carries the sec.gov filing URL it was derived from, so any number can be checked against the original document.
+  icon: https://raw.githubusercontent.com/adamhudson777/filingrail-mcp/main/assets/filingrail-logo-400.png
+source:
+  project: https://github.com/adamhudson777/filingrail-mcp
+  commit: 3d474d587620a7acd6685869b03c6373848a2349
+config:
+  description: Configure your Filingrail API key (free tier is 50 requests/day)
+  secrets:
+    - name: filingrail.rapidapi_key
+      env: RAPIDAPI_KEY
+      example: <RAPIDAPI_KEY>


### PR DESCRIPTION
Adds `servers/filingrail/server.yaml` — a local (containerized) MCP server exposing the Filingrail SEC EDGAR API.

**What it does.** Eight stdio tools over US public-company filing data: XBRL financials and history, Form 4 insider trades, 8-K material events, 13F institutional holdings, company search, and recent filings. Every record carries the `sec.gov` filing URL it was derived from, so any figure an agent surfaces can be checked against the original document.

**Meets the local-server requirements:**
- Dockerfile at the root of the source repo — `python:3.12-slim`, non-root, stdio transport, no ports
- **MIT licensed** (consumable per the contributing guide)
- Already published on the official MCP registry as `io.github.adamhudson777/filingrail-mcp`, and on PyPI as `filingrail-mcp`
- Pinned to commit `3d474d5` on https://github.com/adamhudson777/filingrail-mcp

**Credentials for review.** The single secret is `RAPIDAPI_KEY`. Rather than sharing a key, reviewers can self-serve one in about a minute — the free tier is 50 requests/day with no card required, at https://rapidapi.com/hudson-enterprises-llc-hudson-enterprises-llc-default/api/filingrail. Happy to supply a key through the credentials form instead if you'd prefer.

Note that the server lists its tools without a key present — the key is only required when a tool is actually called — so `list tools` verification works on a bare container.