### PR TITLE
Add Ripen MCP server

### DIFF
--- a/servers/ripen/server.yaml
+++ b/servers/ripen/server.yaml
@@ -1,0 +1,40 @@
+name: ripen
+image: ghcr.io/frankieramirez/ripen:v1.0.0
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - containers
+    - docker
+    - compose
+    - portainer
+about:
+  title: Ripen
+  description: Ripen, a fail-closed image updater
+  icon: https://avatars.githubusercontent.com/u/915310?s=200&v=4
+source:
+  project: https://github.com/frankieramirez/ripen
+  commit: 31dfb794165fadcefd64cd7803f3c79cef91baf6
+run:
+  command:
+    - mcp
+    - --config
+    - /config/policy.yaml
+  volumes:
+    - "{{ripen.policy_path}}:/config/policy.yaml:ro"
+    - "{{ripen.state_path}}:/data:ro"
+config:
+  description: The Ripen policy file and state directory, both mounted read-only. The policy's state_file must be the container path /data/ripen.db.
+  parameters:
+    type: object
+    properties:
+      policy_path:
+        type: string
+        description: Host path to policy.yaml
+      state_path:
+        type: string
+        description: Host path to the directory that holds ripen.db
+    required:
+      - policy_path
+      - state_path

--- a/servers/ripen/tools.json
+++ b/servers/ripen/tools.json
@@ -1,0 +1,85 @@
+[
+  {
+    "name": "status",
+    "description": "Every configured service with its baseline digest, candidate, pending proposal, and last result, plus the circuit breaker and the effective policy. Maps to the `ripen status` command.",
+    "annotations": {
+      "title": "Ripen status",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "candidates",
+    "description": "Digests under observation and whether each has matured past the waiting window. Maps to the `ripen candidates` command.",
+    "annotations": {
+      "title": "Ripen candidates",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "audit",
+    "description": "What Ripen has done, newest first, from the durable audit trail. Maps to the `ripen audit` command.",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "number",
+        "desc": "maximum attempts to return; defaults to 50",
+        "optional": true
+      },
+      {
+        "name": "cursor",
+        "type": "string",
+        "desc": "continue from a previous page's next_cursor",
+        "optional": true
+      },
+      {
+        "name": "run",
+        "type": "string",
+        "desc": "only attempts from one run id",
+        "optional": true
+      },
+      {
+        "name": "backend",
+        "type": "string",
+        "desc": "only attempts for one backend",
+        "optional": true
+      },
+      {
+        "name": "stack",
+        "type": "string",
+        "desc": "only attempts for one stack",
+        "optional": true
+      },
+      {
+        "name": "service",
+        "type": "string",
+        "desc": "only attempts for one service",
+        "optional": true
+      },
+      {
+        "name": "result",
+        "type": "string",
+        "desc": "only attempts with one result code",
+        "optional": true
+      }
+    ],
+    "annotations": {
+      "title": "Ripen audit trail",
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "explain",
+    "description": "Why the next run would, or would not, act on one stack, with the blockers listed in the order a run would hit them. Reads policy and state only. Maps to the `ripen explain <stack>` command.",
+    "arguments": [
+      {
+        "name": "stack",
+        "type": "string",
+        "desc": "the stack name as the policy declares it"
+      }
+    ],
+    "annotations": {
+      "title": "Explain a stack",
+      "readOnlyHint": true
+    }
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ripen
**Repository URL:** https://github.com/frankieramirez/ripen
**Brief Description:** Ripen, a fail-closed image updater. Read-only MCP over stdio: status, candidates, audit, explain. Apply mode and circuit-breaker clearing have no tools.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

Self-hosted image `ghcr.io/frankieramirez/ripen:v1.0.0` (not `mcp/`). `source.commit` is the annotated `v1.0.0` tag.

`task validate -- --name ripen` is green locally. `tools.json` is the four read tools: `ripen mcp` opens the policy at process start, so a live tools list needs a mounted `policy.yaml` that CI does not provide. No credentials: the listing is read-only (`command: [mcp]`, no `--enable-writes`). Test credentials form not used.

Merge is not gated on our side.