### PR TITLE
Add truenas-mcp server entry

### DIFF
--- a/servers/truenas-mcp/server.yaml
+++ b/servers/truenas-mcp/server.yaml
@@ -1,0 +1,28 @@
+name: truenas-mcp
+image: mcp/truenas-mcp
+type: server
+meta:
+  category: infrastructure
+  tags:
+    - truenas
+    - nas
+    - storage
+    - zfs
+    - homelab
+about:
+  title: TrueNAS
+  description: The most comprehensive MCP server for TrueNAS SCALE — 278 actions across 18 categories of the TrueNAS REST API (storage pools, datasets, shares, snapshots, VMs, apps, network), behind one hierarchical tool instead of one tool per action. Destructive operations require an explicit confirm flag.
+  icon: https://avatars.githubusercontent.com/u/8328281?v=4
+source:
+  project: https://github.com/spranab/truenas-mcp
+  branch: master
+  commit: 5afb8870aebb24b09ddf7a15eed22ceda82b9d7c
+config:
+  description: Configure the connection to your TrueNAS SCALE instance
+  secrets:
+    - name: truenas-mcp.api_key
+      env: TRUENAS_API_KEY
+      example: 1-abc123def456
+    - name: truenas-mcp.url
+      env: TRUENAS_URL
+      example: https://truenas.local


### PR DESCRIPTION
Adds [spranab/truenas-mcp](https://github.com/spranab/truenas-mcp) — an MCP server for TrueNAS SCALE exposing 278 REST API actions (storage pools, datasets, shares, snapshots, VMs, apps, network) behind one hierarchical tool instead of one tool per action.

- MIT licensed
- Dockerfile added upstream (spranab/truenas-mcp@5afb887) — multi-stage build, npm ci + tsc from a clean checkout of the pinned commit
- Requires network access to reach the user's own TrueNAS instance (`TRUENAS_URL`), so no `disableNetwork`
- `task validate` and `task build -- --tools truenas-mcp` both pass locally; verified the built image fails fast with a clear error when `TRUENAS_URL`/`TRUENAS_API_KEY` are unset
- Author disclosure: I'm the maintainer of this server.