### PR TITLE
Add harvis (remote server, static site deployment)

### DIFF
--- a/servers/harvis/readme.md
+++ b/servers/harvis/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/harvis-io/harvis-dev-mcp

--- a/servers/harvis/server.yaml
+++ b/servers/harvis/server.yaml
@@ -1,0 +1,16 @@
+name: harvis
+type: remote
+meta:
+  category: devops
+  tags:
+    - hosting
+    - static-sites
+    - deployment
+    - remote
+about:
+  title: harvis
+  description: Deploy static sites and get a live URL in seconds
+  icon: https://harvis.dev/icon-512.png
+remote:
+  transport_type: streamable-http
+  url: https://harvis.dev/api/mcp


### PR DESCRIPTION
Adds **harvis** as a remote MCP server (no OAuth), following the `servers/cloudflare-docs` pattern.

- Endpoint: `https://harvis.dev/api/mcp` (streamable-http, publicly accessible, no auth required)
- What it does: gives agents a `deploy_site` tool — upload static files and get a live URL on a `*.harvis.dev` subdomain in seconds; anonymous deploys with a private claim link. Free tier for small sites.
- Listed in the official MCP Registry as `dev.harvis/harvis`.
- Docs/manifest repo (MIT): https://github.com/harvis-io/harvis-dev-mcp

Disclosure: I'm the maintainer of harvis.