### PR TITLE
fix(deepwiki): switch to streamable-http /mcp endpoint

### DIFF
--- a/servers/deepwiki/server.yaml
+++ b/servers/deepwiki/server.yaml
@@ -12,5 +12,5 @@ about:
   description: Tools for fetching and asking questions about GitHub repositories.
   icon: https://devin.ai/apple-icon.png
 remote:
-  transport_type: sse
-  url: https://mcp.deepwiki.com/sse
+  transport_type: streamable-http
+  url: https://mcp.deepwiki.com/mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** deepwiki
**Repository URL:** n/a — hosted remote server; docs at https://docs.devin.ai/work-with-devin/deepwiki-mcp
**Brief Description:** Existing catalog entry. This PR is not a new submission — it repoints the
`deepwiki` entry at the endpoint the server actually serves today.

The declared SSE endpoint (https://mcp.deepwiki.com/sse) no longer serves MCP: it returns 405 to a
POSTed JSON-RPC initialize (410 as reported in #4735). The server is up and reachable over
streamable-http at https://mcp.deepwiki.com/mcp, which completes the initialize handshake and
lists 3 tools.

```diff
 remote:
-  transport_type: sse
-  url: https://mcp.deepwiki.com/sse
+  transport_type: streamable-http
+  url: https://mcp.deepwiki.com/mcp
```

Verified with the repo tooling:

```
validate -> "Remote tools are valid. Found 3 tools."
build    -> skipped (remote server)
catalog  -> generated with the new transport and url
```

Because this entry has no `tools.json` and no `dynamic.tools`, `validate` performs a live
handshake — so the "Found 3 tools" line is real evidence the new endpoint works, not a
file being read back.

Closes #4735
Refs #4568

## Basic Requirements

- [ ] **Open Source**: n/a — hosted service, no source repository in the entry 
- [x] **MCP Compliant**: verified by live initialize handshake (server reports `DeepWiki 2.14.3`, advertises tools capability)
- [x] **Active Development**: endpoint serving current protocol revision
- [ ] **Docker Artifact**: n/a — `type: remote`, no image is built (Build skipped for remote server deepwiki)
- [x] **Documentation**: `servers/deepwiki/readme.md` docs link resolves (HTTP 200)
- [ ] **Security Contact**: n/a — not a new submission; unchanged by this PR

## Submitter Checklist

- [ ] This server meets the basic requirements listed above — n/a, existing entry
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name deepwiki`
- [x] I have built the MCP Server using `task build -- --tools deepwiki`
- [ ] If the server requires credentials to test it, I have shared test credentials — n/a, no auth required