### PR TITLE
Add cloud-tools

### DIFF
--- a/servers/cloud-tools/server.yaml
+++ b/servers/cloud-tools/server.yaml
@@ -1,0 +1,30 @@
+name: cloud-tools
+image: mcp/cloud-tools
+type: server
+meta:
+  category: monitoring
+  tags:
+    - mcp
+    - finops
+    - cloud-cost
+about:
+  title: cloud-tools
+  description: >-
+    Multi-cloud cost, inventory and waste analysis over MCP — what you spend by
+    service, region and account, and what is idle, oversized,
+    previous-generation, unattached or a commitment you are not consuming. AWS,
+    GCP, Cloudflare and OVH, each behind that cloud's own credential mechanism.
+    Seven tools, each taking the cloud as an argument, and every finding carries
+    the utilisation evidence behind it.
+  icon: https://raw.githubusercontent.com/munhq/cloud-tools/main/docs/brand/icon-512.png
+source:
+  project: https://github.com/munhq/cloud-tools
+  branch: main
+  commit: 6fde4d3af03904c9dcf8ecfede392031e951d34f
+run:
+  disableNetwork: false
+config:
+  description: cloud-tools needs no configuration
+  parameters:
+    type: object
+    properties: {}


### PR DESCRIPTION
Multi-cloud cost, inventory and waste analysis over MCP — what you spend by service, region and account, and what is idle, oversized, previous-generation, unattached, or a commitment you are not consuming. AWS, GCP, Cloudflare and OVH.

Seven tools, each taking `cloud` and `credentials`: `get_costs`, `compare_costs`, `get_inventory`, `get_waste`, `get_commitments`, `get_recommendations`, `get_cross_cloud_summary`.

- Repository: https://github.com/munhq/cloud-tools
- Licence: Apache-2.0
- Dockerfile at the repository root, pinned here to commit `6fde4d3`, which contains it.
- The image needs network access: every tool calls a cloud provider's API, so `disableNetwork` is false.
- Credentials are passed per call and never stored.