### PR TITLE
Add site-spec MCP server

### DIFF
--- a/servers/site-spec/server.yaml
+++ b/servers/site-spec/server.yaml
@@ -1,0 +1,34 @@
+name: site-spec
+image: mcp/site-spec
+type: server
+meta:
+  category: devops
+  tags:
+    - seo
+    - accessibility
+    - website-audit
+    - structured-data
+    - llms-txt
+about:
+  title: Site-Spec
+  description: Audit and repair the layer of a website a browser never shows you, from inside the agent that built it. audit_site crawls a live URL or a local build directory and returns every finding with a check id, severity, file and whether it is auto-fixable, covering robots.txt and llms.txt policy, canonical and noindex signals, structured data, Open Graph, security and cache headers, accessibility semantics and the tracker surface. fix_issue applies the deterministic repair for one check id, dry-run by default. Every check is rule-based, so the same site always produces the same report.
+  icon: https://avatars.githubusercontent.com/u/113392746?s=200&v=4
+source:
+  project: https://github.com/ariaxhan/site-spec
+  branch: main
+  commit: a77fb78d6d09c9b2c5218c88bb24c9bcaa3d41ca
+run:
+  volumes:
+    - "{{site-spec.workspace_path}}:/data"
+config:
+  description: The project directory site-spec may read and write. It is mounted at /data, the container's working directory. Auditing a live URL needs no directory at all; only local audits and fix writes touch it.
+  parameters:
+    type: object
+    properties:
+      workspace_path:
+        type: string
+        title: Workspace directory
+        description: Host directory containing the built site to audit or repair
+        default: site-spec-data
+    required:
+      - workspace_path

--- a/servers/site-spec/tools.json
+++ b/servers/site-spec/tools.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "audit_site",
+    "description": "Audit a website and return { ok, target, mode, live, errors, warnings, pages, findings }, where every finding carries checkId, severity, file, category and fixAvailable. Covers robots.txt and llms.txt policy, canonical and noindex signals, structured data, Open Graph, security and cache headers, accessibility semantics, and the tracker and cookie surface.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "A live URL, a bare hostname, or a path under /data to a local directory of built output"
+      },
+      {
+        "name": "checks",
+        "type": "array",
+        "items": { "type": "string" },
+        "desc": "Only report these check ids, e.g. [\"audit/noindex\"]. Omit for every check; call list_checks for the full set",
+        "optional": true
+      },
+      {
+        "name": "maxPages",
+        "type": "integer",
+        "desc": "How many pages to crawl, 1 to 200, default 25",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "fix_issue",
+    "description": "Apply the deterministic repair for one audit finding and return { checkId, fixAvailable, matchedFindings, actions, diffs, written }. Defaults to a dry run that writes nothing; write=true requires a local directory target and is refused for a URL. Unrepairable findings come back with the manual step spelled out.",
+    "arguments": [
+      {
+        "name": "url_or_path",
+        "type": "string",
+        "desc": "The live URL, or a path under /data to a local directory of built output"
+      },
+      {
+        "name": "check_id",
+        "type": "string",
+        "desc": "The single check id to repair, from an audit_site finding"
+      },
+      {
+        "name": "write",
+        "type": "boolean",
+        "desc": "Defaults to false, which only returns the diff. true writes the fix and requires a local directory",
+        "optional": true
+      },
+      {
+        "name": "out_dir",
+        "type": "string",
+        "desc": "Write the fixed output to this directory under /data instead of in place",
+        "optional": true
+      },
+      {
+        "name": "maxPages",
+        "type": "integer",
+        "desc": "How many pages to crawl while locating the finding",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "compile_spec",
+    "description": "Compile verified business data into a deployable site and return { ok, pack, spec, files, findings }, plus written and writtenTo when out_dir is given. Renders HTML, sitemap.xml, robots.txt, llms.txt, headers and icons. Validation runs at both the spec tier and the rendered tier, so an invalid site never produces output.",
+    "arguments": [
+      {
+        "name": "business",
+        "type": "string",
+        "desc": "The site config object { pack, brief, site, spec, foundation?, target? } as JSON"
+      },
+      {
+        "name": "out_dir",
+        "type": "string",
+        "desc": "Directory under /data to write the rendered site into",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_checks",
+    "description": "Enumerate every check the engine can raise, each with a one-line description and whether an automatic fix exists. Call this before filtering audit_site or choosing a check id for fix_issue.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
👀 in review

Adds `site-spec`: audit and repair the layer of a website a browser never shows you, from inside the agent that built it.

| | |
| --- | --- |
| Source | https://github.com/ariaxhan/site-spec (Apache-2.0) |
| Image | Docker-built `mcp/site-spec`; Dockerfile is at the repo root |
| Tools | `audit_site`, `fix_issue`, `compile_spec`, `list_checks` |
| Config | One volume: the project directory to read or write, mounted at `/data` |
| Secrets | None. Outbound HTTP only to the site being audited. |

`audit_site` crawls a live URL or a local build directory and returns findings with a check id, severity, file and whether an automatic fix exists: robots.txt and llms.txt policy, canonical and noindex signals, structured data, Open Graph, security and cache headers, accessibility semantics, and the tracker surface. `fix_issue` is a dry run by default and refuses to write against a URL. Every check is rule-based, so the same site always produces the same report.

<details>
<summary>Local validation</summary>

```
$ task validate -- --name site-spec
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ OAuth dynamic configuration is valid

$ task build -- --tools site-spec
4 tools found.
✅ Image built as mcp/site-spec
```

The image is a two-stage build: the MCP package esbuild-bundles itself and its workspace dependency into one zero-dependency `.mjs`, so the runtime stage is `node:20-slim` plus a single file and no `node_modules`. `tools.json` was written from the server's own `tools/list` response.
</details>
