### PR TITLE
Add OmniSeek (self-hosted perception MCP server)

### DIFF
--- a/servers/omniseek/server.yaml
+++ b/servers/omniseek/server.yaml
@@ -1,0 +1,33 @@
+name: omniseek
+image: ghcr.io/battam1111/omniseek
+type: server
+meta:
+  category: search
+  tags:
+    - search
+    - research
+    - transcription
+    - vision
+about:
+  title: OmniSeek
+  description: Self-hosted perception MCP server. Cross-lingual search over a curated catalog, local ASR transcription, in-band vision, login-walled sources you hold credentials for, and a persistent relation graph.
+  icon: https://raw.githubusercontent.com/Battam1111/omniseek/main/assets/logo-icon.png
+source:
+  project: https://github.com/Battam1111/omniseek
+  commit: 69671def1dacf887f04ff9534e2301da8fe58ec4
+  dockerfile: Dockerfile
+run:
+  command:
+    - omniseek
+config:
+  description: Optional; OmniSeek works with no configuration.
+  env:
+    - name: OMNISEEK_CONTACT_EMAIL
+      example: you@example.com
+      value: "{{omniseek.contact_email}}"
+  parameters:
+    type: object
+    properties:
+      contact_email:
+        type: string
+        description: Optional contact email for the Crossref / SEC / Unpaywall polite-contact fast lane.


### PR DESCRIPTION
Adds OmniSeek, a self-hosted perception MCP server (Apache-2.0).

- **Image**: prebuilt multi-arch (amd64 + arm64) at `ghcr.io/battam1111/omniseek` (self-provided image, GHCR precedent: `servers/stackgen`).
- **Run shape**: `run.command: [omniseek]` starts the MCP-over-stdio console entrypoint inside the container (the image's default CMD is its self-hosted HTTP mode; stdio is the right shape for the Toolkit). Verified by a real stdio handshake: initialize and tools/list answer with the full tool surface, no configuration.
- **No credentials needed** to start or list tools. Login-walled sources ship disabled by default and only activate when a user configures their own logins.
- **Optional env**: `OMNISEEK_CONTACT_EMAIL` (Crossref / SEC / Unpaywall polite-contact fast lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)