### PR TITLE
Add GitKraken MCP server

### DIFF
--- a/servers/gitkraken/server.yaml
+++ b/servers/gitkraken/server.yaml
@@ -1,0 +1,37 @@
+name: gitkraken
+image: mcp/gitkraken
+type: server
+meta:
+  category: devops
+  tags:
+    - git
+    - devops
+    - issues
+    - pull-requests
+about:
+  title: GitKraken
+  description: Work with Git repositories, issues, and pull requests through GitKraken.
+  icon: https://avatars.githubusercontent.com/u/92606490?v=4
+source:
+  project: https://github.com/gitkraken/mcp
+  commit: de51c47b5238ef529ec842d62a850ff689a53adf
+run:
+  volumes:
+    - "{{gitkraken.paths|volume|into}}"
+  user: "{{gitkraken.container_user}}"
+config:
+  description: Configure the local repository paths GitKraken is allowed to access and, when needed on Linux, the numeric container identity used to access them.
+  parameters:
+    type: object
+    properties:
+      paths:
+        type: array
+        items:
+          type: string
+        default:
+          - /Users/local-test
+      container_user:
+        type: string
+        description: Optional numeric UID or UID:GID (for example, 1000 or 1000:1000) used to access bind-mounted repositories. Leave empty to use the image's built-in non-root user.
+    required:
+      - paths


### PR DESCRIPTION
## MCP Server Information

**Server Name:** GitKraken
**Repository URL:** https://github.com/gitkraken/mcp
**Brief Description:** Work with Git repositories, issues, and pull requests through GitKraken.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gitkraken`
- [x] I have built the MCP Server using `task build -- --tools gitkraken`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6) (Not applicable; image build and tool discovery are auth-independent.)