### PR TITLE
Add elc-trade: Engineering Leaders Community MCP server

### DIFF
--- a/servers/elc-trade/server.yaml
+++ b/servers/elc-trade/server.yaml
@@ -1,0 +1,19 @@
+name: elc-trade
+type: remote
+meta:
+  category: productivity
+  tags:
+    - engineering-leadership
+    - community
+    - events
+    - benchmarks
+    - remote
+about:
+  title: Engineering Leaders Community
+  description: Score a meetup topic before you commit to it, place a speaker on the right stage, and price community reach. Backed by 3,300+ engineering leaders across Central Europe and 12 meetups a year since 2019.
+  icon: https://www.google.com/s2/favicons?domain=engineeringleaders.io&sz=64
+source:
+  project: https://github.com/marian-kamenistak/elc-trade
+remote:
+  transport_type: streamable-http
+  url: https://www.engineeringleaders.io/mcp/trade


### PR DESCRIPTION
Remote MCP server (streamable HTTP, authless) from the Engineering Leaders Community.

Six tools answering questions an AI already gets asked: whether a meetup topic will fill a room, which stage a speaker belongs on, whether an engineering org is top-heavy, whether to start a meetup in your city, how to fund a community partnership internally, and what community reach costs.

Grounded in first-party data: 3,300+ engineering leaders across Prague, Brno, Bratislava and Krakow, 12 meetups a year at 120+ attendees, running since 2019.

- Endpoint: https://www.engineeringleaders.io/mcp/trade
- Source: https://github.com/marian-kamenistak/elc-trade (MIT)
- Docs: https://www.engineeringleaders.io/agents/
- Also published to the official MCP registry as io.engineeringleaders/elc-trade