### PR TITLE
Add OneDroid Engram (remote)

### DIFF
--- a/servers/onedroid-engram/server.yaml
+++ b/servers/onedroid-engram/server.yaml
@@ -1,0 +1,20 @@
+name: onedroid-engram
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: ai
+  tags:
+    - ai
+    - memory
+    - context
+    - postgres
+    - audit
+    - remote
+about:
+  title: OneDroid Engram
+  description: Versioned, portable agent memory that lives in your own Postgres. Search and write durable context across sessions and across agents, with permissions and an append-only audit trail. Bring your own database, so the memory and its history stay yours.
+  icon: https://www.google.com/s2/favicons?domain=onedroid.ai&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://engram.onedroid.ai/mcp


### PR DESCRIPTION
Adds `servers/onedroid-engram/server.yaml`.

**What it is:** versioned, portable agent memory that lives in the user's own Postgres — search and write durable context across sessions and across agents, with permissions and an append-only audit trail.

**Type:** `remote` — the server is hosted by us at `https://engram.onedroid.ai/mcp` over streamable-http, so no image is built and Docker hosts nothing.

**Licence:** Apache-2.0.

**Auth:** standard MCP OAuth. The server advertises `/.well-known/oauth-protected-resource` (RFC 9728), and its authorization-server metadata offers dynamic client registration, PKCE S256 and the device-code grant — so no vendor-specific OAuth provider entry is needed.

Homepage: https://onedroid.ai/engram
