### PR TITLE
Add WaveSpeed MCP server

### DIFF
--- a/servers/wavespeed/server.yaml
+++ b/servers/wavespeed/server.yaml
@@ -1,0 +1,25 @@
+name: wavespeed
+image: mcp/wavespeed
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - image-generation
+    - video-generation
+    - audio-generation
+    - media
+about:
+  title: WaveSpeed
+  description: Official WaveSpeed AI server for media generation. Gives assistants access to the live wavespeed.ai model catalog — image, video, audio, and 3D — with catalog search, per-model input-schema introspection, local-file upload via "@path" markers, and price quotes before running a job.
+  icon: https://www.google.com/s2/favicons?domain=wavespeed.ai&sz=64
+source:
+  project: https://github.com/WaveSpeedAI/mcp-server
+  branch: main
+  commit: 4c08e288c84418b1f902e8d29e1612c6a84de0f6
+config:
+  description: Configure the connection to WaveSpeed AI
+  secrets:
+    - name: wavespeed.api_key
+      env: WAVESPEED_API_KEY
+      example: <YOUR_WAVESPEED_API_KEY>


### PR DESCRIPTION
Adds **WaveSpeed** ([WaveSpeedAI/mcp-server](https://github.com/WaveSpeedAI/mcp-server), MIT) as a local containerized server.

Official server for [WaveSpeed AI](https://wavespeed.ai)'s media-generation platform: it exposes the live model catalog (image, video, audio, 3D) with catalog search, per-model input-schema introspection, local-file upload via `@path` markers, and price quotes before running a job. Also published in the official MCP Registry as `ai.wavespeed/mcp` and on npm as `@wavespeed/mcp`.

- Dockerfile added upstream at the pinned commit; image builds and answers the MCP `initialize` handshake (verified locally).
- `task validate` passes locally (config env / license / icon all ✅).
- Single secret: `WAVESPEED_API_KEY` (user-supplied).

Happy to adjust category/tags if you prefer a different taxonomy.