### PR TITLE
Add Ava remote MCP server

### DIFF
--- a/servers/ava/server.yaml
+++ b/servers/ava/server.yaml
@@ -1,0 +1,18 @@
+name: ava
+type: remote
+dynamic:
+    tools: true
+meta:
+    category: finance
+    tags:
+        - defi
+        - blockchain
+        - wallet
+        - remote
+about:
+    title: Ava
+    description: Ava is the execution layer for AI agents that do DeFi. It turns one sentence into a multi-leg, cross-chain plan (lend, borrow, swap, bridge) where each leg is re-derived from the request before signing and bounded by a mandate the agent cannot exceed. Dependent legs resolve at execution time, so a leg that follows a bridge supplies the amount that actually arrived rather than the amount requested. Every settlement returns a hash-chained receipt whose verification endpoint reports record integrity and on-chain standing as separate fields, so a third party can re-check what was authorized against what settled, with no credential. Live on Base, Avalanche, BNB Chain and Monad.
+    icon: https://www.getava.xyz/icon.svg
+remote:
+    transport_type: streamable-http
+    url: https://api.getava.xyz/mcp


### PR DESCRIPTION
Adds Ava, a remote streamable-HTTP MCP server (no container needed).

- Endpoint: https://api.getava.xyz/mcp
- Site: https://www.getava.xyz
- Repo: https://github.com/kamalbuilds/ava-4.0
- Also listed in the official MCP registry as `xyz.getava/ava`

Ava lets a coding agent execute multi-leg cross-chain DeFi (lend, borrow, swap, bridge) under a mandate it cannot exceed, and returns a hash-chained receipt that can be re-verified against chain state without a credential. Live on Base, Avalanche, BNB Chain and Monad.

An unauthenticated `tools/list` against the endpoint returns the full tool schema, so the scan should enumerate cleanly.