### PR TITLE
Add ili Kanban MCP Server to catalog

### DIFF
--- a/servers/ili-kanban/server.yaml
+++ b/servers/ili-kanban/server.yaml
@@ -1,0 +1,49 @@
+name: ili-kanban-mcp-server
+image: mcp/ili-kanban
+type: server
+
+meta:
+  category: productivity
+  tags:
+    - kanban
+    - dashboard
+    - boards
+    - task-management
+
+about:
+  title: ili Kanban Dashboard
+  description: |
+    MCP Server for ili Dashboard Kanban boards. Exposes tools for reading and writing
+    Kanban boards, cards, and timestamped notes. Designed for AI assistants to manage
+    task workflows in the ili self-hosted dashboard.
+
+    Supported operations:
+      - list_boards: Enumerate all boards
+      - get_board: Fetch board with cards
+      - get_card: Fetch individual card details
+      - create_card: Add new card to a column
+      - move_card: Move card between columns
+      - update_card: Update card fields
+      - add_note: Append note to card
+
+  icon: https://raw.githubusercontent.com/Toa1984/ili-public/main/html/img/favicon-64.png
+
+source:
+  project: https://github.com/Toa1984/ili-public
+  branch: main
+  commit: "70af6811801bef7c1add20b7718dff29dc1fb24d"  # Updated to current HEAD (2026-08-27)
+
+config:
+  description: Configure the connection to ili Dashboard
+  env:
+    - name: DASHBOARD_URL
+      description: URL of the ili Dashboard REST API (required if not using Docker-internal networking)
+      example: "http://host.containers.internal:8798"
+      value: "http://host.containers.internal:8798"
+  parameters:
+    type: object
+    properties:
+      dashboard_url:
+        type: string
+        description: Dashboard API URL (auto-detected; override if needed)
+        example: "http://127.0.0.1:8798"


### PR DESCRIPTION
Adds the ili Dashboard Kanban MCP Server to the official Docker MCP Registry catalog.

## Features

The ili Kanban Dashboard MCP Server provides AI assistants with programmatic access to ili Dashboard Kanban boards:

- 7 MCP tools: list_boards, get_board, get_card, create_card, move_card, update_card, add_note
- Docker image: ghcr.io/toa1984/ili-mcp (MIT licensed)
- Connects to ili REST API (default port 8798)
- Compatible with Docker Desktop MCP Toolkit, Claude Desktop, Claude Code, Cursor

## About ili

ili is an open-source self-hosted Kanban dashboard for AI-driven task management. This MCP Server allows AI assistants to integrate with existing ili instances seamlessly.

Repo: https://github.com/Toa1984/ili-public

## Verification

- [x] YAML follows Docker MCP Registry format
- [x] Public Docker image available at ghcr.io/toa1984/ili-mcp
- [x] MIT License (compatible with registry requirements)
- [x] Clear description and configuration examples