### PR TITLE
Add LicenseGuard remote MCP server

### DIFF
--- a/servers/license-guard/readme.md
+++ b/servers/license-guard/readme.md
@@ -1,0 +1,59 @@
+# LicenseGuard MCP Server
+
+Docs: https://github.com/rccaoki-wq/license-guard
+
+Decides whether an open source dependency's license actually obligates you, given how your project ships.
+
+Generic license scanners answer a different question — *what license is this?* — and then warn on everything. LicenseGuard evaluates the license against your distribution model, so the same license produces different verdicts:
+
+| How you ship | AGPL-3.0 dependency |
+|---|---|
+| SaaS (network-accessible) | **blocked** — §13 network clause |
+| Internal use only | allowed |
+| Distributed binary / on-prem | **blocked** — inherited GPL distribution terms |
+| **devDependency** (never in the artifact) | **allowed** |
+
+That last row is the point: a build-time linter under AGPL never ships, so it triggers nothing. Tools that warn on it anyway train people to ignore every warning they produce.
+
+The same distinctions run through the rest of the license landscape and are not interchangeable:
+
+- **GPL** obligations attach to *distribution*. Running GPL code as a network service is not distribution.
+- **AGPL** adds §13, which attaches to *network interaction* — a separate trigger from GPL's distribution terms.
+- **MPL / EPL / CDDL** are file-scoped and linkage-independent. MPL-2.0 §3.3 explicitly permits distributing a Larger Work under your own terms.
+- **LGPL** is the one that actually depends on linkage: static linking carries a relinking obligation, dynamic linking does not.
+
+## Tools
+
+| Tool | When to call it |
+|---|---|
+| `check_dependency_license` | Before adding a single dependency |
+| `check_manifest_licenses` | To audit a whole manifest or lockfile |
+| `explain_license` | To see what a license requires across every distribution model |
+
+## Coverage
+
+Ecosystems: npm, PyPI, Go modules, crates.io
+
+Manifests: `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `requirements.txt`, `pyproject.toml`, `poetry.lock`, `uv.lock`, `go.mod`, `go.sum`, `Cargo.toml`, `Cargo.lock`
+
+Transitive dependencies are covered from lockfiles. `package-lock.json` v2/v3 embeds a license for every entry, so a full transitive audit runs with zero registry lookups.
+
+Dependencies that cannot be resolved are reported as `not-checked` or `review` and never as `allowed` — an incomplete scan is never presented as clean.
+
+## Access
+
+No authentication. Stateless Streamable HTTP at `https://license-guard.rcc-aoki.workers.dev/mcp`.
+
+Listed in the official MCP registry as `io.github.rccaoki-wq/license-guard`.
+
+## Privacy
+
+Manifest contents, package names and IP addresses are not stored. A local stdio build is also available in the repository for teams that prefer the manifest never to leave their machine — in that mode only package names and versions reach public registries.
+
+## Disclaimer
+
+LicenseGuard provides information derived from published license texts and declared dependency metadata. It is not legal advice, and using it does not create an attorney-client relationship. Verdicts rest on the license information a package declares; they do not claim to identify every obligation or violation.
+
+## License
+
+Apache-2.0

--- a/servers/license-guard/server.yaml
+++ b/servers/license-guard/server.yaml
@@ -1,0 +1,21 @@
+name: license-guard
+type: remote
+meta:
+  category: security
+  tags:
+    - license-compliance
+    - open-source
+    - dependencies
+    - supply-chain
+    - sbom
+    - spdx
+    - remote
+about:
+  title: LicenseGuard
+  description: Decides whether an open source dependency's license actually obligates you, given how your project ships. The same license yields opposite verdicts for hosted SaaS, distributed binaries, on-premises delivery and internal-only use — and a build-time dependency creates no distribution obligation at all. Reads lockfiles so transitive dependencies are covered. Covers npm, PyPI, Go modules and crates.io.
+  icon: https://license-guard.rcc-aoki.workers.dev/favicon.svg
+remote:
+  transport_type: streamable-http
+  url: https://license-guard.rcc-aoki.workers.dev/mcp
+source:
+  project: https://github.com/rccaoki-wq/license-guard

