### PR TITLE
Add openfang-rail (remote MCP: deterministic identity & rental checks, x402 per-call payments)

### DIFF
--- a/servers/openfang-rail/server.yaml
+++ b/servers/openfang-rail/server.yaml
@@ -1,0 +1,19 @@
+name: openfang-rail
+type: remote
+meta:
+  category: finance
+  tags:
+    - finance
+    - validation
+    - identity
+    - x402
+    - remote
+about:
+  title: openfang-rail
+  description: Deterministic business-identity validation (IBAN, LEI, VAT, UK company number) and rental due-diligence checks, with a signed, offline-verifiable receipt on every result. Free tier, no signup; beyond it, calls are paid per request via x402 (gasless EIP-3009 USDC on Base).
+  icon: https://avatars.githubusercontent.com/u/56400197?v=4
+remote:
+  transport_type: streamable-http
+  url: https://rail.akrivis.in/mcp
+source:
+  project: https://github.com/89rat/openfang-rail


### PR DESCRIPTION
## What

Adds [openfang-rail](https://hcrb.in) as a **remote** MCP server entry (`type: remote`, `streamable-http`).

- **URL:** `https://hcrb.in/mcp` — standard MCP JSON-RPC 2.0 (`initialize` / `tools/list` / `tools/call`), no OAuth, no headers, dynamic tool discovery.
- **What it does:** 65 deterministic tools — business-identity validation (IBAN, LEI, VAT, UK company number, ISIN, EAN-13, GSTIN), rental due-diligence (deposit-safety, listing-risk), and on-chain lookups — every result ships with a signed XDR-1 receipt that verifies offline.
- **Auth/pricing:** free tier per day per client, no signup. Beyond it, calls are paid per request via [x402](https://www.x402.org/) (gasless EIP-3009 USDC on Base, non-custodial) — entirely transparent to an MCP client that doesn't pay (it just sees the free tier / 402 challenge on exhausted tools).
- **Verification:** the conformance suite this server scores 100/100 on is public and re-runnable: `npx github:89rat/x402-conformance https://hcrb.in` (MIT).

## Verification

- `initialize` → `serverInfo: code402`; `tools/list` → 65 tools (verified against the live endpoint today).
- No test credentials needed: no secrets, no config — the entry has an empty config surface by design.


