### PR TITLE
Add yantrikdb-mcp server entry

### DIFF
--- a/servers/yantrikdb-mcp/server.yaml
+++ b/servers/yantrikdb-mcp/server.yaml
@@ -1,0 +1,25 @@
+name: yantrikdb-mcp
+image: mcp/yantrikdb-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - memory
+    - knowledge-graph
+    - semantic-search
+    - sqlite
+    - agent-tools
+about:
+  title: YantrikDB
+  description: Persistent memory for agents — writes facts to a local SQLite file and reads them back by semantic search across sessions, with contradiction detection, a knowledge graph, time-scoped recall and consolidation, as 20 MCP tools. Runs entirely offline; no account or API key.
+  icon: https://avatars.githubusercontent.com/u/266386478?s=200&v=4
+source:
+  project: https://github.com/yantrikos/yantrikdb-mcp
+  branch: main
+  commit: dd97ad63686b48838ab878694595e22ff259539a
+run:
+  env:
+    YANTRIKDB_DB_PATH: /mcp/memory.db
+  volumes:
+    - mcp-yantrikdb:/mcp
+  disableNetwork: true


### PR DESCRIPTION
## MCP Server Information

**Server Name:** yantrikdb-mcp
**Repository URL:** https://github.com/yantrikos/yantrikdb-mcp
**Brief Description:** Persistent memory for agents. An agent writes facts with `remember` and gets them back in a later session with `recall` — semantic search over a local SQLite file, plus contradiction detection, a knowledge graph, time-scoped queries and consolidation. 20 MCP tools over stdio. No account, no API key, no model download, no network calls at runtime.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license) — MIT (see the license note below)
- [x] **MCP Compliant**: Implements MCP API specification (Python `mcp` SDK, stdio; 20 tools; tested against both `mcp` 1.x and 2.x in CI)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions (plus `llms-install.md` for agent-driven installs)
- [x] **Security Contact**: Method for reporting security issues — developer@pranab.co.in, also GitHub issues on the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name yantrikdb-mcp`
- [x] I have built the MCP Server using `task build -- --tools yantrikdb-mcp`
- [ ] If the server requires credentials to test it, I have shared test credentials using the form — not applicable, the server needs no credentials

## License, stated plainly

This is worth spelling out because the history is easy to find and I would rather disclose it than have it turn up in review.

- **This server (`yantrikdb-mcp`) is MIT** — always has been. github.com/yantrikos/yantrikdb-mcp, `LICENSE` and `pyproject.toml`.
- **The engine it depends on (`yantrikdb`) is Apache-2.0 — but only as of engine v0.15.4, published 2026-08-18.** Every earlier engine release was **AGPL-3.0-only**. The relicense is live on all three surfaces: the repo github.com/yantrikos/yantrikdb (Apache License 2.0 on `main`), crates.io (`yantrikdb` 0.15.4, `Apache-2.0`; 0.15.3 and below are `AGPL-3.0-only`), and PyPI (`yantrikdb` 0.15.4, `license_expression: Apache-2.0`).
- Because the floor mattered here, I raised it. The dependency pin was `yantrikdb>=0.15.3,<0.16.0`, which still admitted an AGPL engine; it is now `yantrikdb>=0.15.4,<0.16.0` in the pinned commit, so no resolution of this package can pull AGPL code. The relicense carried no code change, so the floor costs nothing behaviorally.
- Older material — blog posts, directory listings, the repo description before today — may still say AGPL. That was accurate when written; it is not accurate now.

I am the author of both projects.

## Notes for the reviewer

- **Dockerfile added upstream for this submission.** The repo had none, since it ships as `pip install yantrikdb-mcp`. It is multi-stage: a builder venv installs the package, the runtime stage carries only the venv. Base is `python:3.12-slim-bookworm` because the engine publishes `manylinux_2_17` wheels for x86_64 and aarch64 and no musl wheel. It builds from a clean checkout — the commit pinned in `server.yaml` is that commit.
- **`disableNetwork: true`** — the server reads and writes one local SQLite file and makes no outbound calls. The default embedder is bundled in the engine, so there is no model download on first run either. Verified: the built image completes the stdio handshake, lists 20 tools, and round-trips `remember` → `recall` under `docker run --network none`.
- **`YANTRIKDB_DB_PATH=/mcp/memory.db` on a named volume** — the memories are the product, so they have to survive the container. The default is `~/.yantrikdb/memory.db`, which would be lost with the container; `run` points it at the mounted volume instead.
- Runs as an unprivileged user (uid 10001).
- `task validate -- --name yantrikdb-mcp` passes every check, and `task build -- --tools yantrikdb-mcp` lists 20 tools.
