### PR TITLE
Add cn-holiday-mcp MCP server

### DIFF
--- a/servers/cn-holiday-mcp/server.yaml
+++ b/servers/cn-holiday-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: cn-holiday-mcp
+image: mcp/cn-holiday-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - holiday
+    - calendar
+    - china
+about:
+  title: CN Holiday MCP
+  description: Zero-dependency MCP server for Chinese public holidays and makeup workdays (调休), 2025-2026, per official State Council notices. Two tools: query_holiday and list_holidays. Pure Node.js stdlib, offline, no API key.
+  icon: https://avatars.githubusercontent.com/u/238782599?v=4
+source:
+  project: https://github.com/qianwei2333/cn-holiday-mcp
+  branch: main
+  commit: ac426eff735804d6bf5087e0f965dfedd5eb327a
+  directory: .


### PR DESCRIPTION
## MCP Server Information

**Server Name:** cn-holiday-mcp
**Repository URL:** https://github.com/qianwei2333/cn-holiday-mcp
**Brief Description:** Zero-dependency MCP server for Chinese public holidays and makeup workdays (调休), 2025-2026, per official State Council notices.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: implements MCP 2024-11-05 (stdio)
- [x] **Active Development**: newly released and maintained
- [x] **Docker Artifact**: Dockerfile added to the repository
- [x] **Documentation**: README with setup instructions (CN + EN)
- [ ] **Security Contact**: not yet published

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [ ] I have tested the MCP Server using `task validate -- --name SERVER_NAME` (submitter machine has no Go/Docker; please run CI)
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME` (same as above)