### PR TITLE
Add your-mail-mcp

### DIFF
--- a/servers/your-mail-mcp/server.yaml
+++ b/servers/your-mail-mcp/server.yaml
@@ -1,0 +1,36 @@
+name: your-mail-mcp
+image: ghcr.io/wildsurfer/your-mail-mcp
+type: server
+longLived: true
+meta:
+  category: communication
+  tags:
+    - email
+    - imap
+    - gmail
+    - icloud
+    - notmuch
+    - read-only
+    - communication
+about:
+  title: Your Mail
+  description: Read-only access to your IMAP mailboxes, several accounts at once, from Gmail, iCloud or any other provider. Mail is mirrored one way into a local maildir by mbsync and indexed by notmuch, so search runs locally and the process cannot send, delete, move or tag mail. Junk and trash are excluded from search by default. Eleven read tools cover search, threads, counts, folders, attachments and sync status.
+  icon: https://avatars.githubusercontent.com/u/1456389?s=200&v=4
+source:
+  project: https://github.com/wildsurfer/your-mail-mcp
+  commit: 099289e6786a71910ad4884e5f5f8963f9e6b8d2
+run:
+  volumes:
+    - "{{your-mail-mcp.accounts}}:/config/accounts.json:ro"
+    - your-mail-mcp-mail:/mail
+    - your-mail-mcp-index:/index
+config:
+  description: Path on this machine to an accounts.json that lists the IMAP accounts (name, host, user, password) in the format from the README. Write the passwords into the file as plain values and keep it readable by you alone. The mirror and the index live in the your-mail-mcp-mail and your-mail-mcp-index volumes.
+  parameters:
+    type: object
+    properties:
+      accounts:
+        type: string
+        description: Path to accounts.json on this machine
+    required:
+      - accounts


### PR DESCRIPTION
## MCP Server Information

**Server Name:** your-mail-mcp
**Repository URL:** https://github.com/wildsurfer/your-mail-mcp
**Brief Description:** Read-only access to one or more IMAP accounts (Gmail, iCloud, any provider). Mail is mirrored one way into a local maildir by mbsync and indexed by notmuch, so search runs locally and the process cannot send, delete, move or tag mail. Eleven read tools. Self-provided image on GHCR (`ghcr.io/wildsurfer/your-mail-mcp`), linux/amd64 and linux/arm64.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes for the reviewer

The server needs one configuration value, the host path of an `accounts.json` that lists the IMAP accounts. It is mounted read-only at `/config/accounts.json`; the mirror and the index live in two named volumes so they survive between sessions. Without the file the server still starts and lists its tools, and `status` says what to mount.

The entry is `longLived`: the container runs mbsync and notmuch in the background for the life of the session, so one container per tool call would restart the sync on every call.

Tested locally with `task validate`, `task build -- --tools --pull-community` (11 tools) and a run through `docker mcp gateway run --catalog ... --config ... --servers your-mail-mcp --long-lived` calling `status`, which reported the configured account.

Any IMAP account with an app password works for testing; the README's provider notes cover Gmail and iCloud.
