### PR TITLE
Add agentmailkit MCP server

### DIFF
--- a/servers/agentmailkit/server.yaml
+++ b/servers/agentmailkit/server.yaml
@@ -1,0 +1,34 @@
+name: agentmailkit
+image: mcp/agentmailkit
+type: server
+meta:
+  category: productivity
+  tags:
+    - email
+    - automation
+    - digest
+    - scheduling
+    - plugins
+about:
+  title: AgentMailKit
+  description: Scheduled, LLM-written email digests that an agent can drive as tools. Each job declares its sources, model, render and delivery in one JSON file; list_jobs shows what is configured, preview_job renders exactly what a job would send without sending it, and run_job executes one. run_job defaults to dry_run=true and only sends real mail when explicitly called with dry_run=false, so an agent can explore the whole surface without touching an inbox.
+  icon: https://avatars.githubusercontent.com/u/113392746?s=200&v=4
+source:
+  project: https://github.com/ariaxhan/agentmailkit
+  branch: main
+  commit: 0c660c71a433b8a1a95f01cad6d91217c347c1d2
+run:
+  volumes:
+    - "{{agentmailkit.config_path}}:/data"
+config:
+  description: The directory holding your agentmailkit.json and its jobs. It is mounted at /data, which is also the container's working directory, so config discovery finds it with no extra flags.
+  parameters:
+    type: object
+    properties:
+      config_path:
+        type: string
+        title: Config directory
+        description: Host directory containing agentmailkit.json and the jobs it references
+        default: agentmailkit-data
+    required:
+      - config_path

--- a/servers/agentmailkit/tools.json
+++ b/servers/agentmailkit/tools.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "list_jobs",
+    "description": "List every configured job, returning one object per job with id, schedule, sources, delivery, render, model and status. Start here to see what exists.",
+    "arguments": []
+  },
+  {
+    "name": "preview_job",
+    "description": "Render what a job would email and return subject, path, chars, truncated, body and would_deliver_to. Writes a local file and can never send, so it is always safe to call.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": "The id of the job to render, as returned by list_jobs"
+      },
+      {
+        "name": "model",
+        "type": "string",
+        "desc": "Override the job's model; pass \"echo\" for an offline preview with no LLM call",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "run_job",
+    "description": "Run a job through the real pipeline and return its run receipt. dry_run defaults to true and stops before delivery; dry_run=false SENDS REAL EMAIL from the configured inbox.",
+    "arguments": [
+      {
+        "name": "job_id",
+        "type": "string",
+        "desc": "The id of the job to run, as returned by list_jobs"
+      },
+      {
+        "name": "dry_run",
+        "type": "boolean",
+        "desc": "Defaults to true, which stops before delivery. Only false actually sends",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_plugins",
+    "description": "List the registered plugin names grouped by kind, so you can see what a job is allowed to reference.",
+    "arguments": [
+      {
+        "name": "kind",
+        "type": "string",
+        "desc": "Narrow to one kind: source, model, gate, delivery, render or post",
+        "optional": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
👀 in review

Adds `agentmailkit`: scheduled, LLM-written email digests that an agent drives as tools instead of a human typing commands.

| | |
| --- | --- |
| Source | https://github.com/ariaxhan/agentmailkit (MIT) |
| Image | Docker-built `mcp/agentmailkit`; Dockerfile is at the repo root |
| Tools | `list_jobs`, `preview_job`, `run_job`, `list_plugins` |
| Config | One volume: the directory holding `agentmailkit.json` and its jobs, mounted at `/data` |
| Secrets | None in the catalog entry. Mail credentials live in the user's own config file on the mounted volume. |

`run_job` defaults to `dry_run=true` and stops before delivery; only an explicit `dry_run=false` sends real mail. `preview_job` can never send. So an agent can explore the entire surface without touching an inbox.

<details>
<summary>Local validation</summary>

```
$ task validate -- --name agentmailkit
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ OAuth dynamic configuration is valid

$ task build -- --tools agentmailkit
4 tools found.
✅ Image built as mcp/agentmailkit
```

`tools.json` was written from the server's own `tools/list` response, not by hand. The server starts and lists tools with no config mounted at all.
</details>
