### PR TITLE
Add neurarch-mcp

### DIFF
--- a/servers/neurarch-mcp/server.yaml
+++ b/servers/neurarch-mcp/server.yaml
@@ -12,7 +12,7 @@ meta:
 about:
   title: Neurarch
   description: Structural awareness of a PyTorch model for the agent. Inspect layers, parameters, FLOPs and blast radius; run the design linter; get the full readiness, cost and deployment verdict; rank candidate designs before training. Reads 81 bundled reference architectures (zoo:<id>), a Hugging Face repo (hf:<org/name>) or model text passed inline.
-  icon: https://avatars.githubusercontent.com/u/neurarch-ai
+  icon: https://github.com/neurarch-ai.png
 source:
   project: https://github.com/neurarch-ai/neurarch-mcp
   branch: main

--- a/servers/neurarch-mcp/server.yaml
+++ b/servers/neurarch-mcp/server.yaml
@@ -1,0 +1,26 @@
+name: neurarch-mcp
+image: mcp/neurarch-mcp
+type: server
+meta:
+  category: ai-ml
+  tags:
+    - pytorch
+    - machine-learning
+    - neural-network
+    - lint
+    - code-review
+about:
+  title: Neurarch
+  description: Structural awareness of a PyTorch model for the agent. Inspect layers, parameters, FLOPs and blast radius; run the design linter; get the full readiness, cost and deployment verdict; rank candidate designs before training. Reads 81 bundled reference architectures (zoo:<id>), a Hugging Face repo (hf:<org/name>) or model text passed inline.
+  icon: https://avatars.githubusercontent.com/u/neurarch-ai
+source:
+  project: https://github.com/neurarch-ai/neurarch-mcp
+  branch: main
+  commit: 8552c74e4e45d59dd4f70dca573cbff590121b25
+  dockerfile: Dockerfile
+config:
+  description: Optional Hugging Face token for gated repos (hf:meta-llama/...). Everything else runs offline inside the container.
+  secrets:
+    - name: neurarch-mcp.hf_token
+      env: HF_TOKEN
+      example: hf_xxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Adds **neurarch-mcp** (https://github.com/neurarch-ai/neurarch-mcp, MIT, npm `neurarch-mcp` 0.13.0) as a local server built from the `Dockerfile` at the repo root.

What it does: gives an agent structural awareness of a PyTorch model. Tools inspect layers, parameters, FLOPs and the blast radius of an edit; `lint_model` runs the structural design rules; `check_design` returns the readiness / cost / deployment verdict; `rank_designs` orders candidate designs before any GPU time is spent. Inside the container it runs in hosted stdio mode (`--hosted --hf --tools=core`): nothing is mounted, so every call names its model as `model_path: "zoo:<id>"` (81 bundled reference architectures), `model_path: "hf:<org/name>"`, or `model_source` with the model text inline.

- Only runtime dependency is `@modelcontextprotocol/sdk`; the parser, rule engine and verifier are vendored, so the container makes no network call except `huggingface.co` on an explicit `hf:` request.
- `HF_TOKEN` is an optional secret for gated repos.
- Verified locally: `node dist/index.js --hosted --tools=core` answers `initialize` and a `tools/call` over raw stdio with no model file present. I could not run `task create` on this machine (no Docker Desktop here), so the image build is left to CI; happy to adjust if it asks for anything.

Opened by an automated agent on behalf of the maintainer.