### PR TITLE
Add meridian-mcp

### DIFF
--- a/servers/meridian-mcp/server.yaml
+++ b/servers/meridian-mcp/server.yaml
@@ -14,7 +14,7 @@ about:
 source:
   project: https://github.com/meridian-silkdev/meridian-mcp
   branch: main
-  commit: 3c184fa7db8c9a504757850b517a6f14138b8518
+  commit: 7abfd5297475bf571898a450a38853c15a138f51
 config:
   description: Configure the connection to Meridian
   env:

--- a/servers/meridian-mcp/server.yaml
+++ b/servers/meridian-mcp/server.yaml
@@ -1,0 +1,32 @@
+name: meridian-mcp
+image: mcp/meridian-mcp
+type: server
+meta:
+  category: productivity
+  tags:
+    - startups
+    - founder-toolkit
+    - business-services
+about:
+  title: Meridian
+  description: Toolbox for startups and founders — browse services, create and track service requests, manage workflow steps, verify payments (Flouci/Stripe), and schedule meetings through the Meridian business-services platform.
+  icon: https://avatars.githubusercontent.com/u/314312746?v=4
+source:
+  project: https://github.com/meridian-silkdev/meridian-mcp
+  branch: main
+  commit: 3c184fa7db8c9a504757850b517a6f14138b8518
+config:
+  description: Configure the connection to Meridian
+  env:
+    - name: MERIDIAN_API_URL
+      example: https://meridian.silkdev.com.tn
+      value: "{{meridian-mcp.api_url}}"
+  secrets:
+    - name: meridian-mcp.api_key
+      env: MERIDIAN_API_KEY
+      example: mrd_xxxxxxxxxxxxxxxx
+  parameters:
+    type: object
+    properties:
+      api_url:
+        type: string


### PR DESCRIPTION
## What
Adds `meridian-mcp` — an MCP server for the Meridian business-services platform (a toolbox for startups/founders): browse services, create/track service requests, manage workflow steps, verify payments (Flouci for Tunisia, Stripe international), and schedule meetings.

## Links
- Source: https://github.com/meridian-silkdev/meridian-mcp
- npm: https://www.npmjs.com/package/@meridiantoolkit/mcp
- Also listed on the official MCP Registry as `io.github.meridian-silkdev/meridian-mcp`

## License
MIT

## Testing / credentials
No credentials are required to validate this server — without `MERIDIAN_API_KEY` every tool responds in a fully functional dry-run mode (returns a placeholder explaining what live endpoint it would call), so `tools/list` and `tools/call` both work out of the box.

## Validation performed locally
- `go run ./cmd/validate --name meridian-mcp` — all checks pass
- `go run ./cmd/build meridian-mcp` and `go run ./cmd/build -tools meridian-mcp` — image builds cleanly, 16 tools discovered via the registry's own pipeline
- Manually ran the built image (`docker run --rm -i mcp/meridian-mcp`) as a real MCP client over stdio and confirmed `tools/list` + a `meridian_status` tool call both respond correctly