### PR TITLE
Add animenewsnetwork

### DIFF
--- a/servers/animenewsnetwork/server.yaml
+++ b/servers/animenewsnetwork/server.yaml
@@ -1,0 +1,18 @@
+name: animenewsnetwork
+image: mcp/animenewsnetwork
+type: server
+meta:
+  category: search
+  tags:
+    - anime
+    - manga
+    - encyclopedia
+    - news
+about:
+  title: Anime News Network
+  description: Reads the Anime News Network encyclopedia and its news wire. Searches anime, manga and the people credited on them, reads a title with its episodes, its cast and its staff, and reads the wire by date or by topic. Every answer carries the page it was read from, a figure the site does not publish comes back as unknown rather than as zero, and the server writes nothing back to the site. No API key and no account are needed.
+  icon: https://raw.githubusercontent.com/smeet666/mcp-animenewsnetwork/main/assets/icon-512.png
+source:
+  project: https://github.com/smeet666/mcp-animenewsnetwork
+  branch: main
+  commit: 67648d0d29c96a0a19bf71f77c1e1cf2d02fc99a


### PR DESCRIPTION
An MCP server that reads the Anime News Network encyclopedia and its news wire: search anime, manga and the people credited on them, read a title with its episodes, cast and staff, and read the wire by date or by topic.

- Read-only, and it writes nothing back to the site.
- No API key and no account. The container needs outbound HTTPS to `www.animenewsnetwork.com` and `cdn.animenewsnetwork.com`, and nothing else: no volume, no port, no credential, so the entry carries no `config` block.
- MIT licensed, with a two-stage Dockerfile that runs unprivileged.
- The commit pinned is the v2.0.1 release, which is the version published on npm.

Built the image from that Dockerfile and listed its tools over stdio before opening this: `search_titles`, `get_title`, `list_recent`, `get_news`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDnHUyGpZZKTMw87cwbkyD