### PR TITLE
Add brainstorm-mcp server

### DIFF
--- a/servers/brainstorm-mcp/server.yaml
+++ b/servers/brainstorm-mcp/server.yaml
@@ -1,0 +1,34 @@
+name: brainstorm-mcp
+image: mcp/brainstorm-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - multi-model
+    - debate
+    - code-review
+    - llm
+    - agent-tools
+about:
+  title: Brainstorm
+  description: Multi-round AI brainstorming debates between GPT, Gemini, DeepSeek, Claude and local Ollama models, returning a structured synthesis as an MCP server — plus a code-review mode and single-call quick-perspective mode. Hosted mode needs no API keys; bring-your-own-key mode is optional.
+  icon: https://avatars.githubusercontent.com/u/8328281?v=4
+source:
+  project: https://github.com/spranab/brainstorm-mcp
+  branch: main
+  commit: 521adaf13f6dbad3505a91a1df310983ba4398ea
+config:
+  description: Optionally provide API keys for the providers you want brainstorm-mcp to call directly (hosted mode and local Ollama work without any of these).
+  secrets:
+    - name: brainstorm-mcp.openai_api_key
+      env: OPENAI_API_KEY
+      example: sk-...
+      required: false
+    - name: brainstorm-mcp.gemini_api_key
+      env: GEMINI_API_KEY
+      example: <YOUR_GEMINI_API_KEY>
+      required: false
+    - name: brainstorm-mcp.deepseek_api_key
+      env: DEEPSEEK_API_KEY
+      example: <YOUR_DEEPSEEK_API_KEY>
+      required: false


### PR DESCRIPTION
Adds `brainstorm-mcp` — an MCP server that runs multi-round debates between GPT, Gemini, DeepSeek, Claude and local Ollama models and returns a structured synthesis, plus a code-review mode and a single-call quick-perspective mode.

- MIT licensed: https://github.com/spranab/brainstorm-mcp
- All provider API keys are optional (declared as non-required secrets) — hosted mode and local Ollama both work without any of them.
- Pinned to commit `521adaf`, which also fixes the repo's Dockerfile to build `dist/` in a builder stage (it's gitignored, so the previous single-stage Dockerfile only worked when a local build happened to already exist — verified with a clean-checkout `docker build`).
- `task validate` and `task build -- --tools brainstorm-mcp` both pass; the built image responds correctly to an MCP `initialize" handshake and lists 7 tools.