### PR TITLE
Add BestPrice remote MCP server

### DIFF
--- a/servers/bestprice/readme.md
+++ b/servers/bestprice/readme.md
@@ -1,0 +1,1 @@
+Docs: https://www.bestprice.gr/mcp

--- a/servers/bestprice/server.yaml
+++ b/servers/bestprice/server.yaml
@@ -1,0 +1,19 @@
+name: bestprice
+type: remote
+meta:
+  category: ecommerce
+  tags:
+    - ecommerce
+    - shopping
+    - price-comparison
+    - price-history
+    - greece
+    - read-only
+    - remote
+about:
+  title: BestPrice Shopping
+  description: Search products, compare current merchant offers and delivered totals, and check price history on BestPrice.gr
+  icon: https://www.bestprice.gr/images/logo.svg
+remote:
+  transport_type: streamable-http
+  url: https://mcp.bestprice.gr/mcp


### PR DESCRIPTION
Adds the public BestPrice Shopping Streamable HTTP server to the Docker MCP Catalog.

- Endpoint: `https://mcp.bestprice.gr/mcp`
- Documentation: `https://www.bestprice.gr/mcp`
- Official MCP Registry ID: `gr.bestprice/mcp`
- Read-only, no OAuth, account, API key, local image, or secrets
- Tools: product search, current offer/delivered-total comparison, and price history for Greece

Local validation:
- Docker validator: passed; live remote tool discovery found 3 tools
- `npx prettier --check servers/bestprice/server.yaml`: passed
- Catalog generation: passed
- Direct MCP initialize: HTTP 200

The icon validator emits only a non-blocking fetch warning because BestPrice returns 403 to that validator user agent; browsers and the public site serve the SVG normally.