### PR TITLE
Add kbdb — file-based knowledge base with hybrid search

### DIFF
--- a/servers/kbdb/server.yaml
+++ b/servers/kbdb/server.yaml
@@ -1,0 +1,19 @@
+name: kbdb
+image: mcp/kbdb
+type: server
+meta:
+  category: ai
+  tags:
+    - knowledge-base
+    - memory
+    - search
+    - rag
+    - markdown
+about:
+  title: kbdb
+  description: "A searchable second brain for AI agents: a file-based knowledge base with ranked keyword and semantic (hybrid) search over your Markdown."
+  icon: https://avatars.githubusercontent.com/u/9333007?v=4
+source:
+  project: https://github.com/diko316/knowledge-base-db
+  branch: main
+  commit: 6f4b16db60e3a527b1445f9d5f580a4fdce24349


### PR DESCRIPTION
Adds `servers/kbdb/server.yaml`.

**kbdb** is a searchable second brain for AI agents: a file-based knowledge base with ranked keyword and semantic (hybrid) search over Markdown. Learn documents, then recall the sections that answer a question. No database server and no cloud account — the store is a folder on disk.

- Source: https://github.com/diko316/knowledge-base-db (Dockerfile at repo root)
- npm: https://www.npmjs.com/package/@dikolab/kbdb
- Official MCP Registry: `io.github.diko316/kbdb`
- Docs: https://diko316.gitlab.io/knowledge-base-db/
- License: AGPL-3.0-only

**Category `ai`** — chosen to match the nearest siblings already in the catalog: `memory` (persistent memory) and `needle` (document RAG) are both `ai`, whereas `search` holds external search APIs (arxiv, brave, paper-search).

**`source.commit` pins `6f4b16d`**, the v1.0.3 release commit and current `main`. That tree's Dockerfile installs `@dikolab/kbdb@1.0.3`, which is published, so the build is reproducible. The image serves 30 tools over stdio against a database seeded at build time with the project's own documentation, so the inspector returns real results rather than an empty store.

**Disclosure:** this `server.yaml` was hand-written against the shape of `servers/fetch/server.yaml` rather than generated with `task create` — go-task is not installed on my machine, so I have not run `task validate` or `task build` locally. Relying on CI here; happy to adjust whatever it flags.