### PR TITLE
Add ParlayAPI local stdio server

### DIFF
--- a/servers/parlayapi/readme.md
+++ b/servers/parlayapi/readme.md
@@ -1,0 +1,44 @@
+# ParlayAPI
+
+Use sports odds, player props, public discovery and account tools from a local
+MCP client. This stdio server exposes the existing ParlayAPI MCP tool set; it
+does not host an HTTP endpoint or a shared odds feed.
+
+## Configure your own account
+
+Public discovery tools work without an API key. For account data, add your own
+ParlayAPI key in the catalog's secret field. The secret is supplied as
+`PARLAYAPI_KEY` to your local server. Each user should configure their own
+account, and account allowances apply to tool calls. Do not share one key across
+a community.
+
+[Get an account](https://parlay-api.com/signup?utm_source=docker_mcp&utm_medium=marketplace&utm_campaign=catalog)
+and review [current plans and request limits](https://parlay-api.com/pricing).
+Availability depends on the requested sport, event, market and source. An odds
+quote, timestamp or calculation does not guarantee freshness or profit.
+
+## Actions and permissions
+
+The 22 tools include public pricing/discovery, account usage, sports odds,
+player props and calculation endpoints. Four tools can change state or send
+something: `parlayapi_signup` creates an account, `parlayapi_checkout_link`
+creates a checkout link, `parlayapi_magic_link` sends login email, and
+`parlayapi_set_bettable_books` updates account preferences. Approve these actions
+explicitly in your client. Starting the process or listing tools makes no API
+request and performs none of those actions.
+
+The container uses stdio, a non-root user and no host volumes or published ports.
+It contacts ParlayAPI when a tool is called. Keep keys and account responses
+private within your own client; this is not a multi-user relay.
+
+## Documentation and data use
+
+- [Source and client configuration](https://github.com/JacobiusMakes/parlay-api-mcp)
+- [API documentation](https://parlay-api.com/docs)
+- [MIT software license](https://github.com/JacobiusMakes/parlay-api-mcp/blob/main/LICENSE)
+- [Applicable API Terms](https://parlay-api.com/terms)
+
+Sharing the MIT code or container grants no API data distribution rights. Terms
+and any written agreement govern data use; these local defaults do not amend
+existing agreements. Report security concerns privately to support@parlay-api.com
+and omit keys from public issues.

--- a/servers/parlayapi/server.yaml
+++ b/servers/parlayapi/server.yaml
@@ -13,7 +13,7 @@ about:
   icon: https://raw.githubusercontent.com/JacobiusMakes/parlay-api-mcp/cdfd4e41453d5f3878bf9b1ece6bb8dce0413809/mcpb/icon.png
 source:
   project: https://github.com/JacobiusMakes/parlay-api-mcp
-  commit: 5ce675a48baaedef286db1c21bc3de44f3e07a42
+  commit: 29083331240dedf5c434f41bb634680fc9d03b6a
 run:
   env:
     PARLAYAPI_BASE_URL: https://parlay-api.com

--- a/servers/parlayapi/server.yaml
+++ b/servers/parlayapi/server.yaml
@@ -1,0 +1,27 @@
+name: parlayapi
+image: mcp/parlayapi
+type: server
+meta:
+  category: data-analytics
+  tags:
+    - sports
+    - odds
+    - data
+about:
+  title: ParlayAPI
+  description: Query sports odds, player props, account usage, and public discovery tools from a local MCP client using your own ParlayAPI account.
+  icon: https://raw.githubusercontent.com/JacobiusMakes/parlay-api-mcp/cdfd4e41453d5f3878bf9b1ece6bb8dce0413809/mcpb/icon.png
+source:
+  project: https://github.com/JacobiusMakes/parlay-api-mcp
+  commit: 5ce675a48baaedef286db1c21bc3de44f3e07a42
+run:
+  env:
+    PARLAYAPI_BASE_URL: https://parlay-api.com
+config:
+  description: Public discovery works without a key. Configure your own account key for account tools; account allowances apply. Do not use a shared community key.
+  secrets:
+    - name: parlayapi.api_key
+      env: PARLAYAPI_KEY
+      example: <PARLAYAPI_KEY>
+      required: false
+      description: Your own ParlayAPI account key. Stored as a Docker MCP secret and passed only to your local server process.

--- a/servers/parlayapi/tools.json
+++ b/servers/parlayapi/tools.json
@@ -1,0 +1,481 @@
+[
+  {
+    "name": "parlayapi_signup",
+    "description": "Create an account for the supplied email after explicit user approval. Changes account state.",
+    "arguments": [
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Email address supplied by the user for this explicitly approved action."
+      },
+      {
+        "name": "intended_use",
+        "type": "string",
+        "desc": "Optional description of intended use supplied by the user. Optional."
+      },
+      {
+        "name": "agent_id",
+        "type": "string",
+        "desc": "Identifier for the calling client. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_checkout_link",
+    "description": "Create a checkout link after explicit user approval. Current plans are available through the pricing tool.",
+    "arguments": [
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Email address supplied by the user for this explicitly approved action."
+      },
+      {
+        "name": "tier",
+        "type": "string",
+        "desc": "Account plan identifier; consult current pricing. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_magic_link",
+    "description": "Send a login email after explicit user approval.",
+    "arguments": [
+      {
+        "name": "email",
+        "type": "string",
+        "desc": "Email address supplied by the user for this explicitly approved action."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_get_pricing",
+    "description": "Read current public pricing and account allowance information.",
+    "arguments": []
+  },
+  {
+    "name": "parlayapi_live_sports",
+    "description": "Read the public live-sports discovery response.",
+    "arguments": []
+  },
+  {
+    "name": "parlayapi_live_search",
+    "description": "Search public live discovery by team, player or sport text.",
+    "arguments": [
+      {
+        "name": "q",
+        "type": "string",
+        "desc": "Search text."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum requested result count. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_live_command_center",
+    "description": "Read the limited public live dashboard preview.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier. Optional."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum requested result count. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_source_quality",
+    "description": "Read published source-quality metadata for a requested time window.",
+    "arguments": [
+      {
+        "name": "minutes",
+        "type": "integer",
+        "desc": "Requested metadata lookback in minutes. Optional."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum requested result count. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_book_coverage",
+    "description": "Read published coverage metadata; it does not guarantee future event or market availability.",
+    "arguments": [
+      {
+        "name": "window_minutes",
+        "type": "integer",
+        "desc": "Requested coverage lookback in minutes. Optional."
+      },
+      {
+        "name": "include_warn",
+        "type": "boolean",
+        "desc": "Whether to include warning results. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_list_sports",
+    "description": "List sport identifiers using your configured account key.",
+    "arguments": [
+      {
+        "name": "active_only",
+        "type": "boolean",
+        "desc": "Whether to request active sports only. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_get_odds",
+    "description": "Request available game odds for the selected sport and filters using your own account.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "markets",
+        "type": "string",
+        "desc": "Comma-separated market identifiers. Optional."
+      },
+      {
+        "name": "regions",
+        "type": "string",
+        "desc": "Comma-separated region identifiers. Optional."
+      },
+      {
+        "name": "bookmakers",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      },
+      {
+        "name": "odds_format",
+        "type": "string",
+        "desc": "Requested odds format: decimal or american. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_get_props",
+    "description": "Request available player prop odds for the selected sport and filters using your own account.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "markets",
+        "type": "string",
+        "desc": "Comma-separated market identifiers. Optional."
+      },
+      {
+        "name": "bookmakers",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      },
+      {
+        "name": "player",
+        "type": "string",
+        "desc": "Player name filter. Optional."
+      },
+      {
+        "name": "include_futures",
+        "type": "boolean",
+        "desc": "Whether to include available futures. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_best_line",
+    "description": "Compare the returned prices for a selected market. Quotes and execution may change.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "market",
+        "type": "string",
+        "desc": "Market identifier. Optional."
+      },
+      {
+        "name": "bookmakers",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_verdict",
+    "description": "Request the API calculation for a specified bet. Results depend on available quotes and model assumptions.",
+    "arguments": [
+      {
+        "name": "sport",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "side",
+        "type": "string",
+        "desc": "Requested outcome side."
+      },
+      {
+        "name": "market",
+        "type": "string",
+        "desc": "Market identifier. Optional."
+      },
+      {
+        "name": "home",
+        "type": "string",
+        "desc": "Home participant name. Optional."
+      },
+      {
+        "name": "away",
+        "type": "string",
+        "desc": "Away participant name. Optional."
+      },
+      {
+        "name": "team",
+        "type": "string",
+        "desc": "Participant name filter. Optional."
+      },
+      {
+        "name": "player",
+        "type": "string",
+        "desc": "Player name filter. Optional."
+      },
+      {
+        "name": "line",
+        "type": "number",
+        "desc": "Requested line value, or null. Optional."
+      },
+      {
+        "name": "book",
+        "type": "string",
+        "desc": "Bookmaker identifier. Optional."
+      },
+      {
+        "name": "price",
+        "type": "string",
+        "desc": "Supplied quote used by the calculation. Optional."
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "Region identifier. Optional."
+      },
+      {
+        "name": "books",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      },
+      {
+        "name": "bankroll",
+        "type": "number",
+        "desc": "User-supplied calculation input, or null. Optional."
+      },
+      {
+        "name": "kelly",
+        "type": "number",
+        "desc": "User-supplied fractional sizing parameter for the calculation. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_set_bettable_books",
+    "description": "Update the account region or bookmaker preferences after explicit user approval.",
+    "arguments": [
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "Region identifier. Optional."
+      },
+      {
+        "name": "books",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_parlay_verdict",
+    "description": "Request the API calculation for supplied parlay legs. This is not a profit guarantee.",
+    "arguments": [
+      {
+        "name": "legs",
+        "type": "array",
+        "desc": "Array of user-supplied leg specifications."
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "Region identifier. Optional."
+      },
+      {
+        "name": "books",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      },
+      {
+        "name": "stake",
+        "type": "number",
+        "desc": "User-supplied stake input, or null. Optional."
+      },
+      {
+        "name": "book",
+        "type": "string",
+        "desc": "Bookmaker identifier. Optional."
+      },
+      {
+        "name": "bankroll",
+        "type": "number",
+        "desc": "User-supplied calculation input, or null. Optional."
+      },
+      {
+        "name": "kelly",
+        "type": "number",
+        "desc": "User-supplied fractional sizing parameter for the calculation. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_best_bets",
+    "description": "Request API-ranked candidates under the specified filters. Calculations depend on inputs and assumptions.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "Region identifier. Optional."
+      },
+      {
+        "name": "books",
+        "type": "string",
+        "desc": "Comma-separated bookmaker identifiers. Optional."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum requested result count. Optional."
+      },
+      {
+        "name": "min_edge",
+        "type": "number",
+        "desc": "Minimum calculated edge filter. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_account_info",
+    "description": "Read your configured account tier and usage information.",
+    "arguments": []
+  },
+  {
+    "name": "parlayapi_find_arbitrage",
+    "description": "Request calculated cross-book price combinations. Quotes, liquidity and execution can change; profit is not guaranteed.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "min_profit",
+        "type": "number",
+        "desc": "Minimum calculated percentage filter; not realized profit. Optional."
+      },
+      {
+        "name": "exclude_exchanges",
+        "type": "boolean",
+        "desc": "Whether to exclude exchange sources. Optional."
+      },
+      {
+        "name": "markets",
+        "type": "string",
+        "desc": "Comma-separated market identifiers. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_find_ev",
+    "description": "Request calculated expected-value candidates relative to a selected reference book.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "sharp_book",
+        "type": "string",
+        "desc": "Reference bookmaker identifier. Optional."
+      },
+      {
+        "name": "min_edge",
+        "type": "number",
+        "desc": "Minimum calculated edge filter. Optional."
+      },
+      {
+        "name": "markets",
+        "type": "string",
+        "desc": "Comma-separated market identifiers. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_consensus",
+    "description": "Request aggregate odds across the sources returned for the selected market.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "markets",
+        "type": "string",
+        "desc": "Comma-separated market identifiers. Optional."
+      }
+    ]
+  },
+  {
+    "name": "parlayapi_find_middles",
+    "description": "Request calculated middle candidates for the specified filters; execution and outcomes remain uncertain.",
+    "arguments": [
+      {
+        "name": "sport_key",
+        "type": "string",
+        "desc": "ParlayAPI sport identifier."
+      },
+      {
+        "name": "min_gap",
+        "type": "number",
+        "desc": "Minimum line-gap filter. Optional."
+      },
+      {
+        "name": "markets",
+        "type": "string",
+        "desc": "Comma-separated market identifiers. Optional."
+      },
+      {
+        "name": "include_props",
+        "type": "boolean",
+        "desc": "Whether to include available player props. Optional."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ParlayAPI (`parlayapi`)
**Repository URL:** https://github.com/JacobiusMakes/parlay-api-mcp
**Brief Description:** Local stdio tools for sports odds, player props, public discovery and account usage. Each user configures their own ParlayAPI account key through Docker MCP secrets.

This adds `servers/parlayapi/server.yaml`, `tools.json` and `readme.md`. The
server runs as a non-root user, with no published port or host volume. Public
discovery works without a key; authenticated data requests use the configured
account's allowance. It is not a shared multi-user data relay.

The tool set also includes signup, checkout-link creation, login-link email
and saved-book preferences. The README identifies those side effects and asks
users to approve them explicitly. Software licensing does not grant API data
distribution rights.

## Basic Requirements

- [x] **Open Source**: MIT license.
- [x] **MCP Compliant**: Real stdio initialize, tools/list and resources/list passed.
- [x] **Active Development**: Public repository maintained, most recent inspected commit Sep 6, 2026.
- [x] **Docker Artifact**: Public Dockerfile pinned at `29083331240dedf5c434f41bb634680fc9d03b6a`; owned-repository hosted Docker build and offline discovery passed.
- [x] **Documentation**: Catalog README and local container instructions prepared.
- [x] **Security Contact**: support@parlay-api.com, with private-report instructions.

## Submitter Checklist

- [x] This server meets the basic requirements listed above.
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name parlayapi` (its exact Go command, below).
- [x] I have built the MCP Server using `task build -- --tools parlayapi` (its exact Go command, below).
- [ ] If the server requires credentials to test it, I have shared test credentials using the contribution form.

## Validation and remaining holds

This revision removes fixed checkout prices and guaranteed-profit language from
two runtime tool docstrings. Executable code and tool schemas are unchanged.

Completed locally: schema/name/type parity for 22 tools; YAML and JSON Prettier
checks; real stdio protocol initialization and metadata discovery with no API
key and network access blocked in the child process. No tools were called.

The public source is pinned at
[`29083331240dedf5c434f41bb634680fc9d03b6a`](https://github.com/JacobiusMakes/parlay-api-mcp/commit/29083331240dedf5c434f41bb634680fc9d03b6a).
Owned-repository [hosted CI](https://github.com/JacobiusMakes/parlay-api-mcp/actions/runs/34046641801)
passed the container build, non-root runtime and offline tool discovery.

Docker's official registry commands also passed on a GitHub-hosted Ubuntu runner
in [run 34046764168](https://github.com/JacobiusMakes/parlay-api-mcp/actions/runs/34046764168),
checking this exact catalog PR head `7343e28955f091b5ecfcd32ce5eb3cf17c1f0e9f`:

```sh
go run ./cmd/validate --name parlayapi
go run ./cmd/build --tools parlayapi
go run ./cmd/catalog parlayapi
```

These are the Go commands executed by the corresponding upstream Task targets.
All three exited successfully. The build reported 22 tools from the submitted
`tools.json`; the built image revision label matched the pinned source commit.
The workflow used no account secrets and made no MCP tool calls. Its
`docker-catalog-parlayapi-7343e289` artifact contains the validation/build/catalog
logs, image label and generated local test catalog. This is evidence of the
submitter's checks, not Docker approval or publication of `mcp/parlayapi`.
Docker review and acceptance of the demonstrated review scope remain outstanding.

## Review scope and credentials

The catalog secret is optional (`required: false`). Existing no-key evidence covers stdio initialization, tools/list and resources/list with network blocked, plus the official validate/build/catalog commands. The build reads the submitted tools.json; this does not test account tools or their results.

No test credential has been supplied. The credential checkbox remains unchecked. Account data calls need an individual account key and allowance; signup, checkout-link creation, login email and preference updates also require explicit user approval. None of these actions was exercised for this submission.

Please confirm whether the demonstrated keyless scope is sufficient for this review, or specify which account-tool checks require private reviewer access. Any such access would need to be arranged by the account owner through the contribution form, outside this PR. No shared community key or API data redistribution right is proposed.
