### PR TITLE
Add Decionis: policy gate for AI agents

### DIFF
--- a/servers/decionis/server.yaml
+++ b/servers/decionis/server.yaml
@@ -1,0 +1,32 @@
+name: decionis
+image: decionis/mcp
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - policy
+    - guardrails
+    - ai-agents
+    - governance
+about:
+  title: Decionis
+  description: Policy gate for AI agents. Evaluate a candidate action against the repository's DECIONIS_POLICY.md and get a verdict before anything commits, deploys, or migrates — the real Decionis protocol evaluator runs in-process, with zero network, zero credentials, and nothing recorded.
+  icon: https://decionis.com/favicon.ico
+source:
+  project: https://github.com/decionis/docker
+  commit: 02f68c0f03daf44da59757385c9531ba411582bc
+run:
+  volumes:
+    - "{{decionis.policy_path}}:/work/DECIONIS_POLICY.md:ro"
+  disableNetwork: true
+config:
+  description: Point Decionis at the repository's DECIONIS_POLICY.md to evaluate against.
+  parameters:
+    type: object
+    properties:
+      policy_path:
+        type: string
+        description: Absolute host path to the repository's DECIONIS_POLICY.md policy file.
+    required:
+      - policy_path


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Decionis
**Repository URL:** https://github.com/decionis/docker
**Brief Description:** Policy gate for AI agents: evaluates a candidate action against the repository's `DECIONIS_POLICY.md` and returns a verdict before anything commits, deploys, or migrates. The real Decionis protocol evaluator runs in-process — zero network, zero credentials, nothing recorded — so the entry sets `disableNetwork: true` and needs no secrets.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: stdio MCP server exposing `decionis_read_policy`, `decionis_evaluate`, and `decionis_verdict_help`
- [x] **Active Development**: actively maintained; the image wraps the published `@decionis/mcp` npm package at an exact pinned version
- [x] **Docker Artifact**: Dockerfile at `mcp-server/Dockerfile` in the source repo; self-provided image `decionis/mcp` on Docker Hub (multi-arch amd64/arm64, provenance + SBOM attestations, cosign keyless signature)
- [x] **Documentation**: README and Docker Hub overview at https://hub.docker.com/r/decionis/mcp
- [x] **Security Contact**: `SECURITY.md` in the repo (security@decionis.ai)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name decionis` (all checks pass)
- [x] I have built the MCP Server using `task build -- --tools --pull-community decionis` (3 tools found)
- [x] No credentials are required to test this server (zero-credential local evaluator), so the test-credentials form is not applicable — configure any file as `policy_path` and the tools list and evaluate immediately.