### PR TITLE
Add codecalc MCP server

### DIFF
--- a/servers/codecalc/server.yaml
+++ b/servers/codecalc/server.yaml
@@ -16,5 +16,5 @@ about:
 source:
   project: https://github.com/The-40-Thieves/codecalc
   branch: mislam2/the-870-docker-mcp-catalog
-  commit: e8a8c36288ead72b932867a5d78cca6eabda7d7d
+  commit: 109f7c4a7059ae8106aec386957578fa8fc7d787
   dockerfile: docker/mcp-server.Dockerfile

--- a/servers/codecalc/server.yaml
+++ b/servers/codecalc/server.yaml
@@ -1,0 +1,20 @@
+name: codecalc
+image: mcp/codecalc
+type: server
+meta:
+  category: devops
+  tags:
+    - code-execution
+    - sandbox
+    - calculator
+    - symbolic-math
+    - devops
+about:
+  title: Codecalc
+  description: Offline code & logic calculator for AI agents - execute code in 13 languages, run symbolic math and SMT logic, and analyze complexity. This image runs codecalc's default rlimit sandbox, not the opt-in gVisor strict isolation boundary (which needs host Docker+runsc outside a container).
+  icon: https://raw.githubusercontent.com/The-40-Thieves/codecalc/main/assets/codecalc-logo.png
+source:
+  project: https://github.com/The-40-Thieves/codecalc
+  branch: mislam2/the-870-docker-mcp-catalog
+  commit: e8a8c36288ead72b932867a5d78cca6eabda7d7d
+  dockerfile: docker/mcp-server.Dockerfile


### PR DESCRIPTION
## What

Adds `servers/codecalc/server.yaml` for [codecalc](https://github.com/The-40-Thieves/codecalc) — an offline, self-hosted MCP server that gives an AI agent a code runner, exact symbolic math, an SMT/logic solver, and complexity analysis (51 MCP tools). Apache-2.0, published on PyPI.

**Docker-built** submission: this PR asks Docker to build, sign, and SBOM the image from the source repo's Dockerfile rather than us hosting it ourselves.

The Dockerfile lives at `docker/mcp-server.Dockerfile` (not the repo root), so `source.dockerfile` in the entry points at it explicitly.

## Honesty note on isolation

This image runs codecalc's **default rlimit sandbox** — the same backend a bare `pip install codecalc` gets. It does **not** run the project's separate opt-in **gVisor+Docker strict isolation boundary**, which needs a host that can launch `runsc`-backed containers itself and so cannot run nested inside this image's own container. This is stated in `about.description` above, in the source repo's Dockerfile header, and in its `docker/README.md`.

## Status of the source PR

`source.commit` in this entry points at [The-40-Thieves/codecalc#194](https://github.com/The-40-Thieves/codecalc/pull/194), which adds the Dockerfile this entry builds. That PR is open but **not yet merged** (intentionally, pending review) — the commit is on a pushed branch and is fetchable from the public repo, which `go run ./cmd/build` confirms below. Happy to update `source.commit`/`source.branch` to point at `main` once it merges, or hold this PR until then if you'd prefer — whichever fits your review flow better.

## Local verification

Ran this repo's own tooling against the entry before opening this PR:

```
$ go run ./cmd/validate --name codecalc
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid

$ go run ./cmd/build --tools codecalc
...
✅ Image built as mcp/codecalc
51 tools found.
```

Also tested independently: `docker build` + a raw MCP stdio `initialize` handshake against the built image, plus `execute_code` calls for `python3` and `node` — all succeeded. Details in the source PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019GD1ozGVriGAmBowzr6nxG