### PR TITLE
Add Apple Ads MCP server

### DIFF
--- a/servers/apple-ads-mcp/readme.md
+++ b/servers/apple-ads-mcp/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/zelentsov-dev/apple-ads-mcp#readme

--- a/servers/apple-ads-mcp/server.yaml
+++ b/servers/apple-ads-mcp/server.yaml
@@ -1,0 +1,82 @@
+name: apple-ads-mcp
+image: ghcr.io/zelentsov-dev/apple-ads-mcp:v0.3.5
+type: server
+meta:
+  category: marketing
+  tags:
+    - apple-ads
+    - advertising
+    - app-store
+    - marketing
+    - analytics
+about:
+  title: Apple Ads
+  description: Local-first Apple Ads Platform API v1 tools for account health, app eligibility, campaign inventory, research, reports, and receipt-gated campaign operations. Read-only by default; credentials stay on the user's machine.
+  icon: https://github.com/zelentsov-dev.png?size=400
+source:
+  project: https://github.com/zelentsov-dev/apple-ads-mcp
+  commit: 8a5690b182cc68d77554e44763b0fd47398f5706
+run:
+  volumes:
+    - "{{apple-ads-mcp.private_key_path}}:/run/keys/apple-ads-private-key.pem:ro"
+  user: "{{apple-ads-mcp.container_user}}"
+config:
+  description: Configure a read-only Apple Ads API profile. The private key is mounted from the host and is never copied into the image. Write and delete gates remain disabled.
+  env:
+    - name: APPLE_ADS_PROFILE
+      example: docker-read-only
+      value: "{{apple-ads-mcp.profile}}"
+    - name: APPLE_ADS_CLIENT_ID
+      example: SEARCHADS.example-client
+      value: "{{apple-ads-mcp.client_id}}"
+    - name: APPLE_ADS_TEAM_ID
+      example: SEARCHADS.example-team
+      value: "{{apple-ads-mcp.team_id}}"
+    - name: APPLE_ADS_KEY_ID
+      example: example-key-id
+      value: "{{apple-ads-mcp.key_id}}"
+    - name: APPLE_ADS_PRIVATE_KEY_PATH
+      example: /run/keys/apple-ads-private-key.pem
+      value: /run/keys/apple-ads-private-key.pem
+    - name: APPLE_ADS_AD_ACCOUNT_ID
+      example: "1234560"
+      value: "{{apple-ads-mcp.ad_account_id}}"
+    - name: APPLE_ADS_ALLOW_WRITES
+      example: "false"
+      value: "false"
+    - name: APPLE_ADS_ALLOW_DELETES
+      example: "false"
+      value: "false"
+  parameters:
+    type: object
+    properties:
+      profile:
+        type: string
+        description: Local profile name used by Apple Ads MCP.
+        default: docker-read-only
+      client_id:
+        type: string
+        description: OAuth client ID created in Apple Ads Advanced settings.
+      team_id:
+        type: string
+        description: OAuth team ID created in Apple Ads Advanced settings.
+      key_id:
+        type: string
+        description: OAuth key ID created in Apple Ads Advanced settings.
+      private_key_path:
+        type: string
+        description: Absolute host path to the Apple Ads private key PEM file. The file is mounted read-only and is not sent to the image registry.
+      ad_account_id:
+        type: string
+        description: Optional default Apple Ads ad account ID.
+      container_user:
+        type: string
+        description: Container user able to read the mounted private key. Use a numeric UID:GID matching the host file owner when available; root is the compatibility default for a mode-0600 key.
+        default: "0:0"
+    required:
+      - profile
+      - client_id
+      - team_id
+      - key_id
+      - private_key_path
+      - container_user

