### PR TITLE
Add metabrain MCP server

### DIFF
--- a/servers/metabrain/server.yaml
+++ b/servers/metabrain/server.yaml
@@ -1,0 +1,34 @@
+name: metabrain
+image: mcp/metabrain
+type: server
+meta:
+  category: ai
+  tags:
+    - agent-memory
+    - memory
+    - recall
+    - sqlite
+    - knowledge
+about:
+  title: MetaBrain
+  description: Persistent memory for coding agents, in one local SQLite file. Call start_brief at the top of a task to load what already worked, recall before acting, learn after discovering something durable, and verdict when a unit of work resolves. Lessons are typed as failure, pattern, gotcha or preference; repeated evidence graduates a hypothesis, so the agent stops relitigating decisions it already made. No cloud, no embeddings, no account.
+  icon: https://avatars.githubusercontent.com/u/113392746?s=200&v=4
+source:
+  project: https://github.com/ariaxhan/metabrain
+  branch: main
+  commit: aacbfb1edf2c18aced5e1ec12682ec48dde7b662
+run:
+  volumes:
+    - "{{metabrain.data_path}}:/data"
+config:
+  description: Where the metabrain SQLite file lives. The directory is mounted at /data inside the container, and the database is /data/agent.db, so memory survives restarts.
+  parameters:
+    type: object
+    properties:
+      data_path:
+        type: string
+        title: Memory directory
+        description: Host directory (or named Docker volume) holding agent.db
+        default: metabrain-data
+    required:
+      - data_path

--- a/servers/metabrain/tools.json
+++ b/servers/metabrain/tools.json
@@ -1,0 +1,116 @@
+[
+  {
+    "name": "start_brief",
+    "description": "Return the start-of-task digest (preferences, learnings, open_hypotheses, open_units, last_checkpoint, recent_errors). Call this first, before planning any work.",
+    "arguments": []
+  },
+  {
+    "name": "recall",
+    "description": "Search stored lessons for the substring query and return up to limit matching lessons, newest first. Call it before acting, with concrete nouns and file names.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Concrete nouns, file names or error text to match against stored lessons"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum lessons to return (default 20)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "learn",
+    "description": "Record or reinforce one durable lesson and return the stored entry. Repeating the same insight reinforces it rather than duplicating it.",
+    "arguments": [
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "One of failure, pattern, gotcha, preference"
+      },
+      {
+        "name": "insight",
+        "type": "string",
+        "desc": "The lesson itself, in one sentence"
+      },
+      {
+        "name": "domain",
+        "type": "string",
+        "desc": "Area the lesson applies to, e.g. a language, service or repo",
+        "optional": true
+      },
+      {
+        "name": "context",
+        "type": "string",
+        "desc": "Evidence: what happened that proved it",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "hypotheses",
+    "description": "List hypothesis objects, optionally filtered by status, so the agent can see which beliefs are still being tested.",
+    "arguments": [
+      {
+        "name": "status",
+        "type": "string",
+        "desc": "Filter to testing, graduated or rejected",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "verdict",
+    "description": "Record pass or fail against a unit of work or a hypothesis, closing the learn to hypothesis to experiment loop. Writes an experiment row when a hypothesis is in play.",
+    "arguments": [
+      { "name": "result", "type": "string", "desc": "pass or fail" },
+      {
+        "name": "unit",
+        "type": "string",
+        "desc": "The unit of work being judged",
+        "optional": true
+      },
+      {
+        "name": "evidence",
+        "type": "string",
+        "desc": "How the result was established",
+        "optional": true
+      },
+      {
+        "name": "hypothesis",
+        "type": "string",
+        "desc": "The hypothesis this result tests",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "stats",
+    "description": "Return a mapping of every metabrain table name to its row count, for a quick read on how much memory exists.",
+    "arguments": []
+  },
+  {
+    "name": "capture_error",
+    "description": "Record a failure by tool name and error text so the same error can be recognised the next time it appears.",
+    "arguments": [
+      {
+        "name": "tool",
+        "type": "string",
+        "desc": "Name of the tool or command that failed"
+      },
+      {
+        "name": "error",
+        "type": "string",
+        "desc": "The error text or signature"
+      },
+      {
+        "name": "context",
+        "type": "string",
+        "desc": "What was being attempted",
+        "optional": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
👀 in review

Adds `metabrain`, a local-first memory server for coding agents: one SQLite file, seven tools, no cloud and no account.

| | |
| --- | --- |
| Source | https://github.com/ariaxhan/metabrain (MIT) |
| Image | Docker-built `mcp/metabrain`; Dockerfile is at the repo root |
| Tools | `start_brief`, `recall`, `learn`, `verdict`, `hypotheses`, `stats`, `capture_error` |
| Config | One volume: a directory mounted at `/data`, holding `agent.db` |
| Secrets | None. No network egress. |

The loop an agent runs: `start_brief` at the top of a task, `recall` before acting, `learn` after discovering something durable, `verdict` when the work resolves. Repeated evidence graduates a hypothesis, so the agent stops relitigating decisions it already made.

<details>
<summary>Local validation</summary>

```
$ task validate -- --name metabrain
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ OAuth dynamic configuration is valid

$ task build -- --tools metabrain
7 tools found.
✅ Image built as mcp/metabrain
```

`tools.json` was written from the server's own `tools/list` response, not by hand.
</details>

<details>
<summary>A note on the volume</summary>

The container runs as uid 10001. A **named** Docker volume works out of the box; a bind mount of a host directory needs that directory writable by uid 10001, otherwise SQLite cannot create the file. The default in `server.yaml` is a named volume for that reason. Happy to change it if you'd prefer a host path default.
</details>
