### PR TITLE
Add SandBase Harness MCP server

### DIFF
--- a/servers/sandbase-harness/server.yaml
+++ b/servers/sandbase-harness/server.yaml
@@ -1,5 +1,5 @@
 name: sandbase-harness
-image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6
+image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.7
 type: server
 meta:
   category: ai
@@ -13,7 +13,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/271874822?s=200&v=4
 source:
   project: https://github.com/sandbaseai/sandbase-harness
-  commit: 5244b1df7918bb4f8b01a740c8f8698c6b700b7f
+  commit: 65ce225d01f56b5584d833af6b1afcc119dfd323
 config:
   description: Connect to a running SandBase Harness runtime API.
   secrets:

--- a/servers/sandbase-harness/server.yaml
+++ b/servers/sandbase-harness/server.yaml
@@ -1,0 +1,37 @@
+name: sandbase-harness
+image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4
+type: server
+meta:
+  category: ai
+  tags:
+    - agent-runtime
+    - sandbox
+    - observability
+about:
+  title: SandBase Harness
+  description: Run and observe isolated coding-agent sessions through a self-hosted SandBase Harness runtime.
+  icon: https://avatars.githubusercontent.com/u/271874822?s=200&v=4
+source:
+  project: https://github.com/sandbaseai/sandbase-harness
+  commit: d79ff1cdb283952647ed04193a731e11abf8253d
+config:
+  description: Connect to a running SandBase Harness runtime API.
+  secrets:
+    - name: sandbase-harness.api_key
+      env: MANAGED_AGENTS_API_KEY
+      example: <YOUR_API_KEY>
+      description: Optional API key when authentication is enabled on the Harness runtime.
+  env:
+    - name: MANAGED_AGENTS_URL
+      example: http://host.docker.internal:3000
+      value: "{{sandbase-harness.url}}"
+      description: URL of the SandBase Harness runtime API. Use host.docker.internal for a runtime on the Docker host.
+  parameters:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string
+        description: URL of the SandBase Harness runtime API.
+        default: http://host.docker.internal:3000

--- a/servers/sandbase-harness/server.yaml
+++ b/servers/sandbase-harness/server.yaml
@@ -1,5 +1,5 @@
 name: sandbase-harness
-image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4
+image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5
 type: server
 meta:
   category: ai
@@ -13,7 +13,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/271874822?s=200&v=4
 source:
   project: https://github.com/sandbaseai/sandbase-harness
-  commit: d79ff1cdb283952647ed04193a731e11abf8253d
+  commit: 3f0532765c9e43df13bc285622d3e84783002ad0
 config:
   description: Connect to a running SandBase Harness runtime API.
   secrets:

--- a/servers/sandbase-harness/server.yaml
+++ b/servers/sandbase-harness/server.yaml
@@ -1,5 +1,5 @@
 name: sandbase-harness
-image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.5
+image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.6
 type: server
 meta:
   category: ai
@@ -13,7 +13,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/271874822?s=200&v=4
 source:
   project: https://github.com/sandbaseai/sandbase-harness
-  commit: 3f0532765c9e43df13bc285622d3e84783002ad0
+  commit: 5244b1df7918bb4f8b01a740c8f8698c6b700b7f
 config:
   description: Connect to a running SandBase Harness runtime API.
   secrets:

--- a/servers/sandbase-harness/tools.json
+++ b/servers/sandbase-harness/tools.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "list_agents",
+    "description": "List agents available in the connected SandBase Harness runtime.",
+    "arguments": []
+  },
+  {
+    "name": "create_session",
+    "description": "Create a SandBase Harness session for an agent.",
+    "arguments": [
+      {
+        "name": "agent",
+        "type": "string",
+        "desc": "Agent ID, for example agent_assistant."
+      },
+      {
+        "name": "environment_id",
+        "type": "string",
+        "desc": "Optional environment ID for the session."
+      },
+      {
+        "name": "title",
+        "type": "string",
+        "desc": "Optional human-readable session title."
+      }
+    ]
+  },
+  {
+    "name": "run_session",
+    "description": "Send a message to a session and wait until its streamed turn becomes idle.",
+    "arguments": [
+      {
+        "name": "session_id",
+        "type": "string",
+        "desc": "ID of the session to run."
+      },
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "Non-empty user message to send to the session."
+      }
+    ]
+  },
+  {
+    "name": "get_session",
+    "description": "Get the current state and usage of a SandBase Harness session.",
+    "arguments": [
+      {
+        "name": "session_id",
+        "type": "string",
+        "desc": "ID of the session to inspect."
+      }
+    ]
+  },
+  {
+    "name": "list_artifacts",
+    "description": "List artifacts produced by a SandBase Harness session.",
+    "arguments": [
+      {
+        "name": "session_id",
+        "type": "string",
+        "desc": "ID of the session whose artifacts should be listed."
+      }
+    ]
+  },
+  {
+    "name": "stop_session",
+    "description": "Stop a running SandBase Harness session.",
+    "arguments": [
+      {
+        "name": "session_id",
+        "type": "string",
+        "desc": "ID of the session to stop."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** SandBase Harness  
**Repository URL:** https://github.com/sandbaseai/sandbase-harness  
**Brief Description:** Run and observe isolated coding-agent sessions through a self-hosted SandBase Harness runtime. The stdio MCP bridge exposes six tools for agents, sessions, streamed turns, artifacts, and cancellation.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Implements MCP 2025-06-18 over stdio
- [x] **Active Development**: Current maintained release is v0.3.7
- [x] **Docker Artifact**: Multi-architecture image and `Dockerfile.mcp`
- [x] **Documentation**: README includes setup, environment variables, and Docker invocation
- [x] **Security Contact**: GitHub private vulnerability reporting is documented in `SECURITY.md`

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I tested the entry with `go run ./cmd/validate --name sandbase-harness` using Go 1.24
- [x] I tested the self-provided image with `go run ./cmd/build --pull-community --tools sandbase-harness`
- [x] No test credentials are required for MCP initialization or tool discovery; the API key is optional and functional session calls target the user's own Harness runtime

## Validation details

- official registry validator: all checks passed (name, directory, title, format, commit pin, secrets, config, license, icon)
- source pinned to the v0.3.7 release commit `65ce225d01f56b5584d833af6b1afcc119dfd323`
- published multi-platform image pulled at OCI index digest `sha256:5f7dcac499e95294be540035bd4892456ffbb7bedf2bb2d8a96d65e4203f11dc`
- registry build validation found all six documented MCP tools
- the release workflow produced `linux/amd64` and `linux/arm64` images plus GitHub build provenance

## Disclosure

I am affiliated with SandBase AI. This submission uses the project's self-provided GHCR image. AI assistance was used to prepare and validate the registry metadata; the image, source pin, tool definitions, and security posture were independently checked as described above.