### PR TITLE
Add OilFlow Compliance (remote server: sanctions, fraud-cluster registry, pre-deal checks for physical-commodity trade)

### DIFF
--- a/servers/oilflow/server.yaml
+++ b/servers/oilflow/server.yaml
@@ -1,0 +1,20 @@
+name: oilflow
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: finance
+  tags:
+    - compliance
+    - sanctions
+    - kyc
+    - trade-finance
+    - commodities
+    - remote
+about:
+  title: OilFlow Compliance
+  description: Screen physical-commodity counterparties against 8 sanctions lists and a first-party fraud-cluster registry, check tradability across 235 jurisdictions, validate letters of credit (UCP 600) and run pre-deal clearance checks. Every verdict states its coverage and evidence gaps. Three tools need no API key; PEP screening is not offered.
+  icon: https://www.google.com/s2/favicons?domain=oilflow.us&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://oilflow.us/api/mcp


### PR DESCRIPTION
Remote server, Streamable HTTP at https://oilflow.us/api/mcp (stateless, JSON responses), no image needed.

- Four tools work with no credentials (cluster_check, predeal_preview at 5 verdicts/day per caller, verify_receipt, request_sandbox_key), so no test credentials are required for review; keyed tools accept an OILFLOW_API_KEY bearer that a free 30-day sandbox key satisfies.
- Coverage is stated in every tool description: eight government sanctions lists, no PEP screening, no SOC 2 claim; pre-deal output is decision support, not a clearance.
- Source: https://github.com/rafaemush/oilflow-mcp-server (npm @oilflow/mcp-server 0.3.2).