### PR TITLE
Add Sourcey (remote streamable-http)

### DIFF
--- a/servers/sourcey/readme.md
+++ b/servers/sourcey/readme.md
@@ -1,0 +1,10 @@
+Sourcey is the public record of what software vendors actually do: startup credits and offers, Agent Readiness grades, and open data, computed from signed releases.
+
+Two public data products run on one evidence engine. Startup Offers answers what a vendor can give you: exact discounts, credit schemes, and startup tiers with explicit eligibility unknowns, exact revisions, and provenance. Agent Readiness answers whether an authorized agent can discover, authenticate to, provision, and operate a service, published as independently assessed report cards with immutable evidence bindings.
+
+This remote MCP server exposes evidence-backed search over both products in Sourcey's immutable Catalog. Public, no auth required to connect.
+
+Docs: https://sourcey.com/llms.txt
+Startup offers: https://sourcey.com/startup-credits
+Agent Readiness report cards: https://sourcey.com/agent-readiness
+Official MCP Registry id: com.sourcey/sourcey

--- a/servers/sourcey/server.yaml
+++ b/servers/sourcey/server.yaml
@@ -1,0 +1,18 @@
+name: sourcey
+type: remote
+meta:
+  category: search
+  tags:
+    - startups
+    - credits
+    - agent-readiness
+    - evidence
+    - catalog
+    - remote
+about:
+  title: Sourcey
+  description: The public record of what software vendors actually do. Evidence-backed startup credits and offers, and Agent Readiness report cards grading how well an authorized agent can discover, authenticate to, provision, and operate a service.
+  icon: https://sourcey.com/brand/sourcey-mark.png
+remote:
+  transport_type: streamable-http
+  url: https://mcp.sourcey.com/mcp


### PR DESCRIPTION
Adds the Sourcey remote MCP server.

Sourcey is the public record of what software vendors actually do: startup credits and offers, Agent Readiness grades, and open data, computed from signed releases. The server exposes evidence-backed search over both public data products in the immutable Catalog: exact startup offers with eligibility and provenance, and Agent Readiness report cards grading how well an authorized agent can discover, authenticate to, provision, and operate a service.

Remote Streamable HTTP at https://mcp.sourcey.com/mcp; public, no auth to connect. Official MCP Registry id `com.sourcey/sourcey`.