--- a/servers/license-guard/tools.json
+++ b/servers/license-guard/tools.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "check_dependency_license",
+    "description": "Determine whether adding or keeping a single open source dependency creates a legal obligation, given how this project ships. Call this BEFORE adding a new dependency to a project, and when auditing an existing one. A permissive result means no source-disclosure duty; a blocked result means the license obligates you and the dependency should be replaced or the shipping model reconsidered.",
+    "arguments": [
+      {
+        "name": "ecosystem",
+        "type": "string",
+        "desc": "Package registry the dependency comes from: npm, pypi, go or cargo",
+        "required": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "Package name as written in the manifest, e.g. \"express\", \"requests\", \"github.com/gin-gonic/gin\"",
+        "required": true
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "desc": "Exact version if known. Omit to use the latest published version, which is disclosed in the result",
+        "required": false
+      },
+      {
+        "name": "distribution_model",
+        "type": "string",
+        "desc": "How the software reaches its users: saas, distributed-binary, on-prem-delivery, internal-only or library-published. This determines the answer",
+        "required": true
+      },
+      {
+        "name": "scope",
+        "type": "string",
+        "desc": "Where the dependency sits. One of runtime, dev, build, test, optional. Use dev, build or test for anything that does not end up in the shipped artifact",
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "check_manifest_licenses",
+    "description": "Scan an entire dependency manifest and report every dependency whose license creates an obligation for this shipping model. Use when reviewing a project as a whole, preparing for due diligence, or after a large dependency change. Pass a package-lock.json when one exists: problematic licenses usually arrive as transitive dependencies rather than ones you added directly, and only a lockfile reveals those.",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Full text of a lockfile or manifest. Accepted: package-lock.json, pnpm-lock.yaml, yarn.lock, requirements.txt, pyproject.toml, poetry.lock, uv.lock, go.mod, go.sum, Cargo.toml, Cargo.lock",
+        "required": true
+      },
+      {
+        "name": "distribution_model",
+        "type": "string",
+        "desc": "How the software reaches its users: saas, distributed-binary, on-prem-delivery, internal-only or library-published",
+        "required": true
+      }
+    ]
+  },
+  {
+    "name": "explain_license",
+    "description": "Given an SPDX license identifier or expression, explain what it requires across every shipping model at once. Use when the question is about the license itself rather than a specific package — for example when comparing AGPL-3.0 against GPL-3.0 for a hosted service, or deciding what a project may safely depend on.",
+    "arguments": [
+      {
+        "name": "license",
+        "type": "string",
+        "desc": "SPDX identifier or expression, e.g. \"AGPL-3.0-only\", \"Apache-2.0\", or \"(MIT OR GPL-2.0-only)\"",
+        "required": true
+      },
+      {
+        "name": "linkage",
+        "type": "string",
+        "desc": "How the dependency is linked: dynamic, static or separate-process. Matters for LGPL-family licenses",
+        "required": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds LicenseGuard as a remote MCP server.

**What it does:** decides whether an open source dependency's license actually obligates you, *given how your project ships*. Generic license scanners answer "what license is this?" and warn on everything. LicenseGuard evaluates the license against the distribution model, so the same license produces different verdicts:

| How you ship | AGPL-3.0 dependency |
|---|---|
| SaaS (network-accessible) | blocked — §13 network clause |
| Internal use only | allowed |
| Distributed binary / on-prem | blocked — inherited GPL distribution terms |
| devDependency (never in the artifact) | allowed |

That last row is the point: a build-time linter under AGPL never ships, so it triggers nothing. Tools that warn on it anyway train people to ignore every warning they produce.

**Files:** `servers/license-guard/{server.yaml,tools.json,readme.md}`

- `type: remote`, `transport_type: streamable-http`, no OAuth and no auth of any kind, so `oauth` and `dynamic.tools` are omitted.
- `tools.json` lists the three tools with their real argument names and enum values, taken from a live `tools/list` response rather than written by hand.
- Endpoint is publicly reachable: `https://license-guard.rcc-aoki.workers.dev/mcp` (POST; GET returns 405 by design, since the server offers no SSE stream).
- Docs URL and icon URL both verified reachable.

**Licensing:** the server is Apache-2.0. This contribution is MIT.

**Elsewhere:** published in the official MCP registry as `io.github.rccaoki-wq/license-guard`, and scored `A` for quality and `A` for license on Glama.

**Coverage:** npm, PyPI, Go modules, crates.io. Reads `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `requirements.txt`, `pyproject.toml`, `poetry.lock`, `uv.lock`, `go.mod`, `go.sum`, `Cargo.toml`, `Cargo.lock`, so transitive dependencies are covered — which matters here, because problem licenses usually arrive as a dependency of a dependency rather than one you added on purpose.

**Privacy:** manifest contents, package names and IP addresses are not stored.

Output is limited to factual statements citing license clauses; it is not legal advice and does not claim completeness. The readme states this.
