### PR TITLE
Add markdown-to-whatsapp MCP server

### DIFF
--- a/servers/markdown-to-whatsapp/server.yaml
+++ b/servers/markdown-to-whatsapp/server.yaml
@@ -1,0 +1,23 @@
+name: markdown-to-whatsapp
+image: mcp/markdown-to-whatsapp
+type: server
+meta:
+  category: productivity
+  tags:
+    - markdown
+    - whatsapp
+    - messaging
+    - formatting
+    - conversion
+about:
+  title: Markdown to WhatsApp
+  description: >-
+    Converts Markdown into the formatting WhatsApp actually renders: bold,
+    italic, strikethrough, monospace, lists and quotes. Tables are drawn as
+    monospace boxes sized to the reader's bubble width, degrading through
+    padding removal, borderless layouts and word-wrapped cells before falling
+    back to a bulleted list. Read-only, no network access and no API key.
+  icon: https://avatars.githubusercontent.com/u/471234?s=200&v=4
+source:
+  project: https://github.com/drsound/markdown-to-whatsapp
+  commit: e5dc6417f380efd7e14be808084788428e365934


### PR DESCRIPTION
Adds `servers/markdown-to-whatsapp/server.yaml` for a local (containerized) server.

**What it does.** WhatsApp is not a Markdown renderer: it has its own small syntax and no table support at all, so an agent writing to WhatsApp emits `**bold**` and `| col | col |` and the recipient reads the asterisks. This converts Markdown into what WhatsApp actually renders, and the interesting part is tables — a WhatsApp bubble fits about 26 monospace characters on a line and a chat has no horizontal scroll, so a table is drawn as a box that degrades in steps (cell padding removed, then borders, then cells word-wrapped) and falls back to a bulleted list only when no box fits. Column widths are measured in display cells rather than characters, so emoji and CJK text stay aligned.

**Checklist**

- MIT licensed, in the repo since the initial commit.
- Dockerfile at the root of the source repository, entrypoint `node bin/markdown-to-whatsapp.js mcp` over stdio.
- One tool, `convert_markdown_to_whatsapp`, read-only. No network access, no API key, no secrets, no volumes, so the entry needs no `config` block.
- Pinned to commit `e5dc641`, which is tag `v1.0.3`.
- Also published to the official MCP registry as `io.github.drsound/markdown-to-whatsapp`.

Note: I could not run `task create` because there is no Docker on this machine, so the `server.yaml` is hand-written against the shape in CONTRIBUTING.md and `servers/markdownify/server.yaml`. The same Dockerfile does build and pass an introspection check on Glama, which runs the equivalent test. Happy to adjust anything CI or the review flags.

https://claude.ai/code/session_015HvJUrFZRZHT8SYVrpuYrh