### PR TITLE
Add distil

### DIFF
--- a/servers/distil/server.yaml
+++ b/servers/distil/server.yaml
@@ -1,0 +1,27 @@
+name: distil
+image: mcp/distil
+type: server
+meta:
+  category: development
+  tags:
+    - mcp
+    - developer-tools
+    - context-window
+about:
+  title: distil
+  description: >-
+    Context optimization middleware for LLM agents — a dynamic tool registry,
+    result masking, token budgeting and smart compaction, so a long session
+    stays inside its window instead of failing for length.
+  icon: https://raw.githubusercontent.com/munhq/distil/main/docs/brand/icon-512.png
+source:
+  project: https://github.com/munhq/distil
+  branch: main
+  commit: b658e92684b3e58e8019f578a8ffaa8ade87db55
+run:
+  disableNetwork: true
+config:
+  description: distil needs no configuration
+  parameters:
+    type: object
+    properties: {}


### PR DESCRIPTION
Context optimization middleware for LLM agents — a dynamic tool registry, result masking, token budgeting and smart compaction, so a long session stays inside its window instead of failing for length. It measures where a session's tokens actually go, then compresses the conversation rather than truncating it.

- Repository: https://github.com/munhq/distil
- Licence: MIT OR Apache-2.0
- Dockerfile at the repository root, pinned here to commit `b658e92`, which contains it.
- `disableNetwork: true` — distil works on conversation payloads it is given and calls no external service.