### PR TITLE
Add SandBase Harness MCP server

### DIFF
--- a/servers/sandbase-harness/server.yaml
+++ b/servers/sandbase-harness/server.yaml
@@ -1,0 +1,40 @@
+name: sandbase-harness
+image: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8
+type: server
+meta:
+  category: ai
+  tags:
+    - agent-runtime
+    - agent-harness
+    - sandbox
+    - sessions
+    - self-hosted
+about:
+  title: SandBase Harness
+  description: Local-first, self-hosted runtime and MCP bridge for creating, running, inspecting, and stopping sandboxed AI agent sessions with artifacts, approvals, audit, and replay.
+  icon: https://avatars.githubusercontent.com/u/207462174?s=200&v=4
+source:
+  project: https://github.com/sandbaseai/sandbase-harness
+  branch: main
+  commit: 5e1264afdc6192382bf12277c2996dd164d572cd
+  dockerfile: Dockerfile.mcp
+config:
+  description: Configure the connection to a SandBase Harness API deployment.
+  secrets:
+    - name: sandbase-harness.managed_agents_api_key
+      env: MANAGED_AGENTS_API_KEY
+      example: YOUR_HARNESS_API_KEY
+      required: false
+  env:
+    - name: MANAGED_AGENTS_URL
+      example: http://host.docker.internal:3000
+      value: "{{sandbase-harness.managed_agents_url}}"
+  parameters:
+    type: object
+    properties:
+      managed_agents_url:
+        type: string
+        description: Base URL of the connected SandBase Harness API.
+        example: http://host.docker.internal:3000
+    required:
+      - managed_agents_url


### PR DESCRIPTION
## MCP Server Information

**Server Name:** SandBase Harness
**Repository URL:** https://github.com/sandbaseai/sandbase-harness
**Brief Description:** Local-first, self-hosted runtime and stdio MCP bridge for managed AI agent sessions with sandboxed execution, artifacts, approvals, audit, and replay.

## Basic Requirements

- [x] **Open Source**: Apache-2.0
- [x] **MCP Compliant**: Verified with MCP `initialize` and `tools/list`
- [x] **Active Development**: Source commit pinned to current `main`
- [x] **Docker Artifact**: Self-provided multi-architecture GHCR image
- [x] **Documentation**: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md (current installation guide); legacy MCP-specific notes: https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md
- [x] **Security Contact**: https://github.com/sandbaseai/sandbase-harness/blob/main/SECURITY.md

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [x] `go run ./cmd/validate --name sandbase-harness` passes
- [x] Pulled and probed `ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8` successfully; the image returned all six tools
- [ ] Test credentials are not required to list tools; session calls require a user-provided Harness API URL and optional API key

The entry uses the self-provided image path and pins the SandBase source commit and `Dockerfile.mcp`.