--- a/servers/apple-ads-mcp/tools.json
+++ b/servers/apple-ads-mcp/tools.json
@@ -1,0 +1,3399 @@
+[
+  {
+    "name": "account_health",
+    "description": "Collect a read-only identity, access, and account baseline.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adamId",
+        "type": "string",
+        "desc": "optional App Store Adam ID to verify ownership"
+      }
+    ]
+  },
+  {
+    "name": "ad_account_get",
+    "description": "Read sanitized account currency, timezone, payment model, features, and delegations.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      }
+    ]
+  },
+  {
+    "name": "ad_accounts_list",
+    "description": "Discover Apple Ads account ACLs available to a profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      }
+    ]
+  },
+  {
+    "name": "ad_create_preview",
+    "description": "Preview creation of one ad.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed create payload for the resource"
+      }
+    ]
+  },
+  {
+    "name": "ad_delete_preview",
+    "description": "Preview irreversible deletion of one ad under a paused campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "ad_get",
+    "description": "Read one ad by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_bid_preview",
+    "description": "Preview an ad-group default bid update with decimal amount and currency.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": "ad group ID as a string"
+      },
+      {
+        "name": "amount",
+        "type": "string",
+        "desc": "decimal bid amount"
+      },
+      {
+        "name": "currency",
+        "type": "string",
+        "desc": "ISO 4217 currency"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_cpa_cap_preview",
+    "description": "Preview an ad-group CPA cap update with decimal amount and currency.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": "ad group ID as a string"
+      },
+      {
+        "name": "amount",
+        "type": "string",
+        "desc": "decimal bid amount"
+      },
+      {
+        "name": "currency",
+        "type": "string",
+        "desc": "ISO 4217 currency"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_create_preview",
+    "description": "Preview creation of one ad group.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed create payload for the resource"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_delete_preview",
+    "description": "Preview irreversible deletion of one ad group under a paused campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_get",
+    "description": "Read one ad group by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_pause_preview",
+    "description": "Preview pausing one ad group.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_group_report",
+    "description": "Read bounded ad-group performance rows.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "ad_group_resume_preview",
+    "description": "Preview resuming one ad group.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_group_schedule_preview",
+    "description": "Preview an ad-group start and end schedule update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "startTime",
+        "type": "null | string",
+        "desc": ""
+      },
+      {
+        "name": "endTime",
+        "type": "null | string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_group_search_match_preview",
+    "description": "Preview enabling or disabling Apple Search Match for a Search Results ad group.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "enabled",
+        "type": "boolean",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_group_targeting_preview",
+    "description": "Preview App Store-only ad-group targeting.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "targeting",
+        "type": "object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_group_update_preview",
+    "description": "Preview an ad-group update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "target resource ID as a string"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed fields to update"
+      }
+    ]
+  },
+  {
+    "name": "ad_groups_query",
+    "description": "Query bounded ad groups with endpoint-specific filters.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "ad_pause_preview",
+    "description": "Preview pausing one ad.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_report",
+    "description": "Read bounded ad performance rows.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "ad_resume_preview",
+    "description": "Preview resuming one ad.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "ad_update_preview",
+    "description": "Preview an ad update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "target resource ID as a string"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed fields to update"
+      }
+    ]
+  },
+  {
+    "name": "ads_query",
+    "description": "Query bounded ads with endpoint-specific filters.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "advertiser_resources_list",
+    "description": "List App Store content-provider delegations available to a profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      }
+    ]
+  },
+  {
+    "name": "app_locale_details",
+    "description": "Query bounded Default Product Page locale details for an app.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      },
+      {
+        "name": "adamId",
+        "type": "string",
+        "desc": "App Store Adam ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "app_opportunities",
+    "description": "Collect eligibility and suggestion opportunities for an app.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adamId",
+        "type": "string",
+        "desc": "App Store Adam ID as a string"
+      },
+      {
+        "name": "countriesOrRegions",
+        "type": "null | array",
+        "desc": "ISO country or region codes"
+      },
+      {
+        "name": "terms",
+        "type": "null | array",
+        "desc": "optional seed terms"
+      }
+    ]
+  },
+  {
+    "name": "app_rejection_reason_get",
+    "description": "Read one App Store app rejection reason.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "rejectionReasonId",
+        "type": "string",
+        "desc": "app rejection reason ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "app_rejection_reasons_query",
+    "description": "Query bounded App Store app rejection reasons.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "app_store_geo_search",
+    "description": "Search eligible App Store countries, administrative areas, and localities.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "geo search text with at least two characters or *"
+      },
+      {
+        "name": "entity",
+        "type": "string",
+        "desc": "Country, AdminArea, or Locality"
+      },
+      {
+        "name": "countryCode",
+        "type": "string",
+        "desc": "ISO 3166-1 alpha-2 country code"
+      },
+      {
+        "name": "eligible",
+        "type": "boolean",
+        "desc": "exclude soft-blocked geos"
+      },
+      {
+        "name": "offset",
+        "type": "integer",
+        "desc": "zero-based result offset"
+      },
+      {
+        "name": "pageSize",
+        "type": "integer",
+        "desc": "page size from 1 to 200"
+      }
+    ]
+  },
+  {
+    "name": "apps_eligibility",
+    "description": "Check App Store advertising eligibility.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "apps_get",
+    "description": "Read an App Store app by Adam ID.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adamId",
+        "type": "string",
+        "desc": "App Store Adam ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "apps_search",
+    "description": "Search apps and optionally restrict results to owned apps.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "app name or Adam ID search text"
+      },
+      {
+        "name": "returnOwnedApps",
+        "type": "boolean",
+        "desc": "limit results to apps owned by the organization"
+      },
+      {
+        "name": "cpids",
+        "type": "null | array",
+        "desc": "optional iTunes content provider IDs"
+      },
+      {
+        "name": "storefronts",
+        "type": "null | array",
+        "desc": "ISO storefront country codes"
+      },
+      {
+        "name": "offset",
+        "type": "integer",
+        "desc": "zero-based result offset"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "result limit from 1 to 200"
+      }
+    ]
+  },
+  {
+    "name": "auth_check",
+    "description": "Validate OAuth credentials and return the caller identity.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      }
+    ]
+  },
+  {
+    "name": "campaign_audit",
+    "description": "Collect campaign, ad-group, keyword, and search-term report baselines.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "campaign_bid_strategy_preview",
+    "description": "Preview MANUAL_CPT or eligible App Store Search Results MAX_CONVERSIONS strategy.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "strategy",
+        "type": "object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "campaign_countries_preview",
+    "description": "Preview replacing campaign country targeting.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "countries",
+        "type": "null | array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "campaign_create_preview",
+    "description": "Preview creation of one campaign and return a ten-minute receipt.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed create payload for the resource"
+      }
+    ]
+  },
+  {
+    "name": "campaign_daily_budget_preview",
+    "description": "Preview a campaign daily-budget update with typed money.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "amount",
+        "type": "object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "campaign_delete_preview",
+    "description": "Preview irreversible deletion of one paused campaign and its cascade inventory.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "campaign_get",
+    "description": "Read one campaign by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "campaign_inventory",
+    "description": "Read a campaign and bounded child inventory for safe auditing.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": "campaign ID as a string"
+      },
+      {
+        "name": "pageSize",
+        "type": "integer",
+        "desc": "maximum children per resource from 1 to 200"
+      }
+    ]
+  },
+  {
+    "name": "campaign_pause_preview",
+    "description": "Preview pausing one campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": "campaign ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "campaign_report",
+    "description": "Read bounded campaign performance rows.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "campaign_resume_preview",
+    "description": "Preview resuming one campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": "campaign ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "campaign_schedule_preview",
+    "description": "Preview a campaign start and end schedule update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "startTime",
+        "type": "null | string",
+        "desc": ""
+      },
+      {
+        "name": "endTime",
+        "type": "null | string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "campaign_shared_budget_assign_preview",
+    "description": "Preview assigning one LOC shared budget to one campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sharedBudgetId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "campaign_shared_budget_unassign_preview",
+    "description": "Preview removing one shared-budget assignment from one campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "sharedBudgetId",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "campaign_status_reason_details",
+    "description": "Read App Store campaign limited-status reason details.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": "campaign ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "campaign_update_preview",
+    "description": "Preview a campaign update after reading current state.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "target resource ID as a string"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed fields to update"
+      }
+    ]
+  },
+  {
+    "name": "campaigns_query",
+    "description": "Query bounded campaigns with endpoint-specific filters.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "category_suggestions",
+    "description": "Get category opportunities for an App Store app.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "change_history",
+    "description": "Read bounded Apple Ads change history.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "change_history_detail",
+    "description": "Read bounded field-level details for one change-history entry.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "detailId",
+        "type": "string",
+        "desc": "change detail ID"
+      },
+      {
+        "name": "offset",
+        "type": "integer",
+        "desc": "zero-based result offset"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "result limit from 1 to 200"
+      }
+    ]
+  },
+  {
+    "name": "creative_create_preview",
+    "description": "Preview creation of one creative.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed create payload for the resource"
+      }
+    ]
+  },
+  {
+    "name": "creative_delete_preview",
+    "description": "Preview irreversible deletion of one unreferenced creative.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "creative_get",
+    "description": "Read one creative by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "creative_update_preview",
+    "description": "Preview a creative update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "target resource ID as a string"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed fields to update"
+      }
+    ]
+  },
+  {
+    "name": "creatives_query",
+    "description": "Query bounded App Store creatives with endpoint-specific filters.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "daily_budget_recommendation_apply_preview",
+    "description": "Preview applying one daily-budget recommendation under an explicit maximum.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "recommendationId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "promotedObjectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "appliedAmount",
+        "type": "null | object",
+        "desc": ""
+      },
+      {
+        "name": "maximumAmount",
+        "type": "null | object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "daily_budget_recommendation_dismiss_preview",
+    "description": "Preview dismissing one daily-budget recommendation.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "recommendationId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "promotedObjectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "appliedAmount",
+        "type": "null | object",
+        "desc": ""
+      },
+      {
+        "name": "maximumAmount",
+        "type": "null | object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "daily_budget_recommendations",
+    "description": "Read daily-budget recommendations without applying them.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "impression_share",
+    "description": "Read app impression-share insights.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "keyword_bid_preview",
+    "description": "Preview a targeting keyword bid update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "keywordId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "bid",
+        "type": "object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "keyword_create_preview",
+    "description": "Preview creation of one targeting keyword.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed create payload for the resource"
+      }
+    ]
+  },
+  {
+    "name": "keyword_delete_preview",
+    "description": "Preview irreversible deletion of one keyword under a paused campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "keyword_get",
+    "description": "Read one targeting keyword by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "keyword_pause_preview",
+    "description": "Preview pausing one targeting keyword.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "keyword_report",
+    "description": "Read bounded keyword performance rows.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "keyword_resume_preview",
+    "description": "Preview resuming one targeting keyword.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "keyword_suggestions",
+    "description": "Get keyword opportunities for an App Store app.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "keyword_update_preview",
+    "description": "Preview a targeting keyword update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "target resource ID as a string"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed fields to update"
+      }
+    ]
+  },
+  {
+    "name": "keywords_bulk_create_preview",
+    "description": "Preview up to 100 targeting keyword creates as one drift-bound operation.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "items",
+        "type": "null | array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "keywords_bulk_update_preview",
+    "description": "Preview up to 100 targeting keyword updates as one drift-bound operation.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "items",
+        "type": "null | array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "keywords_query",
+    "description": "Query bounded targeting keywords with endpoint-specific filters.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "negative_keyword_create_preview",
+    "description": "Preview creation of one negative keyword.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed create payload for the resource"
+      }
+    ]
+  },
+  {
+    "name": "negative_keyword_delete_preview",
+    "description": "Preview irreversible deletion of one negative keyword under a paused campaign.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "negative_keyword_get",
+    "description": "Read one negative keyword by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "negative_keyword_update_preview",
+    "description": "Preview a negative keyword update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "target resource ID as a string"
+      },
+      {
+        "name": "payload",
+        "type": "object",
+        "desc": "typed fields to update"
+      }
+    ]
+  },
+  {
+    "name": "negative_keywords_bulk_create_preview",
+    "description": "Preview up to 100 negative keyword creates in one scope.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "items",
+        "type": "null | array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "negative_keywords_bulk_update_preview",
+    "description": "Preview up to 100 negative keyword updates in one scope.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "campaignId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "adGroupId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "items",
+        "type": "null | array",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "negative_keywords_query",
+    "description": "Query bounded negative keywords with endpoint-specific filters.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "operations_apply",
+    "description": "Apply exactly one non-expired, drift-free preview receipt.",
+    "arguments": [
+      {
+        "name": "receipt",
+        "type": "string",
+        "desc": "one-time operation receipt returned by a preview tool"
+      }
+    ]
+  },
+  {
+    "name": "operations_inspect",
+    "description": "Inspect receipt binding, expiry, and use state without applying it.",
+    "arguments": [
+      {
+        "name": "receipt",
+        "type": "string",
+        "desc": "one-time operation receipt returned by a preview tool"
+      }
+    ]
+  },
+  {
+    "name": "operations_verify",
+    "description": "Re-read receipt targets after an ambiguous write, including restart-safe optimization recovery, and return current state.",
+    "arguments": [
+      {
+        "name": "receipt",
+        "type": "string",
+        "desc": "one-time operation receipt returned by a preview tool"
+      }
+    ]
+  },
+  {
+    "name": "optimization_baseline",
+    "description": "Build a bounded 28-day Apple Ads performance baseline for a named policy.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "optimization_history",
+    "description": "Read bounded local decisions and verification history for a named policy.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "optimization_plan",
+    "description": "Build an on-demand bounded optimization plan without creating a receipt.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "optimization_plan_preview",
+    "description": "Build and bind one bounded active-policy optimization plan to a composite receipt.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "optimization_policies_list",
+    "description": "List named local optimization policies without credentials or account data.",
+    "arguments": []
+  },
+  {
+    "name": "optimization_policy_get",
+    "description": "Read one named optimization policy with resolved balanced thresholds.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "policy",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "org_get",
+    "description": "Read one Apple Ads organization.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "orgId",
+        "type": "string",
+        "desc": "Apple Ads organization ID"
+      }
+    ]
+  },
+  {
+    "name": "phrase_suggestions",
+    "description": "Get phrase opportunities for an App Store app.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "product_page_get",
+    "description": "Read a Default or Custom Product Page by ID.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "productPageId",
+        "type": "string",
+        "desc": "Default or Custom Product Page ID"
+      }
+    ]
+  },
+  {
+    "name": "product_page_locales",
+    "description": "Query bounded Product Page locale details.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "product_pages_query",
+    "description": "Query bounded Default and Custom Product Pages.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "profiles_list",
+    "description": "List configured profile names without exposing credentials.",
+    "arguments": []
+  },
+  {
+    "name": "search_term_popularity",
+    "description": "Read search-term popularity insights.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "search_term_report",
+    "description": "Read bounded search-term performance rows.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "server_info",
+    "description": "Show server version, safety mode, API family, and response limits.",
+    "arguments": []
+  },
+  {
+    "name": "shared_budget_create_preview",
+    "description": "Preview LOC shared-budget creation using a private local billing profile.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "startTime",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "endTime",
+        "type": "null | string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "billingProfile",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "shared_budget_delete_preview",
+    "description": "Preview irreversible deletion of one unassigned LOC shared budget.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "expectedText",
+        "type": "string",
+        "desc": "exact current resource name or keyword text"
+      }
+    ]
+  },
+  {
+    "name": "shared_budget_get",
+    "description": "Read one shared budget by ID for current-state verification.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "id",
+        "type": "string",
+        "desc": "resource ID as a string"
+      }
+    ]
+  },
+  {
+    "name": "shared_budget_update_preview",
+    "description": "Preview a typed LOC shared-budget update.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "sharedBudgetId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "name",
+        "type": "null | string",
+        "desc": ""
+      },
+      {
+        "name": "startTime",
+        "type": "null | string",
+        "desc": ""
+      },
+      {
+        "name": "endTime",
+        "type": "null | string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "null | object",
+        "desc": ""
+      },
+      {
+        "name": "billingProfile",
+        "type": "string",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "shared_budgets_query",
+    "description": "Query bounded shared-budget metadata without invoice contacts.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "supported_app_languages",
+    "description": "Query bounded App Store advertising language metadata.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "target_cpa_recommendation_apply_preview",
+    "description": "Preview applying one target-CPA recommendation under an explicit maximum.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "recommendationId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "promotedObjectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "appliedAmount",
+        "type": "null | object",
+        "desc": ""
+      },
+      {
+        "name": "maximumAmount",
+        "type": "null | object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "target_cpa_recommendation_dismiss_preview",
+    "description": "Preview dismissing one target-CPA recommendation.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "recommendationId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "promotedObjectId",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "appliedAmount",
+        "type": "null | object",
+        "desc": ""
+      },
+      {
+        "name": "maximumAmount",
+        "type": "null | object",
+        "desc": ""
+      }
+    ]
+  },
+  {
+    "name": "target_cpa_recommendations",
+    "description": "Read target-CPA recommendations without applying them.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  },
+  {
+    "name": "target_cpa_suggestions",
+    "description": "Get target CPA suggestions.",
+    "arguments": [
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "local Apple Ads profile name"
+      },
+      {
+        "name": "adAccountId",
+        "type": "string",
+        "desc": "Apple Ads ad account ID"
+      },
+      {
+        "name": "filters",
+        "type": "null | array",
+        "desc": "endpoint-specific filter conditions"
+      },
+      {
+        "name": "sorting",
+        "type": "null | array",
+        "desc": "ordered sort fields"
+      },
+      {
+        "name": "pagination",
+        "type": "null | object",
+        "desc": "bounded result window"
+      },
+      {
+        "name": "fields",
+        "type": "null | array",
+        "desc": "report fields to return"
+      },
+      {
+        "name": "groupBy",
+        "type": "null | array",
+        "desc": "report dimensions"
+      },
+      {
+        "name": "timeRange",
+        "type": "null | object",
+        "desc": "report or insight time range"
+      },
+      {
+        "name": "options",
+        "type": "null | object",
+        "desc": "report or insight options"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** Apple Ads
**Repository URL:** https://github.com/zelentsov-dev/apple-ads-mcp
**Brief Description:** Local-first Apple Ads Platform API v1 tools for account health, app eligibility, campaign inventory, research, reports, and receipt-gated campaign operations. Read-only by default.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Published in the official MCP Registry
- [x] **Active Development**: Current release v0.3.5
- [x] **Docker Artifact**: Multi-platform OCI image and Dockerfile
- [x] **Documentation**: Homebrew, release archive, OCI, and client setup instructions
- [x] **Security Contact**: GitHub private vulnerability reporting documented in SECURITY.md

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name apple-ads-mcp`
- [x] I have built the MCP Server using `task build -- --pull-community --tools apple-ads-mcp`
- [ ] If the server requires credentials to test it, I have shared test credentials using the review form

## Verification and security notes

- The catalog entry uses the public multi-platform image `ghcr.io/zelentsov-dev/apple-ads-mcp:v0.3.5` (manifest digest `sha256:e2624286e02cb7bfbac8050b5c50ccc426ffe424815f0a44c4b6e121fa41707e`).
- `tools.json` contains the statically exported 110-tool inventory, so automated catalog validation does not require Apple Ads credentials.
- The private key is a read-only host mount. It is never copied into the image or submitted to this repository.
- `APPLE_ADS_ALLOW_WRITES=false` and `APPLE_ADS_ALLOW_DELETES=false` are fixed in this catalog entry.
- Real Apple Ads credentials are intentionally not shared. Maintainers can review the static tool inventory and run the public image without credentials for MCP initialization; authenticated Apple API calls require credentials owned by the tester.