### PR TITLE
Add mobile-mcp (Mobile Next) — mobile automation for AI agents

### DIFF
--- a/servers/mobile-mcp/server.yaml
+++ b/servers/mobile-mcp/server.yaml
@@ -1,0 +1,20 @@
+name: mobile-mcp
+image: mcp/mobile-mcp
+type: server
+meta:
+  category: automation
+  tags:
+    - mobile
+    - android
+    - automation
+    - testing
+about:
+  title: Mobile Next — Mobile MCP
+  description: Mobile automation for AI agents: control Android devices and emulators — tap, swipe, type, launch apps, take screenshots, and read the accessibility tree. Devices are reached through the host's adb server (ADB_SERVER_SOCKET=tcp:host.docker.internal:5037), so enable adb on the host and connect devices there. iOS requires running mobile-mcp natively on macOS and is not available in this container.
+  icon: https://raw.githubusercontent.com/mobile-next/mobile-mcp/main/mobile-mcp.png
+source:
+  project: https://github.com/mobile-next/mobile-mcp
+  branch: main
+  commit: a06b9e1e6ccbd40b9c7aec89d6f89f08ab44b96e
+config:
+  description: Requires a running adb server on the Docker host with at least one connected Android device or emulator. On Linux Docker Engine, run with --add-host=host.docker.internal:host-gateway (resolves automatically on Docker Desktop for Mac/Windows). No secrets required.


### PR DESCRIPTION
Adds [mobile-next/mobile-mcp](https://github.com/mobile-next/mobile-mcp) (Apache-2.0, ~19k users via npm/other MCP registries) as a Docker-built server.

- Node.js/TypeScript MCP server for mobile automation: tap, swipe, type, launch apps, screenshots, accessibility tree.
- Android devices/emulators are reached through the host's adb server via `ADB_SERVER_SOCKET=tcp:host.docker.internal:5037` (Dockerfile default; on Linux Engine add `--add-host=host.docker.internal:host-gateway`). iOS requires native macOS and is documented as unavailable in the container.
- No secrets required. Container runs as non-root (uid 1000).
- Dockerfile is in the upstream repo at the pinned commit; image built and MCP initialize handshake verified over stdio.
