### PR TITLE
Add LiquiLens Evidence Carrier MCP server

### DIFF
--- a/servers/liquilens-evidence-carrier/server.yaml
+++ b/servers/liquilens-evidence-carrier/server.yaml
@@ -1,0 +1,34 @@
+name: liquilens-evidence-carrier
+image: ghcr.io/beepboop2025/liquilens-evidence-carrier-mcp@sha256:d55f69e55e579603ae8b510de76b1191047427a92569424a17729ea7f7e3e2f7
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - financial-data
+    - evidence
+    - provenance
+    - read-only
+    - offline
+about:
+  title: LiquiLens Evidence Carrier
+  description: Offline, read-only verification and rights-bounded projection of local financial evidence carrier JSON
+  icon: https://avatars.githubusercontent.com/u/215868371?v=4
+source:
+  project: https://github.com/beepboop2025/liquilens-evidence-carrier
+  commit: 25d2fbcf180c70816d9e60c3590854f887449c79
+  dockerfile: Dockerfile.mcp
+run:
+  volumes:
+    - "{{liquilens-evidence-carrier.evidence_root}}:/evidence:ro"
+  disableNetwork: true
+config:
+  description: Select the local evidence directory the server may inspect read-only
+  parameters:
+    type: object
+    properties:
+      evidence_root:
+        type: string
+        description: Absolute path to the local directory containing financial evidence carrier JSON files
+    required:
+      - evidence_root

--- a/servers/liquilens-evidence-carrier/server.yaml
+++ b/servers/liquilens-evidence-carrier/server.yaml
@@ -1,5 +1,5 @@
 name: liquilens-evidence-carrier
-image: ghcr.io/beepboop2025/liquilens-evidence-carrier-mcp@sha256:d55f69e55e579603ae8b510de76b1191047427a92569424a17729ea7f7e3e2f7
+image: ghcr.io/beepboop2025/liquilens-evidence-carrier-mcp@sha256:4e4ffb010b52375b3203b2dc43706c7fa508de2bf8368eca465f49d56392dcea
 type: server
 meta:
   category: finance
@@ -16,7 +16,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/215868371?v=4
 source:
   project: https://github.com/beepboop2025/liquilens-evidence-carrier
-  commit: 25d2fbcf180c70816d9e60c3590854f887449c79
+  commit: d114d63a01778d3b8433534fe540864b32f9b056
   dockerfile: Dockerfile.mcp
 run:
   volumes:


### PR DESCRIPTION
## MCP Server Information

**Server Name:** LiquiLens Evidence Carrier
**Repository URL:** https://github.com/beepboop2025/liquilens-evidence-carrier
**Brief Description:** Offline, read-only verification and rights-bounded projection of local financial evidence carrier JSON. Users explicitly select one host evidence directory, mounted read-only; container networking is disabled.

## Basic Requirements

- [x] **Open Source**: Apache-2.0 at the pinned source commit
- [x] **MCP Compliant**: stdio MCP server with three read-only verification/projection tools
- [x] **Active Development**: signed v0.15.0 release and exact image source revision
- [x] **Docker Artifact**: Dockerfile.mcp at the pinned source commit
- [x] **Documentation**: README, protocol documentation, install and MCP setup instructions
- [x] **Security Contact**: SECURITY.md and GitHub private vulnerability reporting

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server metadata using `go run ./cmd/validate --name liquilens-evidence-carrier`.
- [ ] Docker catalog CI must still execute the repository `build --tools --pull-community` path; the exact immutable image has already passed its protected-main build, metadata verification, and runtime smoke tests.
- [x] No credentials are required. The server has no network access, mounts only the user-selected evidence directory read-only, and performs no collection or financial action.

### Evidence

- Catalog commit: `1fd371d0c7e97cb622961e3076c6a4d17c8fc6be`
- Image source revision: `d114d63a01778d3b8433534fe540864b32f9b056`
- Carrier release revision: `0d852c06b1a4b0be566c8b4586c9c4c8b8f8f31c` (`v0.15.0`)
- Immutable multi-architecture image: `ghcr.io/beepboop2025/liquilens-evidence-carrier-mcp@sha256:4e4ffb010b52375b3203b2dc43706c7fa508de2bf8368eca465f49d56392dcea`
- Image platforms: linux/amd64 and linux/arm64; non-root UID/GID 65532:65532
- Image publication, attestation, exact-digest no-network/read-only runtime: https://github.com/beepboop2025/liquilens-evidence-carrier/actions/runs/32897003998
- Base CLI image digest: `sha256:d92d7b31850f1788ae910d56035137e422e331f7e07516cce5b546674dbde00a`
- Official MCP Registry v0.15.0: https://registry.modelcontextprotocol.io/v0/servers/io.github.beepboop2025%2Fliquilens-evidence-carrier/versions/0.15.0
- Local catalog validator: all checks passed (name, directory, title, YAML, commit pin, secrets, config, license, icon, and OAuth configuration)
- No test credentials are needed.
