### PR TITLE
Add discord-mcp server

### DIFF
--- a/servers/discord-mcp/server.yaml
+++ b/servers/discord-mcp/server.yaml
@@ -1,0 +1,25 @@
+name: discord-mcp
+image: mcp/discord-mcp
+type: server
+meta:
+  category: communication
+  tags:
+    - discord
+    - chatops
+    - moderation
+    - bot
+    - agent-tools
+about:
+  title: Discord
+  description: Run a Discord server from an AI assistant — 30+ actions across messages, channels, roles, members, moderation, threads, webhooks, invites and the audit log, behind one hierarchical MCP tool.
+  icon: https://avatars.githubusercontent.com/u/8328281?v=4
+source:
+  project: https://github.com/spranab/discord-mcp
+  branch: master
+  commit: c8591761ef445d925d68983d9941cdc6b0c190bc
+config:
+  description: Configure the Discord bot token
+  secrets:
+    - name: discord-mcp.bot_token
+      env: bot_token
+      example: <YOUR_DISCORD_BOT_TOKEN>


### PR DESCRIPTION
Adds `discord-mcp` — 30+ Discord actions (messages, channels, roles, members, moderation, threads, webhooks, invites, audit log) behind one hierarchical MCP tool.

- MIT licensed: https://github.com/spranab/discord-mcp
- Single required secret: the Discord bot token (`bot_token`).
- Pinned to commit `c859176`, which also adds a Dockerfile and a committed `package-lock.json` to the source repo (the repo had neither before — `npm ci` needs a lockfile, and a clean checkout without one failed `task build`, caught and fixed during this submission).
- `task validate` and `task build -- --tools discord-mcp` both pass; the built image fails fast with a clear error when `bot_token` is unset, and the discord.js client logs in successfully with a real token.