### PR TITLE
Add Apiguru Amazon Data (live Amazon product, review and seller data)

### DIFF
--- a/servers/apiguru/readme.md
+++ b/servers/apiguru/readme.md
@@ -1,0 +1,20 @@
+# Apiguru Amazon Data
+
+Live Amazon marketplace data for AI agents: product details, reviews, keyword
+search, best-sellers, deals, live offers and stock, and seller profiles across
+20 country marketplaces. Twelve tools with prices and retry rules in their
+descriptions.
+
+Ten of them are read-only data fetches. `list_capabilities` answers offline
+from the bundled spec and costs nothing. `send_feedback` is the only tool that
+writes: it posts the message you give it to Apiguru's public feedback wall,
+and it is free.
+
+No API key is required. Each machine gets a small free daily budget; after
+that the gateway answers with an HTTP 402 payment challenge (x402, USDC on
+Base). Set `APIGURU_API_KEY` to bill an Apiguru account instead.
+
+- Source and documentation: https://github.com/apiguru-app/agent-kit
+- Tool reference: https://github.com/apiguru-app/agent-kit/blob/main/mcp/README.md
+- API documentation: https://dash.apiguru.app/docs
+- Support: support@apiguru.app

--- a/servers/apiguru/server.yaml
+++ b/servers/apiguru/server.yaml
@@ -1,0 +1,31 @@
+name: apiguru
+image: mcp/apiguru
+type: server
+meta:
+  category: ecommerce
+  tags:
+    - amazon
+    - ecommerce
+    - product-data
+    - price-monitoring
+    - web-scraping
+about:
+  title: Apiguru Amazon Data
+  description: |-
+    Live Amazon marketplace data as 12 tools: product details (single and batch), reviews, keyword search, best-sellers, deals, live offers and stock, seller profiles, seller products and seller reviews across 20 country marketplaces. Prices, billing rules and retry guidance are in every tool description, and a free tool lists the catalogue offline.
+
+    Ten data tools are read-only. `list_capabilities` answers offline and costs nothing. `send_feedback` is the only tool that writes: it posts the message you give it to Apiguru's public feedback wall, and it is free.
+
+    Works with no account and no API key: each machine gets a small free daily budget, then the gateway answers with an HTTP 402 payment challenge (x402, USDC on Base) that agents with a wallet settle automatically. Set APIGURU_API_KEY to bill an Apiguru account instead.
+  icon: https://dash.apiguru.app/static/images/apiguru-mcp-icon.png
+source:
+  project: https://github.com/apiguru-app/agent-kit
+  branch: main
+  commit: 4177503d966b490e5f949b6b32d696caee2a0380
+  directory: mcp
+config:
+  description: Optional. Leave the key empty to run keyless (free probes, then x402). Set an API key from https://dash.apiguru.app to bill your Apiguru account at your plan's rates.
+  secrets:
+    - name: apiguru.api_key
+      env: APIGURU_API_KEY
+      example: <APIGURU_API_KEY>


### PR DESCRIPTION
Adds `servers/apiguru`: an stdio MCP server for the Apiguru Amazon Data API — product details (single and batch), reviews, keyword search, best-sellers, deals, live offers and stock, and seller profiles, products and reviews across 20 Amazon marketplaces.

**No credentials are needed to test it.** The server runs keyless: each machine gets 3 free calls per 24 hours, after which the gateway answers HTTP 402 with an x402 payment challenge. `list_capabilities` is free and answers offline from the bundled spec, so the server can be listed and exercised with no account at all. `APIGURU_API_KEY` is optional and only switches billing to an Apiguru account — happy to supply a funded key through your credentials form if you would rather exercise the keyed path.

**Twelve tools**, each with a `title` and annotations. Ten are read-only data fetches; `list_capabilities` is offline and free; `send_feedback` is the only tool that writes (it posts to our public feedback wall) and is annotated `readOnlyHint: false`, `destructiveHint: false`.

Verified before opening this PR:

```
task validate -- --name apiguru    all checks green (name, directory, title, YAML,
                                   commit pinned, secrets, config env, license, icon, OAuth)
task build -- --tools apiguru      Image built as mcp/apiguru - 12 tools found
```

and the built image answers `tools/list` over stdio with all twelve tools and their annotations.

- Source: https://github.com/apiguru-app/agent-kit (Dockerfile in `mcp/`, pinned commit)
- Docs: https://dash.apiguru.app/docs
- Support: support@apiguru.app
