### PR TITLE
Add Baron

### DIFF
--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -1,0 +1,99 @@
+name: baron
+image: mcp/baron
+type: server
+meta:
+  category: devops
+  tags:
+    - devops
+    - github
+    - azure-devops
+    - linear
+    - issues
+    - pull-requests
+    - ci
+    - workflow
+    - coding-agents
+about:
+  title: Baron
+  description: |-
+    Lets a coding agent drive your work tracker and source control through one normalized contract: read, create and transition issues, cut branches, open and land pull requests, watch CI and record project memory, across GitHub, Azure DevOps and Linear. Providers map their native states onto shared roles (backlog, ready, in_progress, in_review, done), so the same prompts and recipes work whichever tracker a team uses.
+    Mount a project that holds a `.baron/policy.json` (created by `npx @lonca/baron init` in that project) and the server runs every call against that project's policy and credentials.
+  icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
+source:
+  project: https://github.com/loncadev/baron
+  commit: 946be651e176fe097a2d81392daaa702e28b1bbe
+run:
+  volumes:
+    - "{{baron.project_path}}:/project"
+  env:
+    # The catalog image is rebuilt and re-pinned by Docker, so the "a newer version is on npm"
+    # notice the server otherwise appends would point users at a fix they cannot apply here.
+    BARON_NO_UPDATE_CHECK: "1"
+config:
+  description: Point Baron at the project whose `.baron/policy.json` it should run against, and supply credentials for the providers that policy binds. Only the providers you use need values.
+  secrets:
+    - name: baron.github_token
+      env: GITHUB_TOKEN
+      example: <GITHUB_TOKEN>
+      description: GitHub token with repo scope (or fine-grained access to Issues, Pull requests, Contents and Actions on the target repository).
+      required: false
+    - name: baron.azure_devops_token
+      env: AZURE_DEVOPS_TOKEN
+      example: <AZURE_DEVOPS_TOKEN>
+      description: Azure DevOps personal access token with Work Items, Code and Build access.
+      required: false
+    - name: baron.linear_api_key
+      env: LINEAR_API_KEY
+      example: <LINEAR_API_KEY>
+      description: Linear personal API key.
+      required: false
+  env:
+    # At tools-listing time the example is what the container sees, and /app carries a committed
+    # policy so the server starts without a mounted project. At run time the mounted project wins.
+    - name: BARON_ROOT
+      example: /app
+      value: /project
+    - name: GITHUB_OWNER
+      example: octocat
+      value: "{{baron.github_owner}}"
+    - name: GITHUB_REPO
+      example: hello-world
+      value: "{{baron.github_repo}}"
+    - name: AZURE_DEVOPS_ORG
+      example: my-org
+      value: "{{baron.azure_devops_org}}"
+    - name: AZURE_DEVOPS_PROJECT
+      example: My Project
+      value: "{{baron.azure_devops_project}}"
+    - name: AZURE_DEVOPS_REPO
+      example: my-repo
+      value: "{{baron.azure_devops_repo}}"
+    - name: LINEAR_TEAM
+      example: ENG
+      value: "{{baron.linear_team}}"
+  parameters:
+    type: object
+    properties:
+      project_path:
+        type: string
+        description: Host path of the project that contains .baron/policy.json (run `npx @lonca/baron init` there first).
+      github_owner:
+        type: string
+        description: GitHub repository owner (user or organisation).
+      github_repo:
+        type: string
+        description: GitHub repository name.
+      azure_devops_org:
+        type: string
+        description: Azure DevOps organisation name.
+      azure_devops_project:
+        type: string
+        description: Azure DevOps project name.
+      azure_devops_repo:
+        type: string
+        description: Azure DevOps repository name.
+      linear_team:
+        type: string
+        description: Linear team key.
+    required:
+      - project_path

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -22,7 +22,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: 13b8290982d2058fe4b026c47d12c383fcd4e22f
+  commit: be41813c7ebd19364113d4c9fcb1c0e83d5f6a18
 run:
   volumes:
     - "{{baron.project_path}}:/project"

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -22,7 +22,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: be41813c7ebd19364113d4c9fcb1c0e83d5f6a18
+  commit: 49b739f351f1e9c485a4920ad32fe90f01e4db4b
 run:
   volumes:
     - "{{baron.project_path}}:/project"

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -22,7 +22,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: c82931721f110c8dc337cab9c4c6c5130cea9519
+  commit: 53a19d3c8fdd9d4c32f54b6386efce09256c20ea
 run:
   volumes:
     - "{{baron.project_path}}:/project"

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -22,7 +22,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: 9f8f20fbaf68aec9cacc40909b43bfd28a6cc305
+  commit: c82931721f110c8dc337cab9c4c6c5130cea9519
 run:
   volumes:
     - "{{baron.project_path}}:/project"

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -22,7 +22,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: ecf881e8b18d92f1cbd54658a19ee88f52393303
+  commit: 9f8f20fbaf68aec9cacc40909b43bfd28a6cc305
 run:
   volumes:
     - "{{baron.project_path}}:/project"

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -22,7 +22,7 @@ about:
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: 49b739f351f1e9c485a4920ad32fe90f01e4db4b
+  commit: ecf881e8b18d92f1cbd54658a19ee88f52393303
 run:
   volumes:
     - "{{baron.project_path}}:/project"

