### PR TITLE
Add IMBA Agent Docs and Spend MCP servers

### DIFF
--- a/servers/imba-agent-docs/readme.md
+++ b/servers/imba-agent-docs/readme.md
@@ -1,0 +1,1 @@
+Docs: https://imbawallet.com/agent_api_about_en.html

--- a/servers/imba-agent-docs/server.yaml
+++ b/servers/imba-agent-docs/server.yaml
@@ -1,0 +1,17 @@
+name: imba-agent-docs
+image: mcp/imba-agent-docs
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - documentation
+    - ecommerce
+about:
+  title: IMBA Agent Docs
+  description: Read-only policy and HowTo for the prepaid IMBA Agent API. No deposit, buy, or withdraw.
+  icon: https://www.google.com/s2/favicons?domain=imbawallet.com&sz=64
+source:
+  project: https://github.com/IMBAwallet/agent-mcp
+  commit: 29a55ee88ffeb0a275be6d0e69f4d4ca0ad91916
+  dockerfile: Dockerfile.docs

--- a/servers/imba-agent-docs/tools.json
+++ b/servers/imba-agent-docs/tools.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "get_agent_facts",
+    "description": "Canonical prepaid-agent policy and catalog. Cite as-is. Does not move money.",
+    "arguments": []
+  },
+  {
+    "name": "get_agent_use_cases",
+    "description": "Playbook: Visa prepaid, travel eSIM, gift cards. Does not move money.",
+    "arguments": []
+  },
+  {
+    "name": "get_tier_policy",
+    "description": "Tier 0 vs 1+. Convert closed at 0. Withdraw stays closed.",
+    "arguments": []
+  },
+  {
+    "name": "get_catalog_placement",
+    "description": "Which directories take the docs MCP vs the spend MCP. OpenAI is docs-only.",
+    "arguments": []
+  },
+  {
+    "name": "get_public_url",
+    "description": "HTTP GET of an allowlisted public docs URL. Never calls register, deposit, or buy.",
+    "arguments": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "Absolute https://imbawallet.com URL from the public docs allowlist."
+      }
+    ]
+  },
+  {
+    "name": "list_docs_urls",
+    "description": "HowTo, use cases, tiers, discovery, OpenAPI, MCP endpoints.",
+    "arguments": []
+  }
+]

--- a/servers/imba-agent-spend/readme.md
+++ b/servers/imba-agent-spend/readme.md
@@ -1,0 +1,1 @@
+Docs: https://imbawallet.com/agent_api_about_en.html

--- a/servers/imba-agent-spend/server.yaml
+++ b/servers/imba-agent-spend/server.yaml
@@ -1,0 +1,34 @@
+name: imba-agent-spend
+image: mcp/imba-agent-spend
+type: server
+meta:
+  category: ecommerce
+  tags:
+    - ecommerce
+    - finance
+    - payments
+about:
+  title: IMBA Agent Spend
+  description: Deposit USDT TRC-20 and buy Visa prepaid, eSIM, and gift cards with your Ed25519 key. No withdraw. IMBA does not store a shared spend key.
+  icon: https://www.google.com/s2/favicons?domain=imbawallet.com&sz=64
+source:
+  project: https://github.com/IMBAwallet/agent-mcp
+  commit: 29a55ee88ffeb0a275be6d0e69f4d4ca0ad91916
+  dockerfile: Dockerfile.spend
+config:
+  description: Your agent client_id and Ed25519 private key. Never a Wallet JWT or a shared IMBA key.
+  secrets:
+    - name: imba-agent-spend.imba_agent_private_key
+      env: IMBA_AGENT_PRIVATE_KEY
+      example: YOUR_PKCS8_PEM_OR_BASE64URL
+  env:
+    - name: IMBA_AGENT_CLIENT_ID
+      example: YOUR_CLIENT_ID
+      value: "{{imba-agent-spend.imba_agent_client_id}}"
+  parameters:
+    type: object
+    properties:
+      imba_agent_client_id:
+        type: string
+    required:
+      - imba_agent_client_id

