### PR TITLE
Add Misata MCP server

### DIFF
--- a/servers/misata/server.yaml
+++ b/servers/misata/server.yaml
@@ -1,0 +1,34 @@
+name: misata
+image: mcp/misata
+type: server
+meta:
+  category: database
+  tags:
+    - database
+    - testing
+    - test-data
+    - synthetic-data
+    - developer-tools
+about:
+  title: Misata
+  description: "Generate realistic test data for your database: mock rows with foreign keys that resolve and aggregates that reconcile, returned with an integrity check. Seeds a live Postgres, MySQL or SQLite database from its own schema, or exports fixtures as CSV, JSON, SQL or Parquet. A deterministic Faker alternative for relational data."
+  icon: https://avatars.githubusercontent.com/u/112371697?v=4
+source:
+  project: https://github.com/rasinmuhammed/misata
+  branch: main
+  commit: 92e50c9db96a0c659525d5595de7ccdc24d63a64
+config:
+  description: "All optional. Four of the seven tools, including generate_from_schema and seed_database, never call a model and work with nothing configured. A provider key is only needed for the tools that read a plain-English story."
+  secrets:
+    - name: misata.groq_api_key
+      env: GROQ_API_KEY
+      example: <YOUR_GROQ_API_KEY>
+      required: false
+    - name: misata.openai_api_key
+      env: OPENAI_API_KEY
+      example: <YOUR_OPENAI_API_KEY>
+      required: false
+    - name: misata.anthropic_api_key
+      env: ANTHROPIC_API_KEY
+      example: <YOUR_ANTHROPIC_API_KEY>
+      required: false


### PR DESCRIPTION
Adds **Misata**, an MCP server for generating relational test data.

### What it does

The agent designs the schema, which is what agents are genuinely good at, and the engine guarantees the parts they are not: every foreign key resolves, declared aggregates hit their target exactly, and derived columns satisfy the formula they were declared with. An integrity check is returned with the data rather than a promise that it is correct. Output is fully seeded, so the same schema and seed produce the same rows, which matters when the fixtures go into CI.

Seven tools. `generate_from_schema` needs no API key. `seed_database` fills a live Postgres, MySQL or SQLite database from its own schema, inserting parents before children and verifying every foreign key against the database afterwards; it plans first and writes nothing until the user confirms.

### Submission details

- **Licence:** MIT
- **Dockerfile:** in the repo root, pinned at the commit referenced in `server.yaml`
- **Secrets:** all three are `required: false`. Four of the seven tools never call a model and work with nothing configured; a provider key is only needed for the tools that read a plain-English story.
- **Repo:** https://github.com/rasinmuhammed/misata
- **PyPI:** https://pypi.org/project/misata/
- **Docs:** https://www.misata.studio/docs/guides/mcp

### Notes

I do not have a Go toolchain on this machine, so I could not run `task validate` locally. I checked the entry by hand instead: it parses, its key structure and `source` fields match existing entries, the category is one already in use, and the description length sits inside the range of the other 270 entries. Happy to fix anything CI flags.