--- a/servers/baron/server.yaml
+++ b/servers/baron/server.yaml
@@ -7,6 +7,7 @@ meta:
     - devops
     - github
     - azure-devops
+    - jira
     - linear
     - issues
     - pull-requests
@@ -16,12 +17,12 @@ meta:
 about:
   title: Baron
   description: |-
-    Lets a coding agent drive your work tracker and source control through one normalized contract: read, create and transition issues, cut branches, open and land pull requests, watch CI and record project memory, across GitHub, Azure DevOps and Linear. Providers map their native states onto shared roles (backlog, ready, in_progress, in_review, done), so the same prompts and recipes work whichever tracker a team uses.
+    Lets a coding agent drive your work tracker and source control through one normalized contract: read, create and transition issues, cut branches, open and land pull requests, watch CI and record project memory, across GitHub, Azure DevOps, Jira and Linear. Providers map their native states onto shared roles (backlog, ready, in_progress, in_review, done), so the same prompts and recipes work whichever tracker a team uses.
     Mount a project that holds a `.baron/policy.json` (created by `npx @lonca/baron init` in that project) and the server runs every call against that project's policy and credentials.
   icon: https://avatars.githubusercontent.com/u/287505098?s=200&v=4
 source:
   project: https://github.com/loncadev/baron
-  commit: 946be651e176fe097a2d81392daaa702e28b1bbe
+  commit: 13b8290982d2058fe4b026c47d12c383fcd4e22f
 run:
   volumes:
     - "{{baron.project_path}}:/project"
@@ -47,6 +48,11 @@ config:
       example: <LINEAR_API_KEY>
       description: Linear personal API key.
       required: false
+    - name: baron.jira_api_token
+      env: JIRA_API_TOKEN
+      example: <JIRA_API_TOKEN>
+      description: Jira Cloud API token from id.atlassian.com, for the account in JIRA_EMAIL.
+      required: false
   env:
     # At tools-listing time the example is what the container sees, and /app carries a committed
     # policy so the server starts without a mounted project. At run time the mounted project wins.
@@ -71,6 +77,15 @@ config:
     - name: LINEAR_TEAM
       example: ENG
       value: "{{baron.linear_team}}"
+    - name: JIRA_SITE
+      example: https://acme.atlassian.net
+      value: "{{baron.jira_site}}"
+    - name: JIRA_EMAIL
+      example: dev@example.com
+      value: "{{baron.jira_email}}"
+    - name: JIRA_PROJECT
+      example: PROJ
+      value: "{{baron.jira_project}}"
   parameters:
     type: object
     properties:
@@ -95,5 +110,14 @@ config:
       linear_team:
         type: string
         description: Linear team key.
+      jira_site:
+        type: string
+        description: Jira Cloud site root, e.g. https://acme.atlassian.net.
+      jira_email:
+        type: string
+        description: Atlassian account email the API token belongs to.
+      jira_project:
+        type: string
+        description: Jira project key (PROJ in PROJ-123).
     required:
       - project_path


### PR DESCRIPTION
## MCP Server Information

**Server Name:** baron
**Repository URL:** https://github.com/loncadev/baron
**Brief Description:** Lets a coding agent drive a work tracker and source control through one normalized contract — issues, branches, pull requests, CI and project memory across GitHub, Azure DevOps and Linear — with provider-native states mapped onto shared roles, so the same prompts and recipes work whichever tracker a team uses.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license) — Apache-2.0
- [x] **MCP Compliant**: Implements MCP API specification (`@modelcontextprotocol/sdk`, stdio transport)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile at the repository root (build context is the repo root — pnpm workspace)
- [x] **Documentation**: Basic README and setup instructions (README.md, docs/mcp.md)
- [x] **Security Contact**: Method for reporting security issues (.github/SECURITY.md)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name SERVER_NAME`
- [x] I have built the MCP Server using `task build -- --tools SERVER_NAME`
- [ ] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6) — not needed to list tools, see below

## Notes for review

- **No `tools.json` on purpose.** The image ships a committed policy under `/app`, so the server starts and answers `tools/list` with no mount and no real credentials. It was exercised the way the registry's lister runs it — `docker run --rm -i --init --cap-drop=ALL` with every `config.env` example and every secret placeholder set — and returned 10 tools. Tool listing is static; no provider is contacted before a tool is called.
- **`BARON_ROOT` has `example: /app` and `value: /project`.** At listing time the example applies and the baked-in policy is used; at run time the user's project is mounted over `/project` (the one required parameter) and the server runs against that project's `.baron/policy.json` and `.baron/credentials`.
- **All credential secrets are optional.** Only the providers a user's policy binds need values; the server reports `PORT_UNBOUND` for the rest. A variable left blank in the form is treated as absent, so a value in the mounted project's credentials file still applies.
- **No `allowHosts`.** Provider endpoints are configurable (Azure DevOps Server, GitHub Enterprise), so the host list cannot be fixed in the entry.

https://claude.ai/code/session_01JxKSk8Kay2fDcEjghHcW74
