### PR TITLE
Add BlazingCDN official MCP server

### DIFF
--- a/servers/blazingcdn/server.yaml
+++ b/servers/blazingcdn/server.yaml
@@ -1,0 +1,43 @@
+name: blazingcdn
+image: mcp/blazingcdn
+type: server
+meta:
+  category: devops
+  tags:
+    - cdn
+    - devops
+    - cloud
+about:
+  title: BlazingCDN
+  description: Official BlazingCDN MCP server — manage CDN zones (TTLs, compression, on-the-fly image resizing, HLS/DASH streaming), purge and warm up cache, query traffic metrics, manage custom domains, cloud storage and the Video CDN. 52 tools, read-only by default; write and delete tools are opt-in; zone/bucket/account deletion is not implemented at all.
+  icon: https://raw.githubusercontent.com/BlazingCDN/BlazingCDN-MCP/main/assets/logo-400.png
+source:
+  project: https://github.com/BlazingCDN/BlazingCDN-MCP
+  branch: main
+  commit: 927b0cfa4d917e8cf1a644df82ea2b2e24025e58
+run:
+  allowHosts:
+    - wapi.blazingcdn.com:443
+config:
+  description: Connect with your BlazingCDN API token (sign up at blazingcdn.com, then panel — Account — API tokens)
+  secrets:
+    - name: blazingcdn.api_token
+      env: BLAZINGCDN_API_TOKEN
+      example: <YOUR_BLAZINGCDN_API_TOKEN>
+      description: Create an API token in the BlazingCDN panel (Account → API tokens)
+  env:
+    - name: BLAZINGCDN_ALLOW_WRITE
+      example: "1"
+      value: "{{blazingcdn.allow_write}}"
+    - name: BLAZINGCDN_ALLOW_DELETE
+      example: "1"
+      value: "{{blazingcdn.allow_delete}}"
+  parameters:
+    type: object
+    properties:
+      allow_write:
+        type: string
+        description: Set to 1 to enable create/update tools
+      allow_delete:
+        type: string
+        description: Set to 1 to enable delete tools (custom domains and vCDN resources only)


### PR DESCRIPTION
Adds the official MCP server for [BlazingCDN](https://blazingcdn.com) — a CDN for video, software and sports media.

- **Source**: https://github.com/BlazingCDN/BlazingCDN-MCP (TypeScript, official MCP SDK, MIT; pinned commit includes a multi-stage Dockerfile, built and smoke-tested: container starts and serves stdio)
- **Vendor-official**: published by the BlazingCDN team; also listed in the official MCP Registry (`io.github.BlazingCDN/blazingcdn-mcp`), npm (`@blazingcdn/mcp`) and Smithery
- **52 tools**: CDN zone management (TTLs, compression, image resizing, HLS/DASH), cache purge/warmup, traffic metrics, custom domains, cloud storage, Video CDN, offline pricing calculator
- **Safe by default**: read-only unless `BLAZINGCDN_ALLOW_WRITE`/`BLAZINGCDN_ALLOW_DELETE` are set; destructive zone/bucket/account deletion is not implemented in any mode
- **Network-restricted**: `allowHosts` limits egress to `wapi.blazingcdn.com:443` only
- Single secret: `BLAZINGCDN_API_TOKEN`


