### PR TITLE
Add freehire MCP server

### DIFF
--- a/servers/freehire/server.yaml
+++ b/servers/freehire/server.yaml
@@ -1,0 +1,27 @@
+name: freehire
+image: mcp/freehire
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - jobs
+    - career
+    - hiring
+about:
+  title: freehire
+  description: Search IT jobs on freehire.me, an open-source aggregator that crawls postings straight from company career boards rather than reposts — 3.3M+ open roles across 294K companies, normalized into one schema and tagged with stack, seniority, region and work mode. Search and filter the live market, score a skill set against real demand to see coverage and gaps, read a posting or company in full, apply, track application stages with notes, and tailor a CV against a specific job. Search results carry each posting's full description as markdown, so a result set can be screened without a follow-up call per hit.
+  icon: https://freehire.me/pwa-512x512.png
+source:
+  project: https://github.com/strelov1/freehire-mcp
+  branch: main
+  commit: 5d4c5941352561620d2c08248f8d15ffb4ba9dc0
+config:
+  description: Configure the connection to freehire.me
+  secrets:
+    - name: freehire.api_key
+      env: FREEHIRE_TOKEN
+      example: fhk_xxxxxxxx
+run:
+  allowHosts:
+    - freehire.me:443


### PR DESCRIPTION
Adds [freehire-mcp](https://github.com/strelov1/freehire-mcp) as a local containerized server.

MCP server over [freehire.me](https://freehire.me), an open-source IT job aggregator that crawls postings straight from company career boards rather than reposts — 3.3M+ open roles across 294K companies, normalized into one schema and tagged with stack, seniority, region and work mode.

23 tools: faceted search over the live market, market-fit scoring of a skill set against real demand, full posting and company reads, apply, save, application stages and notes, CV context/get/edit/render, and vacancy submission with moderation.

- **License:** MIT
- **Dockerfile:** at the repo root; multi-stage on node:22-alpine, 175 MB, `ENTRYPOINT ["node", "dist/index.js"]` so the server owns stdin/stdout for stdio
- **Egress:** only `freehire.me:443`
- **Secret:** `FREEHIRE_TOKEN` — worth noting it is **optional at startup**. Without it the server still starts and lists all 23 tools, and only tool calls report missing auth. Tool discovery therefore works with no credential configured.

Verified locally:

```
$ printf '...initialize...tools/list...' | docker run --rm -i freehire-mcp
initialize: {'name': 'freehire', 'version': '0.4.2'}
tools/list: 23 tools
```

Also listed in the official MCP registry as `me.freehire/freehire`, and on Glama, Smithery and goose.