### PR TITLE
Add OneDroid Synapse (remote)

### DIFF
--- a/servers/onedroid-synapse/server.yaml
+++ b/servers/onedroid-synapse/server.yaml
@@ -1,0 +1,27 @@
+name: onedroid-synapse
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: security
+  tags:
+    - security
+    - governance
+    - gateway
+    - audit
+    - credentials
+    - remote
+about:
+  title: OneDroid Synapse
+  description: A governed MCP gateway. Connect Jira, Slack, Confluence, Google Workspace, Postgres and more through one endpoint, with credential custody, tool-level allow and deny rules, and an append-only audit log of what every agent called.
+  icon: https://www.google.com/s2/favicons?domain=onedroid.ai&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://synapse.onedroid.ai/mcp
+  headers:
+    Authorization: "Bearer ${SYNAPSE_TOKEN}"
+config:
+  secrets:
+    - name: synapse.token
+      env: SYNAPSE_TOKEN
+      example: <YOUR_SYNAPSE_PERSONAL_ACCESS_TOKEN>

--- a/servers/onedroid-synapse/server.yaml
+++ b/servers/onedroid-synapse/server.yaml
@@ -17,7 +17,7 @@ about:
   icon: https://www.google.com/s2/favicons?domain=onedroid.ai&sz=64
 remote:
   transport_type: streamable-http
-  url: https://synapse.onedroid.ai/mcp
+  url: https://synapse.onedroid.ai/agent/mcp
   headers:
     Authorization: "Bearer ${SYNAPSE_TOKEN}"
 config:


### PR DESCRIPTION
Adds `servers/onedroid-synapse/server.yaml`.

**What it is:** a governed MCP gateway. One endpoint fronts many upstream tools (Jira, Slack, Confluence, Google Workspace, Postgres and others) with credential custody, tool-level allow/deny rules, and an append-only audit log of what every agent called.

**Type:** `remote` — hosted by us at `https://synapse.onedroid.ai/mcp` over streamable-http, so no image is built and Docker hosts nothing.

**Auth:** bearer personal access token, following the same shape as `servers/needle/server.yaml` (`remote.headers` + `config.secrets`). The token identifies the user's hub, so a single fixed URL works for every user — verified against the live service: `initialize` returns HTTP 200 and `tools/list` returns the caller's full tool set.

**Licence:** Apache-2.0.

Homepage: https://onedroid.ai/
