### PR TITLE
Add Gemini MCP server

### DIFF
--- a/servers/gemini/server.yaml
+++ b/servers/gemini/server.yaml
@@ -1,0 +1,29 @@
+name: gemini
+image: mcp/gemini
+type: server
+meta:
+  category: ai
+  tags:
+    - gemini
+    - google
+    - ai
+    - image-generation
+    - research
+about:
+  title: Gemini
+  description: |
+    Google Gemini for Claude — grounded chat and deep research, plus image, video,
+    SVG and landing-page generation. From Houtini, the consultancy that brings AI to
+    the corporate table.
+
+    Get a free API key at https://aistudio.google.com/apikey.
+  icon: https://raw.githubusercontent.com/houtini-ai/gemini-mcp/main/assets/logo.png
+source:
+  project: https://github.com/houtini-ai/gemini-mcp
+  commit: 01e168acc57748907c39b16f0867684f73439af8
+config:
+  description: Google Gemini API access (a Google AI Studio key)
+  secrets:
+    - name: gemini.api_key
+      env: GEMINI_API_KEY
+      example: AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Adds the **Gemini** MCP server (`@houtini/gemini-mcp`) — Google Gemini for Claude: grounded chat, deep research, and image / video / SVG / landing-page generation.

From Houtini — the consultancy that brings AI to the corporate table.

- Docker-built image (`mcp/gemini`); `source.commit` pins the commit that carries the Dockerfile.
- Apache-2.0.
- Keyless tool enumeration verified locally (13 tools), so the build lists tools without a live API key.
- Happy to provide a test API key for review via the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)