### PR TITLE
Add fiscal-mcp

### DIFF
--- a/servers/fiscal-mcp/server.yaml
+++ b/servers/fiscal-mcp/server.yaml
@@ -1,0 +1,18 @@
+name: fiscal-mcp
+image: mcp/fiscal-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - finance
+    - invoice
+    - validation
+    - brazil
+about:
+  title: Fiscal MCP
+  description: Validates Brazilian electronic invoices (NF-e, NFC-e and the national NFS-e) entirely offline, with no digital certificate and no network access. Runs the official SEFAZ XSD schema and translates the raw validator messages into actionable Portuguese, checks the 2026 tax reform fields (IBS/CBS) against the official CST and cClassTrib table shipped inside the package with a recorded provenance and sha256, and verifies the access key. Every finding says what is wrong and what to do about it. It never signs, transmits, issues or cancels a document.
+  icon: https://avatars.githubusercontent.com/u/71329155?v=4
+source:
+  project: https://github.com/JoseTorquato/fiscal-mcp
+  branch: main
+  commit: 1d9ee84709ab7fdd46f6010eeba37feadce9817f


### PR DESCRIPTION
Adds `fiscal-mcp`, an offline validator for Brazilian electronic invoices — NF-e, NFC-e and the national NFS-e.

## Why it fits the catalog

The audience for this tool is overwhelmingly ERP developers working in Delphi and C#, not Python. `docker run` is what lets them use it without installing a Python toolchain — that is the specific reason the Dockerfile exists in the project.

## What it does

- Runs the **official SEFAZ XSD schema** and translates the raw `lxml` validator messages into actionable Portuguese. Running the schema is the easy half; the translation is the product.
- Checks the **2026 Brazilian tax reform fields (IBS/CBS)** against the official CST/cClassTrib table, which ships inside the image with a recorded provenance and sha256. CI never downloads it, so an outage at the source cannot break a build.
- Verifies the access key and its check digit, and explains rejection codes.

Every finding carries what is wrong and what to do about it, because the consumer is an agent that will retry.

## Security posture

- **Nothing leaves the container.** It never signs, transmits, issues or cancels a document, and a test asserts that no socket is opened.
- No credentials, no secrets, no environment variables to configure — hence no `config` block.
- Runs as a non-root user (uid 1000).
- Licensed MIT.

## Verification

`task create` needs Go, which I do not have available, so I ran the equivalent checks by hand against the exact commit referenced in `server.yaml`:

- image builds from the repository root `Dockerfile`
- the build fails on purpose if the rules or the official table are missing from the image — a validator shipped without its data is worse than one that does not ship
- `docker run -i --rm` responds to `initialize` and lists **8 tools**: `validar_nfe`, `explicar_nfe`, `validar_nfse`, `explicar_nfse`, `validar_chave_nfse`, `explicar_rejeicao`, `validar_chave_acesso`, `listar_rejeicoes_conhecidas`
- a real `tools/call` to `validar_nfe` returns the expected findings

Happy to adjust the category — `productivity` seemed closest to the ones already in use, but the tool is squarely finance/tax.

Links: [repository](https://github.com/JoseTorquato/fiscal-mcp) · [PyPI](https://pypi.org/project/fiscal-mcp/) · MCP name `io.github.JoseTorquato/fiscal-mcp`