### PR TITLE
docs: fix Dynatrace description typo

### DIFF
--- a/servers/dynatrace-mcp-server/server.yaml
+++ b/servers/dynatrace-mcp-server/server.yaml
@@ -9,7 +9,7 @@ meta:
     - Monitoring
 about:
   title: Dynatrace
-  description: This MCP Server allows interaction with the Dynatrace observability platform, brining real-time observability data directly into your development workflow.
+  description: This MCP Server allows interaction with the Dynatrace observability platform, bringing real-time observability data directly into your development workflow.
   icon: https://avatars.githubusercontent.com/u/58178984?s=200&v=4
 source:
   project: https://github.com/dynatrace-oss/dynatrace-mcp


### PR DESCRIPTION
## Summary

Correct `brining` to `bringing` in the Dynatrace MCP server catalog description.

## Testing

- `go test ./...`
- `go run ./cmd/validate --name dynatrace-mcp-server`
- `prettier --check servers/dynatrace-mcp-server/server.yaml`
- `git diff origin/main..HEAD --check`