--- a/servers/imba-agent-spend/tools.json
+++ b/servers/imba-agent-spend/tools.json
@@ -1,0 +1,250 @@
+[
+  {
+    "name": "get_spend_policy",
+    "description": "Forbidden rails and tier rules. Read-only.",
+    "arguments": []
+  },
+  {
+    "name": "register_agent",
+    "description": "Register Ed25519 identity. Stdio only. No USDT.",
+    "arguments": [
+      {
+        "name": "public_key",
+        "type": "string",
+        "desc": "Ed25519 public key, PEM or base64."
+      },
+      {
+        "name": "tos_hash",
+        "type": "string",
+        "desc": "Optional terms hash.",
+        "optional": true
+      },
+      {
+        "name": "callback_url",
+        "type": "string",
+        "desc": "Optional HTTPS webhook URL.",
+        "optional": true
+      },
+      {
+        "name": "jwe_public_key",
+        "type": "string",
+        "desc": "Optional X25519 public key for card JWE.",
+        "optional": true
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Optional mailbox for 3-D Secure OTP. Not SMS.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_deposit_address",
+    "description": "USDT TRC-20 deposit address for the authenticated agent. Always re-fetch.",
+    "arguments": []
+  },
+  {
+    "name": "get_balance",
+    "description": "Ledger 2401 USDT balance.",
+    "arguments": []
+  },
+  {
+    "name": "list_cards",
+    "description": "List cards for the authenticated agent.",
+    "arguments": []
+  },
+  {
+    "name": "list_card_products",
+    "description": "List Visa prepaid products. Use id as imba_product_id for create_card.",
+    "arguments": []
+  },
+  {
+    "name": "list_gift_offers",
+    "description": "Live gift catalog. Then purchase_gift with offer_id and ext_id.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Optional search string.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "list_esim_plans",
+    "description": "Travel eSIM plans. Use plan id with purchase_esim.",
+    "arguments": [
+      {
+        "name": "country",
+        "type": "string",
+        "desc": "Optional ISO2 country.",
+        "optional": true
+      },
+      {
+        "name": "esim_provider",
+        "type": "string",
+        "desc": "Optional provider. Default yesim.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "create_card",
+    "description": "Buy a Visa prepaid from this agent 2401. ext_id required. Never Stars.",
+    "arguments": [
+      {
+        "name": "imba_product_id",
+        "type": "number",
+        "desc": "core.card_product.id from list_card_products."
+      },
+      {
+        "name": "ext_id",
+        "type": "string",
+        "desc": "Idempotency key."
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Optional cardholder KYC email.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "topup_card",
+    "description": "Top up a card this agent owns. ext_id required.",
+    "arguments": [
+      {
+        "name": "card_id",
+        "type": "string",
+        "desc": "Card id owned by this agent."
+      },
+      {
+        "name": "amount",
+        "type": "number",
+        "desc": "Top-up amount in USDT."
+      },
+      {
+        "name": "ext_id",
+        "type": "string",
+        "desc": "Idempotency key."
+      }
+    ]
+  },
+  {
+    "name": "purchase_gift",
+    "description": "Buy a brand gift code. ext_id required. Never Stars.",
+    "arguments": [
+      {
+        "name": "offer_id",
+        "type": "string",
+        "desc": "Offer id from list_gift_offers."
+      },
+      {
+        "name": "ext_id",
+        "type": "string",
+        "desc": "Idempotency key."
+      }
+    ]
+  },
+  {
+    "name": "purchase_esim",
+    "description": "Buy a travel eSIM. ext_id required. Never Stars.",
+    "arguments": [
+      {
+        "name": "plan_id",
+        "type": "string",
+        "desc": "Plan id from list_esim_plans."
+      },
+      {
+        "name": "ext_id",
+        "type": "string",
+        "desc": "Idempotency key."
+      },
+      {
+        "name": "iccid",
+        "type": "string",
+        "desc": "Optional existing ICCID owned by this agent.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_card_details",
+    "description": "Card credentials for a card this agent owns. PAN as JWE when registered.",
+    "arguments": [
+      {
+        "name": "card_id",
+        "type": "string",
+        "desc": "Card id owned by this agent."
+      }
+    ]
+  },
+  {
+    "name": "list_notifications",
+    "description": "Inbox and 3-D Secure OTP. Never SMS.",
+    "arguments": [
+      {
+        "name": "category",
+        "type": "string",
+        "desc": "Optional category. Default codes.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "set_webhook",
+    "description": "PATCH agent webhook URL, optional JWE key, optional OTP email.",
+    "arguments": [
+      {
+        "name": "callback_url",
+        "type": "string",
+        "desc": "HTTPS callback URL.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "rotate_hmac",
+    "description": "Rotate webhook HMAC. Requires callback_url first.",
+    "arguments": []
+  },
+  {
+    "name": "kyt_quote",
+    "description": "KYT price. Client schema, not partner.",
+    "arguments": []
+  },
+  {
+    "name": "kyt_check",
+    "description": "Paid KYT check. network + address only.",
+    "arguments": [
+      {
+        "name": "network",
+        "type": "string",
+        "desc": "Network name."
+      },
+      {
+        "name": "address",
+        "type": "string",
+        "desc": "Counterparty address to check."
+      }
+    ]
+  },
+  {
+    "name": "kyt_check_get",
+    "description": "KYT check by id. Own check only.",
+    "arguments": [
+      {
+        "name": "id",
+        "type": "number",
+        "desc": "Check id."
+      }
+    ]
+  },
+  {
+    "name": "kyt_checks",
+    "description": "KYT history for this agent.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** imba-agent-docs, imba-agent-spend
**Repository URL:** https://github.com/IMBAwallet/agent-mcp
**Brief Description:** Prepaid IMBA Agent API. Docs is read-only policy/HowTo. Spend deposits USDT TRC-20 and buys Visa prepaid, eSIM, and gift cards with the operator's own Ed25519 key. No withdraw. Not a ChatGPT money plugin.

## Basic Requirements

- [x] **Open Source**: MIT (https://github.com/IMBAwallet/agent-mcp)
- [x] **MCP Compliant**: Official Registry names com.imbawallet/agent-docs and com.imbawallet/agent; npm @imba_wallet/agent-mcp-docs and @imba_wallet/agent-mcp
- [x] **Active Development**: npm 0.1.4 and hosted remotes at imbawallet.com
- [x] **Docker Artifact**: Dockerfile.docs and Dockerfile.spend (install public npm only; no secrets in the image)
- [x] **Documentation**: https://imbawallet.com/agent_api_about_en.html
- [x] **Security Contact**: support@imbawallet.com

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] Validated with go run ./cmd/validate for both names
- [x] Built with go run ./cmd/build --tools for both names (tools.json)
- [ ] Spend runtime credentials (operator key) can be shared via the review form on request. They are not in this PR or the image.

Pinned commit: 29a55ee88ffeb0a275be6d0e69f4d4ca0ad91916

Made with [Cursor](https://cursor.com)