### PR TITLE
Add Ausca (remote streamable-http)

### DIFF
--- a/servers/ausca/readme.md
+++ b/servers/ausca/readme.md
@@ -1,0 +1,7 @@
+Ausca sells metered agent infrastructure services: document OCR, document analysis, media transcription, remote browser sessions with CDP access, and agent inboxes. Every service is paid per call in USDC on Base over x402 v2, with no account or provider API keys, and a settlement receipt on every completed invocation.
+
+This remote MCP server exposes discovery, preparation, state reads, and capability-scoped lifecycle tools. Payment signs on the buyer's machine; the local wallet-holding server ships in the `ausca` npm package (`npx -y ausca mcp`).
+
+Docs: https://ausca.com/llms.txt
+OpenAPI: https://ausca.com/openapi.json
+Contract: https://ausca.com/SKILL.md

--- a/servers/ausca/server.yaml
+++ b/servers/ausca/server.yaml
@@ -1,0 +1,18 @@
+name: ausca
+type: remote
+meta:
+  category: productivity
+  tags:
+    - agents
+    - documents
+    - transcription
+    - browser
+    - x402
+    - remote
+about:
+  title: Ausca
+  description: Metered agent infrastructure services (document OCR, document analysis, media transcription, browser sessions, agent inboxes) paid per call in USDC on Base, with a receipt for every completed invocation.
+  icon: https://ausca.com/favicon.svg
+remote:
+  transport_type: streamable-http
+  url: https://ausca.com/mcp


### PR DESCRIPTION
Adds the Ausca remote MCP server.

Metered agent infrastructure services (document OCR, document analysis, media transcription, browser sessions, agent inboxes) paid per call in USDC on Base over x402 v2, no account or API keys, receipt-backed results. Remote Streamable HTTP at https://ausca.com/mcp; public, no auth to connect. Official MCP Registry id `com.ausca/agent-services`.