### PR TITLE
Add LineBreak Gate MCP server

### DIFF
--- a/servers/linebreak-gate/readme.md
+++ b/servers/linebreak-gate/readme.md
@@ -1,0 +1,1 @@
+For full documentation, see the [linebreak-gate GitHub repository](https://github.com/Baktun-Studio/linebreak-gate) and [PyPI package](https://pypi.org/project/linebreak-gate/).

--- a/servers/linebreak-gate/server.yaml
+++ b/servers/linebreak-gate/server.yaml
@@ -1,0 +1,38 @@
+name: linebreak-gate
+image: mcp/linebreak-gate
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - ci
+    - cve
+    - supply-chain
+    - code-review
+about:
+  title: LineBreak Gate
+  description: >-
+    Fail-closed CI gate for AI-written code: blocks known CVEs (OSV) and
+    serves human-approved acceptance criteria to coding agents, read-only.
+  icon: https://avatars.githubusercontent.com/u/280721523?s=200&v=4
+source:
+  project: https://github.com/Baktun-Studio/linebreak-gate
+  branch: main
+  commit: 4f042176d0c28659617efc71fb55372013bf2a0c
+run:
+  command:
+    - --path
+    - "{{linebreak-gate.project_dir}}"
+  volumes:
+    - "{{linebreak-gate.project_dir|volume|into}}"
+config:
+  description: The repository whose approved spec (.linebreak/spec/) the server serves
+  parameters:
+    type: object
+    properties:
+      project_dir:
+        type: string
+        title: Project directory
+        description: Absolute path to the repository whose .linebreak/spec/ should be served (read-only, fully offline)
+    required:
+      - project_dir

--- a/servers/linebreak-gate/tools.json
+++ b/servers/linebreak-gate/tools.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "list_stories",
+    "description": "All approved stories in this repository: id, title, epic, local status (todo|doing|review|done), and how many acceptance criteria each carries. The list IS the approved scope - nothing else is in spec."
+  },
+  {
+    "name": "get_story",
+    "description": "One approved story in full: title, epic, and every acceptance criterion with its id, statement, and check type (build | tests | command | manual). Read this BEFORE implementing the story - the criteria are the approved definition of done.",
+    "arguments": [
+      {
+        "name": "story_id",
+        "type": "string",
+        "desc": "Story id as listed by list_stories"
+      }
+    ]
+  },
+  {
+    "name": "next_story",
+    "description": "The next approved story that is not yet done, per local story state. Use this to pick up work without guessing at priorities."
+  },
+  {
+    "name": "set_story_status",
+    "description": "Record story progress: status is doing | review | done. Writes LOCAL story state only (the repo's tracker-sync artifact) - never a configured external tracker, and never the approved criteria.",
+    "arguments": [
+      {
+        "name": "story_id",
+        "type": "string",
+        "desc": "Story id as listed by list_stories"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "doing | review | done"
+      },
+      {
+        "name": "comment",
+        "type": "string",
+        "desc": "Optional progress note"
+      }
+    ]
+  },
+  {
+    "name": "check_story",
+    "description": "Run this story's acceptance criteria against the working tree with the SAME engine as the merge gate (linebreak-gate check). Returns pass | fail | needs-signoff per criterion - verify your work here BEFORE pushing instead of discovering failures at the merge.",
+    "arguments": [
+      {
+        "name": "story_id",
+        "type": "string",
+        "desc": "Story id as listed by list_stories"
+      }
+    ]
+  },
+  {
+    "name": "spec_status",
+    "description": "Is there an approved spec bundle: version, source phase, approver, story count, and the approval signature state (verified | invalid | signed-unverified | unsigned), verified entirely offline."
+  }
+]


### PR DESCRIPTION
## What is this?

**linebreak-gate** is a fail-closed CI gate for AI-written code: it blocks known CVEs (via OSV) at the git/CI boundary and serves a repository's human-approved stories and acceptance criteria to coding agents (Claude Code, Cursor, Codex, ...) over MCP, read-only and fully offline.

The MCP server (`linebreak-gate mcp`, stdio transport) reads `.linebreak/spec/` from the mounted project directory. It exposes 6 tools: `list_stories`, `get_story`, `next_story`, `set_story_status`, `check_story`, `spec_status`. There is no way through this server to write or invalidate approved criteria.

## Details

- **Source / Dockerfile**: https://github.com/Baktun-Studio/linebreak-gate (Apache-2.0, Dockerfile at repo root, pinned commit in `server.yaml`)
- **PyPI**: https://pypi.org/project/linebreak-gate/ (the Dockerfile installs the released `linebreak-gate==1.10.3` from PyPI for reproducibility)
- **Official MCP registry id**: `com.linebreakapp/linebreak-gate`
- **Config**: single required parameter `project_dir` (the repository to serve), mounted as a volume and passed as `--path`. No secrets, no network access needed.
- **tools.json** is included so the build does not need to run the server with an unresolved config.

## Testing

- Built the image locally from the Dockerfile and smoke-tested MCP stdio (`initialize` + `tools/list` piped into `docker run -i`); the server responds and lists all 6 tools.
- `task validate`/`task wizard` were not run locally (no Go toolchain available); the `server.yaml` was hand-validated against merged local-server entries (`git`, `markitdown`, `zscaler-mcp-server`, `SQLite` for `run.command`). Happy to adjust if CI flags anything.
