### PR TITLE
Add BananaBanana remote MCP server

### DIFF
--- a/servers/bananabanana/readme.md
+++ b/servers/bananabanana/readme.md
@@ -1,0 +1,1 @@
+Docs: https://bananabanana.pro/mcp

--- a/servers/bananabanana/server.yaml
+++ b/servers/bananabanana/server.yaml
@@ -1,0 +1,28 @@
+name: bananabanana
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: media
+  tags:
+    - media
+    - image-generation
+    - video-generation
+    - text-to-speech
+    - ai
+    - remote
+about:
+  title: BananaBanana
+  description: Generate images (Nano Banana 2 / Pro), videos with sound (Veo 3.1, Omni Flash) and speech (Gemini TTS) pay-as-you-go, with a cost quote before every expensive call and automatic refunds on failure.
+  icon: https://bananabanana.pro/mcp-icon-512.png
+remote:
+  transport_type: streamable-http
+  url: https://bananabanana.pro/api/mcp
+  headers:
+    Authorization: Bearer ${BANANABANANA_API_KEY}
+config:
+  description: Create an API key in the API Keys section of your BananaBanana profile (https://bananabanana.pro/profile). Generations are billed from that account balance.
+  secrets:
+    - name: bananabanana.api_key
+      env: BANANABANANA_API_KEY
+      example: <BANANABANANA_API_KEY>

--- a/servers/bananabanana/tools.json
+++ b/servers/bananabanana/tools.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "list_models",
+    "description": "List all available image, video and speech generation models with current per-unit USD prices, supported resolutions, durations and constraints.",
+    "arguments": []
+  },
+  {
+    "name": "get_account",
+    "description": "Get the current account balance (USD), this API key's name, optional daily spend cap and how much of it is used today.",
+    "arguments": []
+  },
+  {
+    "name": "top_up",
+    "description": "Get a balance top-up link. OAuth connections receive a one-time deposit-only link valid for 30 minutes; opening it cannot expose API keys, profile data or generation history.",
+    "arguments": []
+  },
+  {
+    "name": "generate_image",
+    "description": "Start an AI image generation (Google Nano Banana family).",
+    "arguments": []
+  },
+  {
+    "name": "edit_image",
+    "description": "Edit / refine a previously generated image with a text instruction on Nano Banana 2 Lite / 2 / Pro (multi-turn editing: change colors, remove objects, restyle, etc.).",
+    "arguments": []
+  },
+  {
+    "name": "generate_video",
+    "description": "Start an AI video generation (Google Veo 3.1 family or Gemini Omni Flash).",
+    "arguments": []
+  },
+  {
+    "name": "edit_video",
+    "description": "Edit an EXISTING video with Gemini Omni Flash (video-to-video): restyle it, replace or add objects, relight the scene, change the mood — motion and composition of the source clip are preserved.",
+    "arguments": []
+  },
+  {
+    "name": "generate_speech",
+    "description": "Generate natural speech with Gemini 3.1 Flash TTS Preview.",
+    "arguments": []
+  },
+  {
+    "name": "get_result",
+    "description": "Get the status and result of a generation job started with generate_image / edit_image / generate_video / edit_video.",
+    "arguments": []
+  },
+  {
+    "name": "list_generations",
+    "description": "List this account's recent generations (both MCP and website) — id, type, model, status, cost and prompt preview.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** bananabanana
**Repository URL:** https://github.com/bananabanana-pro/bananabanana-mcp (documentation repo — this is a hosted remote server, there is no container to build)
**Remote endpoint:** `https://bananabanana.pro/api/mcp` (streamable-http)
**Docs:** https://bananabanana.pro/mcp
**Brief Description:** Remote MCP server for AI media generation — images (Google Nano Banana 2 Lite / 2 / Pro), video with native audio (Veo 3.1 family, Gemini Omni Flash, including video-to-video editing) and speech (Gemini 3.1 Flash TTS). Pay-as-you-go from an account balance: `list_models` returns live prices, expensive calls (video, batches) return a cost quote first and charge nothing until the agent confirms, and failed generations are refunded automatically.

## Basic Requirements

- [x] **Open Source**: Documentation, examples and `server.json` are Apache-2.0 (https://github.com/bananabanana-pro/bananabanana-mcp). The server itself is hosted, so no image is built by Docker.
- [x] **MCP Compliant**: Streamable HTTP (stateless JSON responses), MCP spec `2025-06-18`. Also published in the official MCP registry as `pro.bananabanana/image-video` (DNS-verified namespace).
- [x] **Active Development**: Server is in production and actively maintained.
- [ ] **Docker Artifact**: N/A — remote server, no Dockerfile required.
- [x] **Documentation**: https://bananabanana.pro/mcp plus README, `docs/` and `examples/` in the docs repo.
- [x] **Security Contact**: support@bananabanana.pro

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name bananabanana`
- [x] I have built the MCP Server using `task build -- --tools bananabanana` (skipped for remote server, as expected) and `task catalog -- bananabanana`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes for reviewers

- `tools/list`, `initialize` and `ping` are answered **without** a token, so tool discovery works out of the box; `tools/call` requires `Authorization: Bearer bb_live_…` (created at https://bananabanana.pro/profile) — hence the `headers` + `config.secrets` block.
- The server also implements OAuth 2.1 (DCR + PKCE, RFC 9728 protected-resource metadata) for clients that support it; the catalog entry uses the API-key header because that path works for every Docker MCP Toolkit user today.
- A test API key with a small daily spend cap can be provided on request via the credentials form.
