### PR TITLE
Add alexandria

### DIFF
--- a/servers/alexandria/server.yaml
+++ b/servers/alexandria/server.yaml
@@ -1,0 +1,83 @@
+name: alexandria
+image: mcp/alexandria
+type: server
+meta:
+  category: search
+  tags:
+    - search
+    - research
+    - academic
+    - library
+    - archives
+    - rag
+about:
+  title: Alexandria
+  description: Natural-language search, full-text reading, and cited answers across 138 public digital libraries (academic papers, public domain books, legal records, government archives, software documentation). Most sources need no credentials.
+  icon: https://avatars.githubusercontent.com/u/278549586?s=200&v=4
+source:
+  project: https://github.com/The-40-Thieves/alexandria-mcp
+  branch: main
+  commit: 22fc26745ed7b4445187f1a348df76f9452ecc14
+config:
+  description: Everything is optional. Search and read work with no keys at all; an OpenAI key (or a gateway) enables library_ask, library_answer, library_research, and library_ingest; per-source keys unlock the sources that require one.
+  secrets:
+    - name: alexandria.openai_api_key
+      env: OPENAI_API_KEY
+      example: <OPENAI_API_KEY>
+      description: OpenAI key for routing, synthesis, and embeddings. Not needed for library_search, library_read, library_index, library_recommend, or library_health_check.
+      required: false
+    - name: alexandria.api_key
+      env: ALEXANDRIA_API_KEY
+      example: <ALEXANDRIA_API_KEY>
+      description: API key paired with the gateway base URL. Falls back to OPENAI_API_KEY.
+      required: false
+    - name: alexandria.core_api_key
+      env: CORE_API_KEY
+      example: <CORE_API_KEY>
+      description: Unlocks the CORE open access aggregator (core.ac.uk/services/api).
+      required: false
+    - name: alexandria.courtlistener_api_key
+      env: COURTLISTENER_API_KEY
+      example: <COURTLISTENER_API_KEY>
+      description: Unlocks CourtListener US court opinions (courtlistener.com/profile/tokens).
+      required: false
+    - name: alexandria.govinfo_api_key
+      env: GOVINFO_API_KEY
+      example: <GOVINFO_API_KEY>
+      description: Unlocks GovInfo, and is accepted by congress and regulations (api.data.gov/signup).
+      required: false
+    - name: alexandria.google_books_api_key
+      env: GOOGLE_BOOKS_API_KEY
+      example: <GOOGLE_BOOKS_API_KEY>
+      description: Unlocks Google Books (Google Cloud Console, Books API).
+      required: false
+    - name: alexandria.github_token
+      env: GITHUB_TOKEN
+      example: <GITHUB_TOKEN>
+      description: Unlocks GitHub code search sources; public-repo read scope is enough.
+      required: false
+    - name: alexandria.nasa_ads_api_key
+      env: NASA_ADS_API_KEY
+      example: <NASA_ADS_API_KEY>
+      description: Unlocks NASA ADS (ui.adsabs.harvard.edu/user/settings/token).
+      required: false
+    - name: alexandria.europeana_api_key
+      env: EUROPEANA_API_KEY
+      example: <EUROPEANA_API_KEY>
+      description: Unlocks Europeana cultural heritage records (apis.europeana.eu).
+      required: false
+    - name: alexandria.semantic_scholar_api_key
+      env: SEMANTIC_SCHOLAR_API_KEY
+      example: <SEMANTIC_SCHOLAR_API_KEY>
+      description: Optional; raises the Semantic Scholar rate limit used by library_recommend.
+      required: false
+  env:
+    - name: ALEXANDRIA_BASE_URL
+      example: https://gateway.example.com/v1
+      value: "{{alexandria.base_url}}"
+  parameters:
+    type: object
+    properties:
+      base_url:
+        type: string
+        description: OpenAI-compatible gateway base URL shared by every LLM role. Leave empty to call api.openai.com directly.


### PR DESCRIPTION
## MCP Server Information

**Server Name:** alexandria
**Repository URL:** https://github.com/The-40-Thieves/alexandria-mcp
**Brief Description:** Natural-language search, full-text reading, and cited answers across 138+ public digital libraries (academic papers, public domain books, legal records, government archives, software documentation). Most sources need no credentials; an OpenAI key (or gateway) unlocks the synthesis tools.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements MCP API specification (protocol version 2025-11-25 at runtime)
- [x] **Active Development**: Latest commit on `main` (22fc267) is from 2026-09-04; v11.0.0 tagged and published to npm the same week
- [x] **Docker Artifact**: Root `Dockerfile` builds `dist/` in-image and runs `node dist/index.js` (`TRANSPORT=stdio` by default)
- [x] **Documentation**: `README.md` documents every tool, parameters, and configuration
- [x] **Security Contact**: `SECURITY.md` at the repo root points to GitHub private vulnerability reporting, which is enabled on the repository.

## Submitter Checklist

- [x] This server meets the basic requirements listed above 
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name alexandria`
  - All 10 checks pass: name, directory, title, YAML formatting, commit pin, secrets, config env, license, icon, OAuth/dynamic config.
- [x] I have built the MCP Server using `task build -- --tools alexandria`
  - Image builds cleanly from the pinned commit (`22fc26745ed7b4445187f1a348df76f9452ecc14`, the commit `v11.0.0` points at) and lists 11 tools with no credentials configured: `library_list_sources`, `library_health_check`, `library_ask`, `library_search`, `library_read`, `library_index`, `library_ingest`, `library_recommend`, `library_answer`, `library_research`, `library_citations`.
- [ ] If the server requires credentials to test it, I have shared test credentials using the linked form
  - Not applicable: `library_search`, `library_read`, `library_list_sources`, `library_health_check`, `library_index`, and `library_recommend` all work with zero configuration, which is what `task build --tools` exercised. Only the synthesis tools (`library_ask`, `library_answer`, `library_research`, `library_ingest`) need an `OPENAI_API_KEY`, and per-source tools improve with optional per-source keys — all declared as optional secrets in `server.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
