### PR TITLE
Add PairBook (stock & ETF correlation and overlap)

### DIFF
--- a/servers/pairbook/server.yaml
+++ b/servers/pairbook/server.yaml
@@ -11,8 +11,8 @@ meta:
 about:
   title: PairBook
   description: Correlation, ETF holdings overlap, beta, volatility and diversification for 4,700+ US stocks and ETFs. Any of the 11.3 million possible pairs can be compared, with 52,000+ popular pairs precomputed from issuer disclosures and the rest computed on demand from weekly return series. Data comes from the free PairBook API, refreshes every trading day after the US close, and needs no API key or account.
-  icon: https://raw.githubusercontent.com/vj88-coder/pairbook-mcp/main/.github/logo.png
+  icon: https://raw.githubusercontent.com/pairbook-io/pairbook-mcp/main/.github/logo.png
 source:
-  project: https://github.com/vj88-coder/pairbook-mcp
+  project: https://github.com/pairbook-io/pairbook-mcp
   branch: main
   commit: 96cffa2405917453ab3e0113b3579f70a16b50e5

--- a/servers/pairbook/server.yaml
+++ b/servers/pairbook/server.yaml
@@ -1,0 +1,18 @@
+name: pairbook
+image: mcp/pairbook
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - stocks
+    - etf
+    - correlation
+about:
+  title: PairBook
+  description: Correlation, ETF holdings overlap, beta, volatility and diversification for 4,700+ US stocks and ETFs. Any of the 11.3 million possible pairs can be compared, with 52,000+ popular pairs precomputed from issuer disclosures and the rest computed on demand from weekly return series. Data comes from the free PairBook API, refreshes every trading day after the US close, and needs no API key or account.
+  icon: https://raw.githubusercontent.com/vj88-coder/pairbook-mcp/main/.github/logo.png
+source:
+  project: https://github.com/vj88-coder/pairbook-mcp
+  branch: main
+  commit: 96cffa2405917453ab3e0113b3579f70a16b50e5


### PR DESCRIPTION
Adds PairBook, a read-only finance MCP server: correlation (1/3/5-year weekly), covariance, beta vs S&P 500, volatility, max drawdown, fund facts and issuer-sourced ETF holdings overlap for 4,700+ US stocks and ETFs. Any of the 11.3M possible pairs can be compared; 52,000+ come precomputed and the rest are computed on demand from weekly return series.

- Source: https://github.com/pairbook-io/pairbook-mcp (MIT, Dockerfile at root, pinned commit in server.yaml)
- No secrets or configuration: the server talks to the free public PairBook API (www.pairbook.io), no API key, no account
- stdio transport, 5 read-only tools with annotations and output schemas, 19 protocol-level tests, CI on Node 18/20/22
- Also on npm (pairbook-mcp) and the official MCP registry (io.github.pairbook-io/pairbook-mcp)