### PR TITLE
Add Truth Bear (GAUGE) remote MCP server

### DIFF
--- a/servers/truthbear-gauge-remote/readme.md
+++ b/servers/truthbear-gauge-remote/readme.md
@@ -1,0 +1,26 @@
+# Truth Bear (GAUGE)
+
+Verify official facts from government and institutional sources with Bitcoin-anchored proof.
+
+## Features
+
+- **180+ signals** from FRED, USGS, SEC EDGAR, NOAA, EPA, and more
+- **Bitcoin-anchored proof**: SHA-256 record_hash anchored via daily Merkle tree + OpenTimestamps
+- **3-source cross-validation** in bundle tiers
+- **No API key** — free tools need no wallet; paid tools settle via x402 (USDC on Base)
+
+## Usage
+
+This is a remote MCP server. Connect to it at:
+
+```
+https://api.truthbear.co/mcp
+```
+
+No authentication required for free tools.
+
+## Links
+
+- [Website](https://truthbear.co)
+- [npm](https://www.npmjs.com/package/mcp-gauge-x402)
+- [Source](https://github.com/CHANGCHINFU/mcp-gauge)

--- a/servers/truthbear-gauge-remote/server.yaml
+++ b/servers/truthbear-gauge-remote/server.yaml
@@ -1,0 +1,20 @@
+name: truthbear-gauge-remote
+type: remote
+meta:
+  category: data
+  tags:
+    - data
+    - verification
+    - government
+    - finance
+    - environment
+    - remote
+    - x402
+about:
+  title: Truth Bear (GAUGE)
+  description: Verify official facts from 180+ government sources (FRED, USGS, SEC EDGAR, NOAA, EPA) with Bitcoin-anchored proof. Each record includes source URL and SHA-256 record_hash anchored via OpenTimestamps. Free preview tools included, paid tools settle via x402.
+  icon: https://avatars.githubusercontent.com/u/74649886?s=200&v=4
+  source_url: https://github.com/CHANGCHINFU/mcp-gauge
+remote:
+  transport_type: streamable-http
+  url: https://api.truthbear.co/mcp

--- a/servers/truthbear-gauge-remote/tools.json
+++ b/servers/truthbear-gauge-remote/tools.json
@@ -1,0 +1,7 @@
+[
+  {"name": "gauge_catalog", "description": "Browse 180+ available official data signals"},
+  {"name": "gauge_preview", "description": "Preview a signal before paying"},
+  {"name": "gauge_sample", "description": "Get a sample data point"},
+  {"name": "gauge_river_free", "description": "Free river/water reading"},
+  {"name": "gauge_anchor", "description": "Verify any record_hash against Bitcoin"}
+]


### PR DESCRIPTION
## Summary

Adds Truth Bear (GAUGE) as a remote MCP server — verifiable official facts from 180+ government sources with Bitcoin-anchored proof.

## Server Details

- **Type:** Remote (streamable-http)
- **URL:** `https://api.truthbear.co/mcp`
- **Category:** Data
- **Authentication:** None required for free tools
- **License:** MIT

## What it does

- 180+ signals from FRED, USGS, SEC EDGAR, NOAA, EPA, and more
- Each record includes: source URL + SHA-256 record_hash anchored to Bitcoin via OpenTimestamps
- 5 free tools (catalog, preview, sample, river reading, anchor verification)
- Paid tools settle per call via x402 (USDC on Base) — no API key needed

## Links

- [Source](https://github.com/CHANGCHINFU/mcp-gauge)
- [npm](https://www.npmjs.com/package/mcp-gauge-x402)
- [Website](https://truthbear.co)