### PR TITLE
fix(catalog): Preserve long-lived servers

### DIFF
--- a/pkg/catalog/tile.go
+++ b/pkg/catalog/tile.go
@@ -183,6 +183,7 @@ func ToTile(ctx context.Context, server servers.Server) (Tile, error) {
 		Title:          server.About.Title,
 		Type:           server.Type,
 		Image:          image,
+		LongLived:      server.LongLived,
 		DateAdded:      &dateAdded,
 		ReadmeURL:      "http://desktop.docker.com/mcp/catalog/v" + strconv.Itoa(Version) + "/readme/" + server.Name + ".md",
 		ToolsURL:       "http://desktop.docker.com/mcp/catalog/v" + strconv.Itoa(Version) + "/tools/" + server.Name + ".json",

--- a/pkg/catalog/tile_test.go
+++ b/pkg/catalog/tile_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,5 +55,70 @@ func TestWriteYamlPreservesLongLived(t *testing.T) {
 	}
 	if !strings.Contains(string(contents), "longLived: true") {
 		t.Errorf("WriteYaml() output does not contain longLived: true:\n%s", contents)
+	}
+}
+
+func TestMarshalJSONPreservesLongLived(t *testing.T) {
+	contents, err := json.Marshal(TopLevel{
+		Version:     Version,
+		Name:        Name,
+		DisplayName: DisplayName,
+		Registry: TileList{
+			{
+				Name: "long-lived-server",
+				Tile: Tile{LongLived: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), `"longLived":true`) {
+		t.Errorf("json.Marshal() output does not contain \"longLived\":true:\n%s", contents)
+	}
+}
+
+func TestMarshalJSONOmitsLongLivedWhenFalse(t *testing.T) {
+	contents, err := json.Marshal(TopLevel{
+		Version:     Version,
+		Name:        Name,
+		DisplayName: DisplayName,
+		Registry: TileList{
+			{
+				Name: "regular-server",
+				Tile: Tile{LongLived: false},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(contents), "longLived") {
+		t.Errorf("json.Marshal() output contains longLived for a regular server:\n%s", contents)
+	}
+}
+
+func TestWriteYamlOmitsLongLivedWhenFalse(t *testing.T) {
+	catalogFile := filepath.Join(t.TempDir(), "catalog.yaml")
+	if err := WriteYaml(catalogFile, TopLevel{
+		Version:     Version,
+		Name:        Name,
+		DisplayName: DisplayName,
+		Registry: TileList{
+			{
+				Name: "regular-server",
+				Tile: Tile{LongLived: false},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := os.ReadFile(catalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(contents), "longLived") {
+		t.Errorf("WriteYaml() output contains longLived for a regular server:\n%s", contents)
 	}
 }

--- a/pkg/catalog/tile_test.go
+++ b/pkg/catalog/tile_test.go
@@ -1,0 +1,58 @@
+package catalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/mcp-registry/pkg/servers"
+)
+
+func TestToTilePreservesLongLived(t *testing.T) {
+	tile, err := ToTile(context.Background(), servers.Server{
+		Name:      "long-lived-server",
+		Type:      "server",
+		LongLived: true,
+		About: servers.About{
+			Title:       "Long-lived server",
+			Description: "A long-lived server",
+		},
+		Remote: servers.Remote{
+			TransportType: "streamable-http",
+			URL:           "https://example.com/mcp",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tile.LongLived {
+		t.Error("ToTile() did not preserve LongLived")
+	}
+}
+
+func TestWriteYamlPreservesLongLived(t *testing.T) {
+	catalogFile := filepath.Join(t.TempDir(), "catalog.yaml")
+	if err := WriteYaml(catalogFile, TopLevel{
+		Version:     Version,
+		Name:        Name,
+		DisplayName: DisplayName,
+		Registry: TileList{
+			{
+				Name: "long-lived-server",
+				Tile: Tile{LongLived: true},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := os.ReadFile(catalogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "longLived: true") {
+		t.Errorf("WriteYaml() output does not contain longLived: true:\n%s", contents)
+	}
+}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -137,6 +137,7 @@ type Tile struct {
 	Ref       string `json:"ref" yaml:"ref"`
 	ReadmeURL string `json:"readme,omitempty" yaml:"readme,omitempty"`
 	ToolsURL  string `json:"toolsUrl,omitempty" yaml:"toolsUrl,omitempty"`
+	LongLived bool   `json:"longLived,omitempty" yaml:"longLived,omitempty"`
 	// TODO(dga): The UI ignores tiles without a source. An empty one is ok. Put back omitempty when this is fixed
 	// Source         string         `json:"source,omitempty" yaml:"source,omitempty"`
 	Source         string         `json:"source" yaml:"source"`


### PR DESCRIPTION
Closes #4889.

`server.yaml` accepts `longLived`, but `ToTile` currently drops it while generating catalog tiles. Existing long-lived entries therefore become on-demand servers in generated catalogs. This copies the setting into the tile representation and adds regression coverage for conversion and YAML output.

The fix was split from #960 to keep the LinkedIn server update focused.

Verification: `go test ./...`
