### PR TITLE
Add Financial Modeling Prep MCP server

### DIFF
--- a/servers/fmp/server.yaml
+++ b/servers/fmp/server.yaml
@@ -1,0 +1,29 @@
+name: fmp
+image: mcp/fmp
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - stocks
+    - financial-data
+    - markets
+about:
+  title: Financial Modeling Prep
+  description: |
+    Financial Modeling Prep (FMP) for Claude — real-time quotes, fundamentals
+    (income statement, balance sheet, cash flow), analyst estimates and price
+    targets, insider trading, market movers, economic indicators and technicals.
+    From Houtini, the consultancy that brings AI to the corporate table.
+
+    Get an API key at https://site.financialmodelingprep.com/developer/docs.
+  icon: https://www.google.com/s2/favicons?domain=financialmodelingprep.com&sz=64
+source:
+  project: https://github.com/houtini-ai/fmp-mcp
+  commit: a862366210d09fc2f0ab97deb98f45f4bf2d163a
+config:
+  description: Financial Modeling Prep API access
+  secrets:
+    - name: fmp.api_key
+      env: FMP_API_KEY
+      example: your_fmp_api_key


### PR DESCRIPTION
Adds the **Financial Modeling Prep** MCP server (`@houtini/fmp-mcp`) — real-time quotes, fundamentals (income statement, balance sheet, cash flow), analyst estimates and price targets, insider trading, market movers, economic indicators and technicals, for Claude.

From Houtini — the consultancy that brings AI to the corporate table.

- Docker-built image (`mcp/fmp`); `source.commit` pins the commit that carries the Dockerfile.
- MIT.
- Keyless tool enumeration verified locally (26 tools).
- Happy to provide a test API key for review via the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)