### PR TITLE
Add SandBase Harness MCP server

### DIFF
--- a/servers/sandbase-harness/readme.md
+++ b/servers/sandbase-harness/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md

--- a/servers/sandbase-harness/server.yaml
+++ b/servers/sandbase-harness/server.yaml
@@ -1,0 +1,36 @@
+name: sandbase-harness
+image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8
+type: server
+meta:
+  category: devops
+  tags:
+    - agent-runtime
+    - sandbox
+    - sessions
+    - memory
+    - audit
+    - mcp
+about:
+  title: SandBase Harness
+  description: Local-first AI agent runtime with sandboxed sessions, durable state, memory, credentials, audit/replay, and an MCP bridge.
+  icon: https://raw.githubusercontent.com/sandbaseai/sandbase-harness/main/docs/assets/sandbase-harness-icon.png
+source:
+  project: https://github.com/sandbaseai/sandbase-harness
+  commit: dea25a2741ca2a494567aae13617f239bb542c03
+config:
+  description: Connect the MCP bridge to a running SandBase Harness API.
+  secrets:
+    - name: sandbase-harness.api_key
+      env: MANAGED_AGENTS_API_KEY
+      example: YOUR_RUNTIME_API_KEY
+  env:
+    - name: MANAGED_AGENTS_URL
+      example: http://host.docker.internal:3000
+      value: "{{sandbase-harness.managed_agents_url}}"
+  parameters:
+    type: object
+    properties:
+      managed_agents_url:
+        type: string
+    required:
+      - managed_agents_url

--- a/servers/sandbase-harness/tools.json
+++ b/servers/sandbase-harness/tools.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "list_agents",
+    "description": "List agents available in the connected SandBase managed-agents runtime."
+  },
+  {
+    "name": "create_session",
+    "description": "Create a SandBase managed-agents session for an agent."
+  },
+  {
+    "name": "run_session",
+    "description": "Send a message to a session and wait until its streamed turn becomes idle."
+  },
+  {
+    "name": "get_session",
+    "description": "Get the current state and usage of a managed-agents session."
+  },
+  {
+    "name": "list_artifacts",
+    "description": "List artifacts produced by a managed-agents session."
+  },
+  {
+    "name": "stop_session",
+    "description": "Stop a running managed-agents session."
+  }
+]


### PR DESCRIPTION
## Summary
- add SandBase Harness to the Docker MCP Registry
- use the published GHCR image `ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8`
- document the six tools, runtime URL, optional API key, pinned source commit, and project icon

## Validation
- `go run ./cmd/validate -name sandbase-harness`
- all registry validation checks pass
- published image completed an MCP initialize handshake over stdio