### PR TITLE
Add Animica (remote MCP server)

### DIFF
--- a/servers/animica/readme.md
+++ b/servers/animica/readme.md
@@ -1,0 +1,1 @@
+Docs: https://animica.org/blockchain-mcp-server/

--- a/servers/animica/server.yaml
+++ b/servers/animica/server.yaml
@@ -1,0 +1,17 @@
+name: animica
+type: remote
+meta:
+  category: blockchain
+  tags:
+    - blockchain
+    - post-quantum
+    - ai-inference
+    - quantum-rng
+    - remote
+about:
+  title: Animica
+  description: Read-only access to the Animica post-quantum L1 blockchain (head, blocks, transactions, balances, richlist), free OpenAI-compatible AI inference, a quantum RNG beacon, and mining-pool stats. 16 tools, no private keys, no auth required.
+  icon: https://animica.org/logo.png
+remote:
+  transport_type: streamable-http
+  url: https://mcp.animica.org/mcp


### PR DESCRIPTION
Adds **Animica** as a remote MCP server (`servers/animica/`).

- Remote streamable-http endpoint: https://mcp.animica.org/mcp — public, no auth, no secrets; tools are listed dynamically.
- Source: https://github.com/animicaorg/animica-mcp (Apache-2.0); PyPI `animica-mcp`; official MCP registry `io.github.animicaorg/animica`.
- 16 read-only tools for the Animica post-quantum L1 blockchain (head, blocks, transactions, balances, richlist), free OpenAI-compatible AI inference, a quantum RNG beacon and mining-pool stats. No private keys.
- Docs: https://animica.org/blockchain-mcp-server/ · Security contact: see `info.contact` in https://animica.dev/openapi.json

- [x] The server is open source (Apache-2.0)
- [x] It is MCP compliant (streamable HTTP, passes `tools/list` introspection; also listed on Glama and the official registry)
- [x] Actively maintained
- [x] Documentation available
- [x] Security contact available
