### PR TITLE
Add saga-mcp server entry

### DIFF
--- a/servers/saga-mcp/server.yaml
+++ b/servers/saga-mcp/server.yaml
@@ -1,0 +1,25 @@
+name: saga-mcp
+image: mcp/saga-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - project-management
+    - task-tracker
+    - issue-tracker
+    - sqlite
+    - agent-tools
+about:
+  title: Saga
+  description: Project tracker for coding agents — projects, epics, tasks, subtasks, dependencies, comments and notes in a SQLite file, exposed as 31 MCP tools with an activity log and a one-call dashboard.
+  icon: https://avatars.githubusercontent.com/u/8328281?v=4
+source:
+  project: https://github.com/spranab/saga-mcp
+  branch: master
+  commit: 18b807becdd0220d7d2635db443f173cb080d83b
+run:
+  env:
+    DB_PATH: /mcp/tracker.db
+  volumes:
+    - mcp-saga:/mcp
+  disableNetwork: true


### PR DESCRIPTION
## MCP Server Information

**Server Name:** saga-mcp
**Repository URL:** https://github.com/spranab/saga-mcp
**Brief Description:** A project tracker that lives inside the agent loop. Projects, epics, tasks, subtasks, dependencies, comments and notes are stored in a SQLite file in the user's project; 31 MCP tools read and write it, with an activity log and a one-call dashboard so an agent can pick up where it left off in a new session. No accounts, no external service, no network calls.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license) — MIT
- [x] **MCP Compliant**: Implements MCP API specification (`@modelcontextprotocol/sdk`, stdio; 31 tools with MCP safety annotations)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues — developer@pranab.co.in, also GitHub issues on the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name saga-mcp`
- [x] I have built the MCP Server using `task build -- --tools saga-mcp`
- [ ] If the server requires credentials to test it, I have shared test credentials using the form — not applicable, the server needs no credentials

## Notes for the reviewer

- The upstream Dockerfile previously did `COPY dist/ dist/`, so it only built after a local `npm run build`. It now compiles TypeScript in a build stage, so it builds from a clean checkout of the pinned commit; that is the commit referenced in `server.yaml`.
- `run` sets `DB_PATH=/mcp/tracker.db` and mounts a named volume at `/mcp`, because the tracker is a SQLite file that has to survive across container runs. `DB_PATH` is the server's only setting and it has no default, so it is set here rather than left to the user.
- `disableNetwork: true` — the server only reads and writes its local SQLite file; it makes no outbound calls.
- `task validate` passes all checks and `task build -- --tools saga-mcp` lists 31 tools.
