### PR TITLE
Add trends-mcp (local stdio) to the Docker MCP catalog

### DIFF
--- a/servers/trends-mcp/readme.md
+++ b/servers/trends-mcp/readme.md
@@ -1,0 +1,7 @@
+# Trends MCP
+
+Hosted product and docs: https://www.trendsmcp.ai/docs
+
+GitHub (stdio adapter + Dockerfile): https://github.com/trendsmcp-ai/Trends-MCP
+
+Get an API key: https://www.trendsmcp.ai/account

--- a/servers/trends-mcp/server.yaml
+++ b/servers/trends-mcp/server.yaml
@@ -1,0 +1,26 @@
+name: trends-mcp
+image: mcp/trends-mcp
+type: server
+meta:
+  category: search
+  tags:
+    - search
+    - trends
+    - google
+    - tiktok
+    - youtube
+    - research
+about:
+  title: Trends MCP
+  description: Live trend data from Google, TikTok, YouTube, Amazon, Reddit, and 30+ other sources via one MCP connection.
+  icon: https://www.google.com/s2/favicons?domain=trendsmcp.ai&sz=64
+source:
+  project: https://github.com/trendsmcp-ai/Trends-MCP
+  commit: 236fbdf7bcb3a9d9188a4ce81205f7120293031b
+config:
+  description: API key from https://www.trendsmcp.ai/account (100 free requests/month). tools/list works with no key.
+  secrets:
+    - name: trends-mcp.api_key
+      env: TRENDSMCP_API_KEY
+      example: YOUR_API_KEY
+      description: Free key at [trendsmcp.ai/account](https://www.trendsmcp.ai/account). Paid tool calls bill this key. Never commit a real key.

--- a/servers/trends-mcp/tools.json
+++ b/servers/trends-mcp/tools.json
@@ -1,0 +1,60 @@
+[
+  {
+    "name": "get_trends",
+    "description": "Return about 5 years of weekly or daily interest for one keyword on one source, 0-100. Use for history and whether interest is durable. Do not use for today's leaderboard (get_top_trends) or percent change (get_growth). Requires TRENDSMCP_API_KEY.",
+    "arguments": [
+      {
+        "name": "keyword",
+        "type": "string",
+        "desc": "Keyword in the format required by the source"
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "One source, lowercase catalog name. Examples: google search, youtube, tiktok, reddit, amazon"
+      },
+      {
+        "name": "data_mode",
+        "type": "string",
+        "desc": "weekly (default) or daily"
+      }
+    ]
+  },
+  {
+    "name": "get_growth",
+    "description": "Return percent change for a keyword over one or more windows (7D to 5Y). source may be a comma-separated list to compare platforms in one call. Requires TRENDSMCP_API_KEY.",
+    "arguments": [
+      {
+        "name": "keyword",
+        "type": "string",
+        "desc": "Keyword in the format required by the source"
+      },
+      {
+        "name": "source",
+        "type": "string",
+        "desc": "One source, or a comma-separated list such as google search, tiktok, amazon"
+      },
+      {
+        "name": "percent_growth",
+        "type": "string",
+        "desc": "Comma-separated presets such as 3M,1Y,12M"
+      }
+    ]
+  },
+  {
+    "name": "get_top_trends",
+    "description": "Live leaderboard. No keyword. Use for what is trending on a platform right now. type must match the feed name exactly. Requires TRENDSMCP_API_KEY.",
+    "arguments": [
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "Feed name exactly, e.g. Google Trends, TikTok Trending Hashtags, YouTube Trending"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Number of results to return"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** trends-mcp
**Repository URL:** https://github.com/trendsmcp-ai/Trends-MCP
**Brief Description:** Live trend data from Google, TikTok, YouTube, Amazon, Reddit, and 30+ other sources. Stdio adapter in a container; paid tools use TRENDSMCP_API_KEY at runtime.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: stdio MCP (FastMCP); tools/list works with no API key
- [x] **Active Development**: Recent commits on https://github.com/trendsmcp-ai/Trends-MCP
- [x] **Docker Artifact**: Dockerfile at repo root (pinned commit 236fbdf7bcb3a9d9188a4ce81205f7120293031b)
- [x] **Documentation**: README plus https://www.trendsmcp.ai/docs
- [x] **Security Contact**: SECURITY.md (security@trendsmcp.ai)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name trends-mcp` (Go/Task not available in this submit environment; please run CI)
- [x] I have built the MCP Server using `task build -- --tools trends-mcp` (tools.json is included so listing does not need a key)
- [x] If the server requires credentials to test it, I have shared test credentials using this form

## Security notes

- No live API keys in this PR. `server.yaml` uses example `YOUR_API_KEY` only.
- Secret env is `TRENDSMCP_API_KEY`. Docker should inject it at runtime, not bake it into the image.
- `tools.json` lists the three tools so catalog generation does not need credentials.

A free test key can be issued at https://www.trendsmcp.ai/account and sent only via the Docker review form, not in this PR.

## Related

There is an older remote-server PR: https://github.com/docker/mcp-registry/pull/3922 (same name). This entry is the local/container path now that the repo has a Dockerfile. Happy to close 3922 if you want a single `trends-mcp` name.

Made with [Cursor](https://cursor.com)