### PR TITLE
Add tubescout — YouTube research MCP (keyless search, resilient transcripts, demand signals)

### DIFF
--- a/servers/tubescout/server.yaml
+++ b/servers/tubescout/server.yaml
@@ -1,0 +1,18 @@
+name: tubescout
+image: mcp/tubescout
+type: server
+meta:
+  category: search
+  tags:
+    - youtube
+    - research
+    - transcripts
+    - search
+about:
+  title: TubeScout
+  description: Turns YouTube into a research engine for AI agents — no API key required. Search videos with filters, get video metadata with engagement signals, extract transcripts through a resilient 3-strategy fallback chain, batch-fetch transcripts, scan channels for strategy and performance, and read YouTube autocomplete as search-demand data for keyword research.
+  icon: https://raw.githubusercontent.com/not0lucky/tubescout/main/assets/logo-400.png
+source:
+  project: https://github.com/not0lucky/tubescout
+  branch: main
+  commit: ced42fccd2f0c14bfe153f44eeac21895f46ace7


### PR DESCRIPTION
Adds [tubescout](https://github.com/not0lucky/tubescout) as a local (containerized) server.

**What it does:** turns YouTube into a research engine for agents — no API key, no config, no secrets:
- `search_videos` — filtered search (upload window, duration, sort)
- `get_video` — metadata + engagement signals (likes per 1k views)
- `get_transcript` / `get_transcripts` — resilient 3-strategy fallback chain (ANDROID-client timedtext → InnerTube transcript endpoint with retries → yt-dlp when present)
- `get_channel_videos` — channel scans (positioning, cadence, what performs)
- `get_search_suggestions` — YouTube autocomplete as search-demand data

**Checks:**
- MIT licensed ✓
- Dockerfile in the source repo (multi-stage, node:22-alpine) ✓
- Image built and smoke-tested locally: MCP initialize → tools/list (6 tools) → live tool call, all passing inside the container ✓
- No secrets or config required — zero-config stdio server ✓
- Published on npm (`tubescout`) and the official MCP Registry (`io.github.not0lucky/tubescout`) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)