### PR TITLE
Add Financial Evidence MCP server

### DIFF
--- a/servers/financial-evidence/server.yaml
+++ b/servers/financial-evidence/server.yaml
@@ -16,4 +16,4 @@ about:
   icon: https://avatars.githubusercontent.com/u/215868371?v=4
 source:
   project: https://github.com/beepboop2025/financial-evidence-skills
-  commit: d1685f5ba8551119c335c60989cd6fcf079816c0
+  commit: 9f83ac55946b78fd61e55367fe08304621e9decd

--- a/servers/financial-evidence/server.yaml
+++ b/servers/financial-evidence/server.yaml
@@ -16,4 +16,4 @@ about:
   icon: https://avatars.githubusercontent.com/u/215868371?v=4
 source:
   project: https://github.com/beepboop2025/financial-evidence-skills
-  commit: 9f83ac55946b78fd61e55367fe08304621e9decd
+  commit: 970310037c75ed68d84665373a852f71eaa3e03a

--- a/servers/financial-evidence/server.yaml
+++ b/servers/financial-evidence/server.yaml
@@ -16,4 +16,4 @@ about:
   icon: https://avatars.githubusercontent.com/u/215868371?v=4
 source:
   project: https://github.com/beepboop2025/financial-evidence-skills
-  commit: f3ebb5b9ef872af20ab327a5ca293a1c92e90207
+  commit: d1685f5ba8551119c335c60989cd6fcf079816c0

--- a/servers/financial-evidence/server.yaml
+++ b/servers/financial-evidence/server.yaml
@@ -1,0 +1,19 @@
+name: financial-evidence
+image: mcp/financial-evidence
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - financial-data
+    - money-markets
+    - capital-markets
+    - china-economy
+    - read-only
+about:
+  title: Financial Evidence
+  description: Read-only discovery and evidence routing across LiquiLens, Undertow, Seiche, and Palimpsest for money markets, capital markets, China economy, bank risk, and market liquidity.
+  icon: https://avatars.githubusercontent.com/u/215868371?v=4
+source:
+  project: https://github.com/beepboop2025/financial-evidence-skills
+  commit: f3ebb5b9ef872af20ab327a5ca293a1c92e90207


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Financial Evidence
**Repository URL:** https://github.com/beepboop2025/financial-evidence-skills
**Brief Description:** Read-only evidence discovery and routing across LiquiLens, Undertow, Seiche, and Palimpsest for money markets, capital markets, China economy, bank risk, and market liquidity.

## Basic Requirements

- [x] **Open Source**: MIT licensed
- [x] **MCP Compliant**: stdio MCP server with three read-only tools
- [x] **Active Development**: current release and exact source commit
- [x] **Docker Artifact**: top-level Dockerfile at the pinned commit
- [x] **Documentation**: README includes terminal, MCP, OpenBB, DuckDB, Excel, and FDC3 setup
- [x] **Security Contact**: GitHub security policy and private vulnerability reporting

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `go run ./cmd/validate --name financial-evidence`
- [x] I have built the MCP Server using `task build -- --tools financial-evidence` through the public fork copy of this repository canonical CI.
- [x] No credentials are required; all routed sources are public and the tools are read-only.

### Evidence

- Source release: [`v0.1.4`](https://github.com/beepboop2025/financial-evidence-skills/releases/tag/v0.1.4)
- Source commit: `970310037c75ed68d84665373a852f71eaa3e03a`
- Registry validation: all checks passed locally (name, directory, title, YAML, pinned commit, secrets, config, MIT license, icon)
- Source CI: Python 3.10/3.14, OpenBB extension, Docker build, MCP tool discovery, and MCPB pack all passed at the pinned commit
- Catalog CI: [public fork run 32722163211](https://github.com/beepboop2025/mcp-registry/actions/runs/32722163211) passed unit tests, Docker build, MCP tool discovery, manifest validation, and catalog generation using the copied upstream workflow
- Official MCP Registry package: `io.github.beepboop2025/financial-evidence`