### PR TITLE
fix(deepwiki): use Streamable HTTP endpoint

### DIFF
--- a/servers/deepwiki/server.yaml
+++ b/servers/deepwiki/server.yaml
@@ -12,5 +12,5 @@ about:
   description: Tools for fetching and asking questions about GitHub repositories.
   icon: https://devin.ai/apple-icon.png
 remote:
-  transport_type: sse
-  url: https://mcp.deepwiki.com/sse
+  transport_type: streamable-http
+  url: https://mcp.deepwiki.com/mcp


### PR DESCRIPTION
## Summary

- update DeepWiki's remote transport from `sse` to `streamable-http`
- switch the endpoint from `https://mcp.deepwiki.com/sse` to `https://mcp.deepwiki.com/mcp`

This matches DeepWiki's current documentation, which recommends the `/mcp` Streamable HTTP endpoint and marks `/sse` as a legacy protocol being deprecated.

Fixes #4735

## Validation

- Confirmed the endpoint and transport against the official DeepWiki MCP documentation.
- Verified the PR changes only `servers/deepwiki/server.yaml` (2 additions, 2 deletions).
- Upstream GitHub Actions is currently awaiting approval before the forked PR workflows can run.