### PR TITLE
Add codeindex

### DIFF
--- a/servers/codeindex/server.yaml
+++ b/servers/codeindex/server.yaml
@@ -13,7 +13,7 @@ about:
     symbol is defined, the body of one function, what calls it, imports in both
     directions, and what a change breaks. tree-sitter across 40+ languages, 16
     tools, no API key and nothing to configure.
-  icon: https://avatars.githubusercontent.com/u/243440819?s=200&v=4
+  icon: https://raw.githubusercontent.com/munhq/codeindex/main/docs/brand/icon-512.png
 source:
   project: https://github.com/munhq/codeindex
   branch: main

--- a/servers/codeindex/server.yaml
+++ b/servers/codeindex/server.yaml
@@ -1,0 +1,39 @@
+name: codeindex
+image: mcp/codeindex
+type: server
+meta:
+  category: development
+  tags:
+    - development
+    - code-analysis
+about:
+  title: codeindex
+  description: >-
+    Answers code questions structurally instead of reading whole files — where a
+    symbol is defined, the body of one function, what calls it, imports in both
+    directions, and what a change breaks. tree-sitter across 40+ languages, 16
+    tools, no API key and nothing to configure.
+  icon: https://avatars.githubusercontent.com/u/243440819?s=200&v=4
+source:
+  project: https://github.com/munhq/codeindex
+  branch: main
+  commit: 29d621964550004cf142be2167f652467f5dfb34
+run:
+  # codeindex indexes the repository it is pointed at, so the path the user
+  # chooses is bind-mounted and passed as --workspace. Nothing is written there.
+  command:
+    - "--workspace"
+    - "{{codeindex.workspace|volume-target}}"
+  volumes:
+    - "{{codeindex.workspace|volume}}"
+  # The index is built from the mounted files; the server never calls out.
+  disableNetwork: true
+config:
+  description: The repository codeindex should index
+  parameters:
+    type: object
+    properties:
+      workspace:
+        type: string
+    required:
+      - workspace


### PR DESCRIPTION
Adds `servers/codeindex/server.yaml`.

**What it does.** Structural code intelligence over MCP, so an agent answers code questions without reading whole files: where a symbol is defined, the body of one function, what calls it, imports in both directions, and what a change breaks. tree-sitter across 40+ languages, 16 tools. No API key, no account, nothing to configure.

**Image.** Builds from the `Dockerfile` at the repository root. It fetches the statically linked release binary for `TARGETARCH` (amd64 and arm64 both published), verifies it against the `SHA256SUMS` published beside it, and ships it `FROM scratch` — the binary and nothing else, 51 MB, no shell and no package manager.

**Runtime.** codeindex indexes the repository it is pointed at, so the configured path is bind-mounted and passed as `--workspace`. It never writes to that path, and it never uses the network once the index is built, so `disableNetwork: true`.

**Verified locally** before opening this:

```
docker run -i --rm -v "$PWD:/workspace:ro" codeindex:test
initialize  -> {'name': 'codeindex', 'version': '0.3.3'}
tools/list  -> 16 tools
find_symbol -> /workspace/install.sh:135-154 function resolve_artifact
```

Also published in the official MCP registry as `io.github.munhq/codeindex`, on npm as `@munhq/codeindex`, and on Smithery as `munhq/codeindex`. MIT.