### PR TITLE
Add Vedaksha: astronomical ephemeris and Vedic astrology, 17 tools

### DIFF
--- a/servers/vedaksha/server.yaml
+++ b/servers/vedaksha/server.yaml
@@ -1,0 +1,37 @@
+name: vedaksha
+image: mcp/vedaksha
+type: server
+meta:
+  category: data-analytics
+  tags:
+    - astronomy
+    - ephemeris
+    - astrology
+    - jyotish
+    - panchang
+    - rust
+    - offline
+about:
+  title: Vedaksha
+  description: |
+    Astronomical ephemeris and Vedic astrology (Jyotish) engine, written in Rust and exposed as 17 MCP tools.
+
+    Tools:
+    • Natal charts with houses, aspects, dignities and nakshatras
+    • Panchanga: tithi, vara, nakshatra, yoga, karana
+    • Vimshottari dashas, vargas (divisional charts) and ashtakavarga
+    • Transits, transit search and muhurta search over a date range
+    • Shadbala, karakas, combustion, drishti, bhavas
+    • Synastry and composite charts
+
+    Positions come from a clean-room implementation of VSOP87 and ELP/MPP02, with optional JPL SPK kernels, validated against JPL Horizons on a committed 24,350-row fixture; the SPK path agrees to 0.103 arcsec. Eleven sidereal ayanamsha systems are each derived forward from a primary source rather than tuned to match another implementation, and the derivation for each is recorded in the repository.
+
+    Runs entirely offline in the container: no network calls, no telemetry, no API keys and no configuration.
+  icon: https://avatars.githubusercontent.com/u/268800574?s=200&v=4
+source:
+  project: https://github.com/arthiqlabs/vedaksha
+  commit: 5e763bad48ece6baec3d5711fb3ba313535cb9fb
+run:
+  command:
+    - --stdio
+  disableNetwork: true


### PR DESCRIPTION
## MCP Server Information

**Server Name:** vedaksha
**Repository URL:** https://github.com/arthiqlabs/vedaksha
**Brief Description:** Astronomical ephemeris and Vedic astrology (Jyotish) engine in Rust, exposed as 17 MCP tools. Runs fully offline: no network calls, no telemetry, no API keys, no configuration.

## Please read first: the licence is BUSL-1.1, not a permissive licence

I have deliberately left the "Open Source" box unticked rather than tick it loosely, and I would rather you decide now than discover it later.

Vedaksha is **BUSL-1.1** (source-available). Concretely:

- The licence grants the right to **copy, modify, create derivative works and redistribute**, so building and distributing an `mcp/vedaksha` image in Docker Hub's `mcp` namespace is permitted.
- **Non-commercial use is free** for everyone -- personal projects, research, education, internal tools. Commercial use is a one-time USD $500 per organisation.
- Each version converts to **Apache-2.0 four years after its release**.

Note that `task validate` reports "License is valid". That is only because `internal/licenses.IsValid` rejects `gpl`/`agpl`/`npl` prefixes and GitHub's licence detector cannot classify BUSL-1.1 at all, so it sees no licence rather than an approved one. I do not want that null result read as an endorsement. If the catalog requires a permissive licence, this PR should be closed and I will not re-open it.

## Basic Requirements

- [ ] **Open Source**: BUSL-1.1 -- source-available, not permissive. See above.
- [x] **MCP Compliant**: 17 tools over stdio; the catalog is generated from the Rust tool definitions and locked by a snapshot test in CI, so `tools/list` cannot drift from the code
- [x] **Active Development**: v7.2.0 released 2026-08-23; CI runs the full suite, clippy over all targets, MSRV, `no_std`, WASM and the Python bindings on every push
- [x] **Docker Artifact**: Dockerfile in the repository root, multi-arch (amd64 + arm64)
- [x] **Documentation**: README, MAINTENANCE.md, CONTRIBUTING.md, and a published provenance record for the ephemeris derivations
- [x] **Security Contact**: SECURITY.md, security@ contact at info@arthiq.net

## Submitter Checklist

- [ ] This server meets the basic requirements listed above -- all except the licence, which is stated plainly above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name vedaksha`
- [x] I have built the MCP Server using `task build -- --tools vedaksha`
- [x] No credentials are needed to test this server: it takes no API keys and makes no network calls

## Verification output

`task validate -- --name vedaksha`:

```
✅ Name is valid          ✅ Commit is pinned        ✅ Icon is valid
✅ Directory is valid     ✅ Secrets are valid       ✅ Remote validation skipped (not a remote server)
✅ Title is valid         ✅ Config env is valid     ✅ OAuth dynamic configuration is valid
✅ YAML formatting is valid
```

`task build -- --tools vedaksha`:

```
17 tools found.
✅ Image built as mcp/vedaksha
```

The published image was also exercised directly over stdio, with the invocation reconstructed from the entry rather than retyped:

```
docker run --rm -i ghcr.io/arthiqlabs/vedaksha-mcp:v7.2.0 --stdio
-> exit 0, 0 bytes on stderr, 17 tools from tools/list
```

`run.command: ["--stdio"]` is needed because the image's `CMD` is `["--http"]`; the flag exists precisely so a gateway can override it.

## About the server

Planetary positions come from a clean-room implementation of VSOP87 and ELP/MPP02, with optional JPL SPK kernels, validated against JPL Horizons on a committed 24,350-row fixture; the SPK path agrees to 0.103 arcsec. Eleven sidereal ayanamsha systems are each derived forward from a primary source rather than tuned to match another implementation, and the derivation for each is recorded in the repository.
