### PR TITLE
Add SSH server

### DIFF
--- a/servers/ssh/server.yaml
+++ b/servers/ssh/server.yaml
@@ -1,0 +1,37 @@
+name: ssh
+image: mcp/ssh
+type: server
+meta:
+  category: devops
+  tags:
+    - ssh
+    - devops
+    - remote-execution
+    - sysadmin
+about:
+  title: SSH
+  description: Remote server work over SSH — run commands, move files with checksum verification, search logs and audit hosts, from a cloud VPS down to a BusyBox router. Destructive commands are checked before they reach the shell.
+  icon: https://raw.githubusercontent.com/hypnosis/ssh-mcp-server/main/assets/icon-512.png
+source:
+  project: https://github.com/hypnosis/ssh-mcp-server
+  commit: dd548340622b35b61716f386652cd19ab9a263d4
+run:
+  volumes:
+    - "{{ssh.profiles_file}}:/profiles/ssh-profiles.json:ro"
+    - "{{ssh.ssh_directory}}:/home/node/.ssh:ro"
+config:
+  description: The profiles file naming the machines this server may reach, and the SSH directory holding the keys those profiles use. Inside the container the keys are at /home/node/.ssh, so let each profile's privateKeyPath point there.
+  env:
+    - name: SSH_PROFILES_FILE
+      example: /profiles/ssh-profiles.json
+      value: /profiles/ssh-profiles.json
+  parameters:
+    type: object
+    properties:
+      profiles_file:
+        type: string
+      ssh_directory:
+        type: string
+    required:
+      - profiles_file
+      - ssh_directory

--- a/servers/ssh/server.yaml
+++ b/servers/ssh/server.yaml
@@ -14,7 +14,7 @@ about:
   icon: https://raw.githubusercontent.com/hypnosis/ssh-mcp-server/main/assets/icon-512.png
 source:
   project: https://github.com/hypnosis/ssh-mcp-server
-  commit: dd548340622b35b61716f386652cd19ab9a263d4
+  commit: 09c6ca27f736c591acdd4d529e1949c2857d4caa
 run:
   volumes:
     - "{{ssh.profiles_file}}:/profiles/ssh-profiles.json:ro"
@@ -25,6 +25,9 @@ config:
     - name: SSH_PROFILES_FILE
       example: /profiles/ssh-profiles.json
       value: /profiles/ssh-profiles.json
+    - name: SSH_MCP_CONTROL_DIR
+      example: /tmp/ssh-mcp
+      value: /tmp/ssh-mcp
   parameters:
     type: object
     properties:


### PR DESCRIPTION
Adds [ssh-mcp-server](https://github.com/hypnosis/ssh-mcp-server) as `servers/ssh`, Docker-built (Option A).

## What it does

Remote server work over SSH, driven by the OpenSSH client inside the container: run commands, move files with sha256 verification, search logs, follow long-running jobs, and audit hosts — from a cloud VPS down to a BusyBox router. Destructive commands are checked before they reach the shell. 18 tools, structured output with a legend for every field.

MIT licensed, published on npm as `@hypnosis/ssh-mcp-server`, listed in the official MCP registry as `io.github.hypnosis/ssh-mcp-server`. The pinned commit is release tag `v2.3.1`.

## Configuration

Two host paths, both mounted read-only: the profiles file naming the machines the server may reach, and the user's `.ssh` directory holding the keys those profiles use. Nothing is baked into the image, and no credentials leave the machine.

## What I verified locally

- `go run ./cmd/validate -name ssh` — all checks pass (name, directory, title, YAML formatting, pinned commit, secrets, config env, license, icon)
- `go run ./cmd/build -tools ssh` — image builds as `mcp/ssh`, 18 tools found
- Live run: the built container mounted a key, connected to a test SSH host and returned `exit_code 0` from a real command — so it connects, not just starts

## For the reviewer

No external service or account is needed. Any SSH host works: mount a key and a profiles file naming that host, then call `ssh_exec`. The repository ships a two-container lab (`npm run lab:up`, BusyBox and coreutils) if you want a disposable target, and the profiles file shape is documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)