### PR TITLE
Add gitlab-mcp server by zereight

### DIFF
--- a/servers/gitlab-mcp/server.yaml
+++ b/servers/gitlab-mcp/server.yaml
@@ -1,0 +1,30 @@
+name: gitlab-mcp
+image: mcp/gitlab-mcp
+type: server
+meta:
+  category: devops
+  tags:
+    - gitlab
+    - devops
+about:
+  title: GitLab MCP by zereight
+  description: Agent-workflow-optimized GitLab MCP server with 100+ tools for projects, merge requests, issues, pipelines, wiki, and releases, including 2-step batched MR review.
+  icon: https://avatars.githubusercontent.com/u/42544600?v=4
+source:
+  project: https://github.com/zereight/gitlab-mcp
+  commit: b0918eeff53bd7ec28b1bfc30a98acd6909ba76e
+config:
+  description: Configure the connection to GitLab
+  secrets:
+    - name: gitlab-mcp.personal_access_token
+      env: GITLAB_PERSONAL_ACCESS_TOKEN
+      example: <YOUR_GITLAB_TOKEN>
+  env:
+    - name: GITLAB_API_URL
+      example: https://gitlab.com/api/v4
+      value: '{{gitlab-mcp.gitlab_api_url}}'
+  parameters:
+    type: object
+    properties:
+      gitlab_api_url:
+        type: string

--- a/servers/gitlab-mcp/tools.json
+++ b/servers/gitlab-mcp/tools.json
@@ -1,0 +1,5538 @@
+[
+  {
+    "name": "merge_merge_request",
+    "description": "Merge a merge request. Use this only after checking the merge request approval, conflict, and pipeline state; use `approve_merge_request` to approve rather than merge. The operation changes repository state and may squash commits, schedule auto-merge, or delete the source branch, so it requires merge permission and returns GitLab's merge result or a mergeability error. Pass `sha` from `get_merge_request` (`sha` or `diff_refs.head_sha`); GitLab 19.2+ groups may reject merges without it.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "sha": {
+          "type": "string",
+          "description": "SHA of the source-branch HEAD from get_merge_request (`sha` or `diff_refs.head_sha`). If provided, GitLab merges only when HEAD still matches. GitLab 19.2+ groups may require this (Require a commit SHA on the merge requests API)."
+        },
+        "auto_merge": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, the merge request merges when the pipeline succeeds."
+        },
+        "merge_commit_message": {
+          "type": "string",
+          "description": "Custom merge commit message"
+        },
+        "merge_when_pipeline_succeeds": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, the merge request merges when the pipeline succeeds. Deprecated in GitLab 17.11. Use `auto_merge` instead."
+        },
+        "should_remove_source_branch": {
+          "type": "boolean",
+          "default": false,
+          "description": "Remove source branch after merge"
+        },
+        "squash_commit_message": {
+          "type": "string",
+          "description": "Custom squash commit message"
+        },
+        "squash": {
+          "type": "boolean",
+          "default": false,
+          "description": "Squash commits into a single commit when merging"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "approve_merge_request",
+    "description": "Approve a merge request. Use this to record an approval on an existing merge request; it does not merge the request or change its source branch. The operation changes review state, may require re-authentication or approval permission, and returns the updated approval result or a permission/state error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of the merge request to approve"
+        },
+        "sha": {
+          "type": "string",
+          "description": "The HEAD of the merge request. Optional, but used to ensure the merge request hasn't changed since you last reviewed it"
+        },
+        "approval_password": {
+          "type": "string",
+          "description": "Current user's password. Required if 'Require user re-authentication to approve' is enabled in the project settings"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "unapprove_merge_request",
+    "description": "Unapprove a merge request. Use this to remove the current user's approval from an existing merge request; use `merge_merge_request` only when you intend to merge. The operation changes review state and requires approval permission, and GitLab returns the updated result or an error when the request or approval is unavailable.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of the merge request to unapprove"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_approval_state",
+    "description": "Get merge request approval details including approvers. Use this to inspect approval rules and approvers before deciding whether a merge request can be merged; use `approve_merge_request` to change approval state. It is read-only and returns the approval-state response, while missing requests, unsupported GitLab versions, and permission failures are reported as errors.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of the merge request"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_conflicts",
+    "description": "Get the conflicts of a merge request. Use this to inspect merge conflicts before attempting `merge_merge_request`; it reports conflicts and does not resolve them. It is read-only, requires access to the project and merge request, and returns GitLab's conflict data or an error when the request cannot be evaluated.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of the merge request"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_request_pipelines",
+    "description": "List pipelines for a merge request with pagination. Use this to inspect pipelines associated with one merge request; use `list_pipelines` for project-wide pipeline filtering. It is read-only and paginated, requires project access, and returns pipeline records or GitLab errors for invalid identifiers, missing resources, or rate limits.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The internal ID of the merge request"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "merge_request_iid",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_or_update_file",
+    "description": "Create or update a file in a GitLab project. Use this for a single repository file when you know whether the target path is new or already exists; use `push_files` for a multi-file commit. Optional `encoding` (`text` or `base64`) defaults to `GITLAB_REPO_FILE_ENCODING` so existing callers stay unchanged. The operation creates or updates remote content in a commit, requires repository write permission, and returns the commit result or a conflict/validation error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "file_path": {
+          "type": "string",
+          "description": "Path where to create/update the file"
+        },
+        "content": {
+          "type": "string",
+          "description": "Content of the file"
+        },
+        "commit_message": {
+          "type": "string",
+          "description": "Commit message"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Branch to create/update the file in"
+        },
+        "previous_path": {
+          "type": "string",
+          "description": "Path of the file to move/rename"
+        },
+        "last_commit_id": {
+          "type": "string",
+          "description": "Last known file commit ID"
+        },
+        "commit_id": {
+          "type": "string",
+          "description": "Current file commit ID (for update operations)"
+        },
+        "encoding": {
+          "type": "string",
+          "enum": [
+            "text",
+            "base64"
+          ],
+          "description": "Content encoding. Use 'base64' for binary files (content must already be base64-encoded). When omitted, GITLAB_REPO_FILE_ENCODING applies."
+        }
+      },
+      "required": [
+        "file_path",
+        "content",
+        "commit_message",
+        "branch",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "search_repositories",
+    "description": "Search for GitLab projects. Use this to discover matching content; choose a typed get or list tool when the target identifier is already known. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Search query"
+        },
+        "query": {
+          "type": "string",
+          "description": "Search query (alias for 'search')"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_repository",
+    "description": "Create a new GitLab project. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Repository name"
+        },
+        "namespace_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Group namespace ID to create the project in. Omit to use the current user's namespace."
+        },
+        "description": {
+          "type": "string",
+          "description": "Repository description"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "private",
+            "internal",
+            "public"
+          ],
+          "description": "Repository visibility level"
+        },
+        "initialize_with_readme": {
+          "type": "boolean",
+          "description": "Initialize with README.md"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_group",
+    "description": "Create new group or subgroup. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the group"
+        },
+        "path": {
+          "type": "string",
+          "description": "The path of the group"
+        },
+        "description": {
+          "type": "string",
+          "description": "The group's description"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "private",
+            "internal",
+            "public"
+          ],
+          "description": "The group's visibility level"
+        },
+        "parent_id": {
+          "type": "number",
+          "description": "The parent group ID for creating a subgroup"
+        }
+      },
+      "required": [
+        "name",
+        "path"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_file_contents",
+    "description": "Get contents of a file or directory from a GitLab project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path (optional; falls back to env)"
+        },
+        "file_path": {
+          "type": "string",
+          "description": "Path to the file or directory. Takes precedence over 'path' when both are provided"
+        },
+        "path": {
+          "type": "string",
+          "description": "Alias of file_path"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Branch/tag/commit to get contents from"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "push_files",
+    "description": "Push multiple files in a single commit. Use this to commit several file changes atomically; use `create_or_update_file` when only one path is involved. Each file defaults to action `create`; optional per-file `action` (create/update/delete/move) and `encoding` (text/base64) are additive. `GITLAB_PERMISSION_MODE=modify` rejects `delete` and `move`. The operation writes repository history on the selected branch, requires repository write permission, and returns the commit result or a validation, conflict, or protected-branch error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Branch to push to"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path of the file in the repo"
+              },
+              "content": {
+                "type": "string",
+                "description": "File content. Required for create and update. Omit for delete, or for a move that should keep the original content. Base64-encoded when encoding is 'base64'."
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "create",
+                  "update",
+                  "delete",
+                  "move"
+                ],
+                "description": "Commit action for this file. Defaults to 'create'."
+              },
+              "encoding": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "base64"
+                ],
+                "description": "Use 'base64' for binary files (content must already be base64-encoded). When omitted, GITLAB_REPO_FILE_ENCODING applies."
+              },
+              "previous_path": {
+                "type": "string",
+                "description": "Previous path of the file. Required when action is 'move'."
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "additionalProperties": false
+          },
+          "description": "Array of files to push. Each entry defaults to action 'create'. Per-file fields: action (create/update/delete/move), encoding (text/base64; omitted uses GITLAB_REPO_FILE_ENCODING), previous_path (required for move). Content is required for create and update; omit content for delete, or for a move that should keep the original file. GITLAB_PERMISSION_MODE=modify rejects delete and move."
+        },
+        "commit_message": {
+          "type": "string",
+          "description": "Commit message"
+        }
+      },
+      "required": [
+        "branch",
+        "files",
+        "commit_message",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_issue",
+    "description": "Create a new issue. Use this to open a new issue; use `update_issue` for an existing issue and `create_issue_note` to add discussion without changing issue fields. The operation creates remote project data, requires issue creation permission, and returns the new issue or a validation, permission, or duplicate-related error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "title": {
+          "type": "string",
+          "description": "Issue title"
+        },
+        "description": {
+          "type": "string",
+          "description": "Issue description"
+        },
+        "assignee_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Array of user IDs to assign"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of label names"
+        },
+        "milestone_id": {
+          "type": "string",
+          "description": "Milestone ID to assign"
+        },
+        "issue_type": {
+          "type": "string",
+          "enum": [
+            "issue",
+            "incident",
+            "test_case",
+            "task"
+          ],
+          "default": "issue",
+          "description": "The type of issue. One of issue, incident, test_case or task."
+        },
+        "weight": {
+          "type": "number",
+          "description": "Weight of the issue (numeric, typically hours of work)"
+        }
+      },
+      "required": [
+        "title",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_merge_request",
+    "description": "Create a new merge request. Use this to open a new merge request from an existing source branch to a target branch; use `update_merge_request` after it exists. The operation creates remote review state, requires project access, and returns the new merge request or a validation, permission, branch, or duplicate-related error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "title": {
+          "type": "string",
+          "description": "Merge request title"
+        },
+        "description": {
+          "type": "string",
+          "description": "Merge request description"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Branch containing changes"
+        },
+        "target_branch": {
+          "type": "string",
+          "description": "Branch to merge into"
+        },
+        "target_project_id": {
+          "type": "string",
+          "description": "Numeric ID of the target project."
+        },
+        "assignee_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "The ID of the users to assign the MR to"
+        },
+        "reviewer_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "The ID of the users to assign as reviewers of the MR"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Labels for the MR"
+        },
+        "draft": {
+          "type": "boolean",
+          "description": "Create as draft merge request"
+        },
+        "allow_collaboration": {
+          "type": "boolean",
+          "description": "Allow commits from upstream members"
+        },
+        "remove_source_branch": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Flag indicating if a merge request should remove the source branch when merging."
+        },
+        "squash": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "If true, squash all commits into a single commit on merge."
+        }
+      },
+      "required": [
+        "title",
+        "source_branch",
+        "target_branch",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "fork_repository",
+    "description": "Fork a project to your account or specified namespace. Use this to create a copy of an existing project in the current user's namespace or a permitted namespace; use `search_repositories` or `get_project` to inspect projects without copying them. The operation creates a new project, requires fork permission, and returns the forked project or a namespace/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace to fork to (full path)"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_branch",
+    "description": "Create a new branch. Use this to create a branch from a branch, tag, or commit; use `get_branch` or `list_branches` to inspect branches and `protect_branch` to configure protection afterward. The operation changes remote repository state, requires branch-creation permission, and returns the new branch or a validation, missing-ref, protected-project, or already-exists error. `project_id` accepts a numeric ID or URL-encoded path, `branch` is the new name, and `ref` selects its starting revision.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Name for the new branch"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Source branch/commit for new branch"
+        }
+      },
+      "required": [
+        "branch",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_branch",
+    "description": "Get branch details (commit, protection status). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch_name": {
+          "type": "string",
+          "description": "Name of the branch"
+        }
+      },
+      "required": [
+        "branch_name",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_branches",
+    "description": "List branches in project with search filter. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search term to filter branches by name"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_branch",
+    "description": "Delete branch from project. Use this only after confirming the branch name and intended data loss; use `get_branch` or `list_branches` before deletion and never use it to remove branch protection. The operation permanently removes a remote branch, requires branch-delete permission, and returns the deletion result or a protected-branch, missing-resource, or permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch_name": {
+          "type": "string",
+          "description": "Name of the branch to delete"
+        }
+      },
+      "required": [
+        "branch_name",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_protected_branches",
+    "description": "List protected branches in a project, supports search filter. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search term to filter protected branches by name"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_protected_branch",
+    "description": "Get details of a single protected branch (access levels, force push settings). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch_name": {
+          "type": "string",
+          "description": "Name of the protected branch"
+        }
+      },
+      "required": [
+        "branch_name",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "protect_branch",
+    "description": "Protect a repository branch (set push/merge/unprotect access levels). Use this to create or update protection rules for a branch or wildcard; use `get_protected_branch` to inspect existing rules first. The operation changes who may push, merge, or unprotect, may enable force-push or code-owner settings, requires maintainer-level permission, and returns the protection rule or a validation/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch_name": {
+          "type": "string",
+          "description": "Branch name or wildcard pattern to protect"
+        },
+        "name": {
+          "type": "string",
+          "description": "Deprecated alias for branch_name; prefer branch_name for consistency"
+        },
+        "push_access_level": {
+          "type": "integer",
+          "description": "Access level for pushing (0=No access, 30=Developer, 40=Maintainer, 60=Admin). GitLab default applies when omitted."
+        },
+        "merge_access_level": {
+          "type": "integer",
+          "description": "Access level for merging (0=No access, 30=Developer, 40=Maintainer, 60=Admin). GitLab default applies when omitted."
+        },
+        "unprotect_access_level": {
+          "type": "integer",
+          "description": "Access level for unprotecting (0=No access, 30=Developer, 40=Maintainer, 60=Admin). GitLab default applies when omitted."
+        },
+        "allow_force_push": {
+          "type": "boolean",
+          "description": "Allow force push to the protected branch. Default: false"
+        },
+        "code_owner_approval_required": {
+          "type": "boolean",
+          "description": "Require code owner approval before merging (PREMIUM). Default: false"
+        }
+      },
+      "required": [
+        "branch_name"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "unprotect_branch",
+    "description": "Remove protection from a previously protected branch. Use this to remove protection from an existing branch; use `protect_branch` to change access levels without removing the rule. The operation changes repository security controls, requires permission to manage protected branches, and returns the result or an error when the branch is missing or policy forbids the change.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "branch_name": {
+          "type": "string",
+          "description": "Name of the protected branch to unprotect"
+        }
+      },
+      "required": [
+        "branch_name",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_default_branch",
+    "description": "Change the default branch of a project. Use this to change which branch GitLab treats as the project's default; use `create_branch` to create a branch rather than changing project defaults. The operation changes project settings and may affect clone, merge request, and CI defaults, requires project-maintainer permission, and returns the updated project or a validation/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "default_branch": {
+          "type": "string",
+          "description": "The new default branch name for the project"
+        }
+      },
+      "required": [
+        "default_branch",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request",
+    "description": "Get details of a merge request (mergeRequestIid or branchName required). Set include_summaries=true for deployment/commit/approval summaries. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Source branch name"
+        },
+        "include_summaries": {
+          "type": "boolean",
+          "description": "If true, include deployment_summary, commit_addition_summary and approval_summary (extra API calls, larger response). Default false to reduce token usage."
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_diffs",
+    "description": "Get the changes/diffs of a merge request (mergeRequestIid or branchName required). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Source branch name"
+        },
+        "view": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "parallel"
+          ],
+          "description": "Diff view type"
+        },
+        "excluded_file_patterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of regex patterns to exclude files from the diff results. Each pattern is a JavaScript-compatible regular expression that matches file paths to ignore. Examples: [\"^vendor/\", \"^test/mocks/\", \"\\.spec\\.ts$\", \"package-lock\\.json\"]"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_request_changed_files",
+    "description": "List changed file paths in a merge request without diff content (mergeRequestIid or branchName required). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Source branch name"
+        },
+        "excluded_file_patterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of regex patterns to exclude files. Examples: [\"^vendor/\", \"\\.pb\\.go$\"]"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_request_diffs",
+    "description": "List merge request diffs with pagination (mergeRequestIid or branchName required). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Source branch name"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        },
+        "unidiff": {
+          "type": "boolean",
+          "description": "Present diffs in the unified diff format. Default is false. Introduced in GitLab 16.5."
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_file_diff",
+    "description": "Get diffs for specific files from a merge request (mergeRequestIid or branchName required). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Source branch name"
+        },
+        "file_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of file paths to retrieve diffs for (e.g. ['src/api/users.ts', 'src/repo/user.go']). Call list_merge_request_changed_files first to get the full list of changed paths."
+        },
+        "unidiff": {
+          "type": "boolean",
+          "description": "Present diff in the unified diff format. Default is false."
+        }
+      },
+      "required": [
+        "project_id",
+        "file_paths"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_request_versions",
+    "description": "List all versions of a merge request. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The internal ID of the merge request"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_version",
+    "description": "Get a specific version of a merge request. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The internal ID of the merge request"
+        },
+        "version_id": {
+          "type": "string",
+          "description": "The ID of the merge request diff version"
+        },
+        "unidiff": {
+          "type": "boolean",
+          "description": "Present diffs in the unified diff format. Default is false. Introduced in GitLab 16.5."
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "version_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_branch_diffs",
+    "description": "Get diffs between two branches or commits. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "from": {
+          "type": "string",
+          "description": "The base branch or commit SHA to compare from"
+        },
+        "to": {
+          "type": "string",
+          "description": "The target branch or commit SHA to compare to"
+        },
+        "straight": {
+          "type": "boolean",
+          "description": "Comparison method: false for '...' (default), true for '--'"
+        },
+        "excluded_file_patterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of regex patterns to exclude files from the diff results. Each pattern is a JavaScript-compatible regular expression that matches file paths to ignore. Examples: [\"^vendor/\", \"^test/mocks/\", \"\\.spec\\.ts$\", \"package-lock\\.json\"]"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_merge_request",
+    "description": "Update a merge request (mergeRequestIid or branchName required). Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Source branch name"
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the merge request"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the merge request"
+        },
+        "target_branch": {
+          "type": "string",
+          "description": "The target branch"
+        },
+        "assignee_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "The ID of the users to assign the MR to"
+        },
+        "reviewer_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "The ID of the users to assign as reviewers of the MR"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Labels for the MR"
+        },
+        "state_event": {
+          "type": "string",
+          "enum": [
+            "close",
+            "reopen"
+          ],
+          "description": "New state (close/reopen) for the MR"
+        },
+        "remove_source_branch": {
+          "type": "boolean",
+          "description": "Flag indicating if the source branch should be removed"
+        },
+        "squash": {
+          "type": "boolean",
+          "description": "Squash commits into a single commit when merging"
+        },
+        "draft": {
+          "type": "boolean",
+          "description": "Work in progress merge request"
+        },
+        "milestone_id": {
+          "type": "string",
+          "description": "Milestone ID to assign. Set to 0 to unassign. Null is treated as omitted."
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_note",
+    "description": "Create a new note (comment) to an issue or merge request. Use this for a top-level comment on an issue or merge request when no typed discussion operation is needed; use `create_merge_request_thread` or `create_issue_note` for threaded replies. The operation creates remote discussion content, requires note permission, and returns the created note or a target/permission/validation error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or namespace/project_path"
+        },
+        "noteable_type": {
+          "type": "string",
+          "enum": [
+            "issue",
+            "merge_request"
+          ],
+          "description": "Type of noteable (issue or merge_request)"
+        },
+        "noteable_iid": {
+          "type": "string",
+          "description": "IID of the issue or merge request"
+        },
+        "body": {
+          "type": "string",
+          "description": "Note content"
+        }
+      },
+      "required": [
+        "noteable_type",
+        "body",
+        "project_id",
+        "noteable_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_merge_request_thread",
+    "description": "Create a new thread on a merge request. Use this to start a review thread on a merge request; use `create_merge_request_note` for an unthreaded note and `create_merge_request_discussion_note` to reply to an existing thread. The operation creates remote review content, requires note permission, and returns the discussion or a position/permission/validation error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the thread"
+        },
+        "position": {
+          "type": "object",
+          "properties": {
+            "base_sha": {
+              "type": "string",
+              "description": "REQUIRED: Base commit SHA in the source branch. Get this from merge request diff_refs.base_sha."
+            },
+            "head_sha": {
+              "type": "string",
+              "description": "REQUIRED: SHA referencing HEAD of the source branch. Get this from merge request diff_refs.head_sha."
+            },
+            "start_sha": {
+              "type": "string",
+              "description": "REQUIRED: SHA referencing the start commit of the source branch. Get this from merge request diff_refs.start_sha."
+            },
+            "position_type": {
+              "type": "string",
+              "enum": [
+                "text",
+                "image",
+                "file"
+              ],
+              "description": "REQUIRED: Position type. Use 'text' for code diffs, 'image' for image diffs, 'file' for file-level comments."
+            },
+            "new_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File path after changes. REQUIRED for most diff comments. Use same as old_path if file wasn't renamed."
+            },
+            "old_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File path before changes. REQUIRED for most diff comments. Use same as new_path if file wasn't renamed."
+            },
+            "new_line": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Line number in modified file (after changes). Use for added lines or context lines. NULL for deleted lines. For single-line comments on new lines."
+            },
+            "old_line": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Line number in original file (before changes). Use for deleted lines or context lines. NULL for added lines. For single-line comments on old lines."
+            },
+            "line_range": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "type": "object",
+                      "properties": {
+                        "line_code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_10_15'. Get this from GitLab diff API response, never fabricate."
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "new",
+                                "old",
+                                "expanded",
+                                "logic",
+                                "style"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. MUST match the line_code format and old_line/new_line values."
+                        },
+                        "old_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines."
+                        },
+                        "new_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines."
+                        }
+                      },
+                      "description": "Start line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither."
+                    },
+                    "end": {
+                      "type": "object",
+                      "properties": {
+                        "line_code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_12_17'. Must be from same file as start.line_code."
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "new",
+                                "old",
+                                "expanded",
+                                "logic",
+                                "style"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. SHOULD MATCH start.type for consistent ranges (don't mix old/new types)."
+                        },
+                        "old_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines. MUST be >= start.old_line if both specified."
+                        },
+                        "new_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines. MUST be >= start.new_line if both specified."
+                        }
+                      },
+                      "description": "End line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither. Range must be valid (end >= start)."
+                    }
+                  },
+                  "required": [
+                    "start",
+                    "end"
+                  ],
+                  "description": "Line range for multiline comments on GitLab merge request diffs. VALIDATION RULES: 1) line_code is critical for GitLab API success, 2) start/end must have consistent types, 3) line numbers must form valid range, 4) get line_code from GitLab diff API, never generate manually."
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "MULTILINE COMMENTS: Specify start/end line positions for commenting on multiple lines. Alternative to single old_line/new_line."
+            },
+            "width": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Width of the image (for position_type='image')."
+            },
+            "height": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Height of the image (for position_type='image')."
+            },
+            "x": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: X coordinate on the image (for position_type='image')."
+            },
+            "y": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Y coordinate on the image (for position_type='image')."
+            }
+          },
+          "required": [
+            "base_sha",
+            "head_sha",
+            "start_sha",
+            "position_type"
+          ],
+          "description": "Position when creating a diff note"
+        },
+        "created_at": {
+          "type": "string",
+          "description": "Date the thread was created at (ISO 8601 format)"
+        }
+      },
+      "required": [
+        "body",
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "resolve_merge_request_thread",
+    "description": "Resolve a thread on a merge request. Use this to mark an existing merge request review thread resolved; use `update_merge_request_discussion_note` when the note text itself must change. The operation changes review state, requires permission to resolve discussions, and returns the updated discussion or a missing-thread/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a thread"
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "Whether to resolve the thread"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "discussion_id",
+        "resolved"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "mr_discussions",
+    "description": "List discussion items for a merge request. Use this to list complete discussion threads for a merge request; use `get_merge_request_notes` when only flat notes are needed. It is read-only and returns threaded discussion items, while invalid merge request identifiers, missing resources, and permission failures are reported as errors.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_merge_request_discussion_note",
+    "description": "Delete a discussion note on a merge request. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a thread"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a thread note"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "discussion_id",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_merge_request_discussion_note",
+    "description": "Update a discussion note on a merge request. Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a thread"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a thread note"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the note or reply"
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "Resolve or unresolve the note"
+        }
+      }
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_merge_request_discussion_note",
+    "description": "Add a new discussion note to an existing merge request thread. Use this to reply inside an existing merge request discussion; use `create_merge_request_thread` to start a new thread and `create_merge_request_note` for a top-level note. The operation creates remote review content, requires note permission, and returns the new note or a missing-discussion/position/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a thread"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the note or reply"
+        },
+        "created_at": {
+          "type": "string",
+          "description": "Date the note was created at (ISO 8601 format)"
+        }
+      },
+      "required": [
+        "body",
+        "project_id",
+        "merge_request_iid",
+        "discussion_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_merge_request_note",
+    "description": "Add a new note to a merge request. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the note or reply"
+        }
+      },
+      "required": [
+        "body",
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_merge_request_note",
+    "description": "Delete an existing merge request note. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a thread note"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_note",
+    "description": "Get a specific note for a merge request. Use this to fetch one known merge request note by note identifier; use `get_merge_request_notes` for a collection and `mr_discussions` for threaded context. It is read-only and returns the note object or an error for an invalid identifier, missing note, or insufficient permission.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a thread note"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_merge_request_notes",
+    "description": "List notes for a merge request. Use this to list flat notes on a merge request; use `mr_discussions` when thread structure and resolution state are required. It is read-only and returns note records, while invalid identifiers, missing resources, and pagination or permission errors are reported by GitLab.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "The sort order of the notes"
+        },
+        "order_by": {
+          "type": "string",
+          "enum": [
+            "created_at",
+            "updated_at"
+          ],
+          "description": "The field to sort the notes by"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_merge_request_note",
+    "description": "Modify an existing merge request note. Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a thread note"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the note or reply"
+        }
+      },
+      "required": [
+        "body",
+        "project_id",
+        "merge_request_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_draft_note",
+    "description": "Get a single draft note from a merge request. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "draft_note_id": {
+          "type": "string",
+          "description": "The ID of the draft note"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "draft_note_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_draft_notes",
+    "description": "List draft notes for a merge request. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_draft_note",
+    "description": "Create a draft note for a merge request. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the draft note"
+        },
+        "in_reply_to_discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion the draft note replies to"
+        },
+        "position": {
+          "type": "object",
+          "properties": {
+            "base_sha": {
+              "type": "string",
+              "description": "REQUIRED: Base commit SHA in the source branch. Get this from merge request diff_refs.base_sha."
+            },
+            "head_sha": {
+              "type": "string",
+              "description": "REQUIRED: SHA referencing HEAD of the source branch. Get this from merge request diff_refs.head_sha."
+            },
+            "start_sha": {
+              "type": "string",
+              "description": "REQUIRED: SHA referencing the start commit of the source branch. Get this from merge request diff_refs.start_sha."
+            },
+            "position_type": {
+              "type": "string",
+              "enum": [
+                "text",
+                "image",
+                "file"
+              ],
+              "description": "REQUIRED: Position type. Use 'text' for code diffs, 'image' for image diffs, 'file' for file-level comments."
+            },
+            "new_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File path after changes. REQUIRED for most diff comments. Use same as old_path if file wasn't renamed."
+            },
+            "old_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File path before changes. REQUIRED for most diff comments. Use same as new_path if file wasn't renamed."
+            },
+            "new_line": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Line number in modified file (after changes). Use for added lines or context lines. NULL for deleted lines. For single-line comments on new lines."
+            },
+            "old_line": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Line number in original file (before changes). Use for deleted lines or context lines. NULL for added lines. For single-line comments on old lines."
+            },
+            "line_range": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "type": "object",
+                      "properties": {
+                        "line_code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_10_15'. Get this from GitLab diff API response, never fabricate."
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "new",
+                                "old",
+                                "expanded",
+                                "logic",
+                                "style"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. MUST match the line_code format and old_line/new_line values."
+                        },
+                        "old_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines."
+                        },
+                        "new_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines."
+                        }
+                      },
+                      "description": "Start line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither."
+                    },
+                    "end": {
+                      "type": "object",
+                      "properties": {
+                        "line_code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_12_17'. Must be from same file as start.line_code."
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "new",
+                                "old",
+                                "expanded",
+                                "logic",
+                                "style"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. SHOULD MATCH start.type for consistent ranges (don't mix old/new types)."
+                        },
+                        "old_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines. MUST be >= start.old_line if both specified."
+                        },
+                        "new_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines. MUST be >= start.new_line if both specified."
+                        }
+                      },
+                      "description": "End line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither. Range must be valid (end >= start)."
+                    }
+                  },
+                  "required": [
+                    "start",
+                    "end"
+                  ],
+                  "description": "Line range for multiline comments on GitLab merge request diffs. VALIDATION RULES: 1) line_code is critical for GitLab API success, 2) start/end must have consistent types, 3) line numbers must form valid range, 4) get line_code from GitLab diff API, never generate manually."
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "MULTILINE COMMENTS: Specify start/end line positions for commenting on multiple lines. Alternative to single old_line/new_line."
+            },
+            "width": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Width of the image (for position_type='image')."
+            },
+            "height": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Height of the image (for position_type='image')."
+            },
+            "x": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: X coordinate on the image (for position_type='image')."
+            },
+            "y": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Y coordinate on the image (for position_type='image')."
+            }
+          },
+          "required": [
+            "base_sha",
+            "head_sha",
+            "start_sha",
+            "position_type"
+          ],
+          "description": "Position when creating a diff note"
+        },
+        "resolve_discussion": {
+          "type": "boolean",
+          "description": "Whether to resolve the discussion when publishing"
+        }
+      },
+      "required": [
+        "body",
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_draft_note",
+    "description": "Update an existing draft note. Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "draft_note_id": {
+          "type": "string",
+          "description": "The ID of the draft note"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the draft note"
+        },
+        "position": {
+          "type": "object",
+          "properties": {
+            "base_sha": {
+              "type": "string",
+              "description": "REQUIRED: Base commit SHA in the source branch. Get this from merge request diff_refs.base_sha."
+            },
+            "head_sha": {
+              "type": "string",
+              "description": "REQUIRED: SHA referencing HEAD of the source branch. Get this from merge request diff_refs.head_sha."
+            },
+            "start_sha": {
+              "type": "string",
+              "description": "REQUIRED: SHA referencing the start commit of the source branch. Get this from merge request diff_refs.start_sha."
+            },
+            "position_type": {
+              "type": "string",
+              "enum": [
+                "text",
+                "image",
+                "file"
+              ],
+              "description": "REQUIRED: Position type. Use 'text' for code diffs, 'image' for image diffs, 'file' for file-level comments."
+            },
+            "new_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File path after changes. REQUIRED for most diff comments. Use same as old_path if file wasn't renamed."
+            },
+            "old_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "File path before changes. REQUIRED for most diff comments. Use same as new_path if file wasn't renamed."
+            },
+            "new_line": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Line number in modified file (after changes). Use for added lines or context lines. NULL for deleted lines. For single-line comments on new lines."
+            },
+            "old_line": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Line number in original file (before changes). Use for deleted lines or context lines. NULL for added lines. For single-line comments on old lines."
+            },
+            "line_range": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "type": "object",
+                      "properties": {
+                        "line_code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_10_15'. Get this from GitLab diff API response, never fabricate."
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "new",
+                                "old",
+                                "expanded",
+                                "logic",
+                                "style"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. MUST match the line_code format and old_line/new_line values."
+                        },
+                        "old_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines."
+                        },
+                        "new_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines."
+                        }
+                      },
+                      "description": "Start line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither."
+                    },
+                    "end": {
+                      "type": "object",
+                      "properties": {
+                        "line_code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "CRITICAL: Line identifier in format '{file_path_sha1_hash}_{old_line_number}_{new_line_number}'. USUALLY REQUIRED for GitLab diff comments despite being optional in schema. Example: 'a1b2c3d4e5f6_12_17'. Must be from same file as start.line_code."
+                        },
+                        "type": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "new",
+                                "old",
+                                "expanded",
+                                "logic",
+                                "style"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Line type: 'old' = deleted/original line, 'new' = added/modified line, null = unchanged context. SHOULD MATCH start.type for consistent ranges (don't mix old/new types)."
+                        },
+                        "old_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in original file (before changes). REQUIRED when type='old', NULL when type='new' (for purely added lines), can be present for context lines. MUST be >= start.old_line if both specified."
+                        },
+                        "new_line": {
+                          "type": [
+                            "number",
+                            "null"
+                          ],
+                          "description": "Line number in modified file (after changes). REQUIRED when type='new', NULL when type='old' (for purely deleted lines), can be present for context lines. MUST be >= start.new_line if both specified."
+                        }
+                      },
+                      "description": "End line position for multiline comment range. MUST specify either old_line OR new_line (or both for context), never neither. Range must be valid (end >= start)."
+                    }
+                  },
+                  "required": [
+                    "start",
+                    "end"
+                  ],
+                  "description": "Line range for multiline comments on GitLab merge request diffs. VALIDATION RULES: 1) line_code is critical for GitLab API success, 2) start/end must have consistent types, 3) line numbers must form valid range, 4) get line_code from GitLab diff API, never generate manually."
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "MULTILINE COMMENTS: Specify start/end line positions for commenting on multiple lines. Alternative to single old_line/new_line."
+            },
+            "width": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Width of the image (for position_type='image')."
+            },
+            "height": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Height of the image (for position_type='image')."
+            },
+            "x": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: X coordinate on the image (for position_type='image')."
+            },
+            "y": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "IMAGE DIFFS ONLY: Y coordinate on the image (for position_type='image')."
+            }
+          },
+          "required": [
+            "base_sha",
+            "head_sha",
+            "start_sha",
+            "position_type"
+          ],
+          "description": "Position when creating a diff note"
+        },
+        "resolve_discussion": {
+          "type": "boolean",
+          "description": "Whether to resolve the discussion when publishing"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "draft_note_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_draft_note",
+    "description": "Delete a draft note. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "draft_note_id": {
+          "type": "string",
+          "description": "The ID of the draft note"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "draft_note_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "publish_draft_note",
+    "description": "Publish a single draft note. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "draft_note_id": {
+          "type": "string",
+          "description": "The ID of the draft note"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "draft_note_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "bulk_publish_draft_notes",
+    "description": "Publish all draft notes for a merge request. Optionally sets reviewer_state and posts a summary note (GitLab 19.2+). Can set reviewer_state even with no drafts. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "reviewer_state": {
+          "type": "string",
+          "enum": [
+            "requested_changes",
+            "reviewed"
+          ],
+          "description": "Set reviewer review state after publishing (GitLab 19.2+). Does not record a formal approval. Works even with no draft notes."
+        },
+        "note": {
+          "type": "string",
+          "description": "Summary note body to post on the merge request (GitLab 19.2+)"
+        },
+        "internal": {
+          "type": "boolean",
+          "description": "If true, the summary note is internal (GitLab 19.2+, default false)"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_request_emoji_reactions",
+    "description": "List all emoji reactions on a merge request. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_request_note_emoji_reactions",
+    "description": "List all emoji reactions on a merge request note. Pass discussion_id for discussion thread replies. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a note (comment or thread reply)"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion thread. Required for notes that are discussion replies; omit for top-level notes."
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_merge_request_emoji_reaction",
+    "description": "Add an emoji reaction to a merge request (e.g. thumbsup, rocket, eyes). Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the emoji without colons (e.g. 'thumbsup', 'rocket', 'eyes')"
+        }
+      },
+      "required": [
+        "name",
+        "project_id",
+        "merge_request_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_merge_request_emoji_reaction",
+    "description": "Remove an emoji reaction from a merge request. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "award_id": {
+          "type": "string",
+          "description": "The ID of the emoji reaction to delete"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "award_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_merge_request_note_emoji_reaction",
+    "description": "Add an emoji reaction to a merge request note. Pass discussion_id for discussion thread replies. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a note (comment or thread reply)"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion thread. Required for notes that are discussion replies; omit for top-level notes."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the emoji without colons (e.g. 'thumbsup', 'rocket', 'eyes')"
+        }
+      },
+      "required": [
+        "name",
+        "project_id",
+        "merge_request_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_merge_request_note_emoji_reaction",
+    "description": "Remove an emoji reaction from a merge request note. Pass discussion_id for discussion thread replies. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "merge_request_iid": {
+          "type": "string",
+          "description": "The IID of a merge request"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a note (comment or thread reply)"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion thread. Required for notes that are discussion replies; omit for top-level notes."
+        },
+        "award_id": {
+          "type": "string",
+          "description": "The ID of the emoji reaction to delete"
+        }
+      },
+      "required": [
+        "project_id",
+        "merge_request_iid",
+        "note_id",
+        "award_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_issue_note",
+    "description": "Modify an existing issue thread note. Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a thread"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a thread note"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the note or reply"
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "Resolve or unresolve the note"
+        }
+      }
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_issue_note",
+    "description": "Add a note to an issue, optionally replying to a discussion thread. Use this to add a note to an existing issue, optionally as a reply to a discussion; use `update_issue` for issue fields and `create_note` only when the generic endpoint is required. The operation creates remote discussion content, requires note permission, and returns the note or a missing-issue/thread/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a thread. If provided, replies to that thread; otherwise creates a top-level note"
+        },
+        "body": {
+          "type": "string",
+          "description": "The content of the note or reply"
+        },
+        "created_at": {
+          "type": "string",
+          "description": "Date the note was created at (ISO 8601 format)"
+        }
+      },
+      "required": [
+        "body",
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_issue_emoji_reactions",
+    "description": "List all emoji reactions on an issue. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_issue_note_emoji_reactions",
+    "description": "List all emoji reactions on an issue note. Pass discussion_id for discussion thread replies. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a note (comment or thread reply)"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion thread. Required for notes that are discussion replies; omit for top-level notes."
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_issue_emoji_reaction",
+    "description": "Add an emoji reaction to an issue (e.g. thumbsup, rocket, eyes). Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the emoji without colons (e.g. 'thumbsup', 'rocket', 'eyes')"
+        }
+      },
+      "required": [
+        "name",
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_issue_emoji_reaction",
+    "description": "Remove an emoji reaction from an issue. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "award_id": {
+          "type": "string",
+          "description": "The ID of the emoji reaction to delete"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid",
+        "award_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_issue_note_emoji_reaction",
+    "description": "Add an emoji reaction to an issue note. Pass discussion_id for discussion thread replies. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a note (comment or thread reply)"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion thread. Required for notes that are discussion replies; omit for top-level notes."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the emoji without colons (e.g. 'thumbsup', 'rocket', 'eyes')"
+        }
+      },
+      "required": [
+        "name",
+        "project_id",
+        "issue_iid",
+        "note_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_issue_note_emoji_reaction",
+    "description": "Remove an emoji reaction from an issue note. Pass discussion_id for discussion thread replies. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The IID of an issue"
+        },
+        "note_id": {
+          "type": "string",
+          "description": "The ID of a note (comment or thread reply)"
+        },
+        "discussion_id": {
+          "type": "string",
+          "description": "The ID of a discussion thread. Required for notes that are discussion replies; omit for top-level notes."
+        },
+        "award_id": {
+          "type": "string",
+          "description": "The ID of the emoji reaction to delete"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid",
+        "note_id",
+        "award_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_issues",
+    "description": "List issues (default: created by current user; use scope='all' for all). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path (optional - if not provided, lists issues across all accessible projects)"
+        },
+        "assignee_id": {
+          "type": "string",
+          "description": "Return issues assigned to the given user ID (user id, none, or any). Mutually exclusive with assignee_username."
+        },
+        "assignee_username": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Return issues assigned to the given username. Mutually exclusive with assignee_id."
+        },
+        "author_id": {
+          "type": "string",
+          "description": "Return issues created by the given user ID. Mutually exclusive with author_username."
+        },
+        "author_username": {
+          "type": "string",
+          "description": "Return issues created by the given username. Mutually exclusive with author_id."
+        },
+        "confidential": {
+          "type": "boolean",
+          "description": "Filter confidential or public issues"
+        },
+        "created_after": {
+          "type": "string",
+          "description": "Return issues created after the given time"
+        },
+        "created_before": {
+          "type": "string",
+          "description": "Return issues created before the given time"
+        },
+        "due_date": {
+          "type": "string",
+          "description": "Return issues that have the due date"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of label names"
+        },
+        "milestone": {
+          "type": "string",
+          "description": "Milestone title"
+        },
+        "issue_type": {
+          "type": "string",
+          "enum": [
+            "issue",
+            "incident",
+            "test_case",
+            "task"
+          ],
+          "description": "Filter to a given type of issue. One of issue, incident, test_case or task"
+        },
+        "iteration_id": {
+          "type": "string",
+          "description": "Return issues assigned to the given iteration ID. None returns issues that do not belong to an iteration. Any returns issues that belong to an iteration. "
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "created_by_me",
+            "assigned_to_me",
+            "all"
+          ],
+          "description": "Return issues from a specific scope"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search for specific terms"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "opened",
+            "closed",
+            "all"
+          ],
+          "description": "Return issues with a specific state"
+        },
+        "updated_after": {
+          "type": "string",
+          "description": "Return issues updated after the given time"
+        },
+        "updated_before": {
+          "type": "string",
+          "description": "Return issues updated before the given time"
+        },
+        "with_labels_details": {
+          "type": "boolean",
+          "description": "Return more details for each label"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "my_issues",
+    "description": "List issues assigned to the authenticated user. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path (optional to search across all accessible projects)"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "opened",
+            "closed",
+            "all"
+          ],
+          "description": "Return issues with a specific state (default: opened)"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of label names to filter by"
+        },
+        "milestone": {
+          "type": "string",
+          "description": "Milestone title to filter by"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search for specific terms in title and description"
+        },
+        "created_after": {
+          "type": "string",
+          "description": "Return issues created after the given time (ISO 8601)"
+        },
+        "created_before": {
+          "type": "string",
+          "description": "Return issues created before the given time (ISO 8601)"
+        },
+        "updated_after": {
+          "type": "string",
+          "description": "Return issues updated after the given time (ISO 8601)"
+        },
+        "updated_before": {
+          "type": "string",
+          "description": "Return issues updated before the given time (ISO 8601)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (default: 20, max: 100)"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_issue",
+    "description": "Get details of a specific issue. Returns a slim milestone by default; set full_response=true for the complete milestone object. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of the project issue"
+        },
+        "full_response": {
+          "type": "boolean",
+          "description": "If true, return the complete issue object including the full milestone description. Default returns a slim milestone (id, iid, title, state, web_url) to reduce token usage."
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_issue",
+    "description": "Update an issue. Returns a slim confirmation by default; set full_response=true for the complete updated issue object. Use this to change fields on an existing issue; use `update_issue_description_patch` for a targeted description edit that avoids sending the full body, and use `create_issue_note` for discussion. The operation mutates issue state, requires issue-edit permission, and returns the updated issue or a validation/permission/conflict error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of the project issue"
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the issue"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the issue"
+        },
+        "assignee_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Array of user IDs to assign issue to"
+        },
+        "confidential": {
+          "type": "boolean",
+          "description": "Set the issue to be confidential"
+        },
+        "discussion_locked": {
+          "type": "boolean",
+          "description": "Flag to lock discussions"
+        },
+        "due_date": {
+          "type": "string",
+          "description": "Date the issue is due (YYYY-MM-DD)"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of label names"
+        },
+        "milestone_id": {
+          "type": "string",
+          "description": "Milestone ID to assign"
+        },
+        "state_event": {
+          "type": "string",
+          "enum": [
+            "close",
+            "reopen"
+          ],
+          "description": "Update issue state (close/reopen)"
+        },
+        "weight": {
+          "type": "number",
+          "description": "Weight of the issue (numeric, typically hours of work)"
+        },
+        "issue_type": {
+          "type": "string",
+          "enum": [
+            "issue",
+            "incident",
+            "test_case",
+            "task"
+          ],
+          "description": "The type of issue. One of issue, incident, test_case or task."
+        },
+        "full_response": {
+          "type": "boolean",
+          "description": "If true, return the complete updated issue object. Default returns a slim confirmation (iid, title, state, web_url, updated_at) to reduce token usage."
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_issue_description_patch",
+    "description": "Apply a patch (search/replace or unified diff) to an issue description. Reduces token usage by allowing small changes without sending the full description. Supports dry_run to preview changes and create_note to summarize updates. Use this for a targeted search/replace or unified-diff change to an issue description; use `dry_run` before applying an uncertain patch and `create_note` when an audit summary is wanted. It changes the issue description when not dry-running, requires issue-edit permission, and returns the patch result or a mismatch/validation/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of the project issue"
+        },
+        "patch_type": {
+          "type": "string",
+          "enum": [
+            "search_replace",
+            "unified_diff"
+          ],
+          "description": "Type of patch format to apply"
+        },
+        "patch": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50000,
+          "description": "The patch content to apply to the issue description"
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "If true, preview changes without updating the issue"
+        },
+        "create_note": {
+          "type": "boolean",
+          "description": "If true, add a note summarizing the change after update"
+        },
+        "allow_multiple": {
+          "type": "boolean",
+          "description": "For search_replace: allow multiple matches to all be replaced (default: false \u2014 fail on duplicate)"
+        }
+      },
+      "required": [
+        "patch_type",
+        "patch",
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_issue",
+    "description": "Delete an issue. Use this only after confirming the issue and intended permanent removal; use `update_issue` to close or edit an issue without deleting it. The operation permanently removes issue data, requires delete permission, and returns the deletion result or a missing-resource, permission, or policy error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of the project issue"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_todos",
+    "description": "List GitLab to-do items for the current user. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "assigned",
+            "mentioned",
+            "build_failed",
+            "marked",
+            "approval_required",
+            "unmergeable",
+            "directly_addressed",
+            "merge_train_removed",
+            "member_access_requested"
+          ],
+          "description": "Filter by to-do action"
+        },
+        "author_id": {
+          "type": "number",
+          "description": "Filter by author ID"
+        },
+        "project_id": {
+          "type": "number",
+          "description": "Filter by project ID"
+        },
+        "group_id": {
+          "type": "number",
+          "description": "Filter by group ID"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "done"
+          ],
+          "description": "Filter by to-do state"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Issue",
+            "MergeRequest",
+            "Commit",
+            "Epic",
+            "DesignManagement::Design",
+            "AlertManagement::Alert",
+            "Project",
+            "Namespace",
+            "Vulnerability",
+            "WikiPage::Meta"
+          ],
+          "description": "Filter by to-do target type"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "mark_todo_done",
+    "description": "Mark a GitLab to-do item as done. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "The ID of the to-do item"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "mark_all_todos_done",
+    "description": "Mark all pending GitLab to-do items as done for the current user. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_issue_links",
+    "description": "List all issue links for a specific issue. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of a project's issue"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_issue_discussions",
+    "description": "List discussions for an issue. Use this to inspect threaded discussions for an issue; use `list_issues` for issue records and `get_issue` for one issue's fields. It is read-only and returns discussion items, while invalid identifiers, missing issues, and permission failures are reported as errors.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of the project issue"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_issue_link",
+    "description": "Get a specific issue link. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of a project's issue"
+        },
+        "issue_link_id": {
+          "type": "string",
+          "description": "ID of an issue relationship"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid",
+        "issue_link_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_issue_link",
+    "description": "Create an issue link between two issues. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of a project's issue"
+        },
+        "target_project_id": {
+          "type": "string",
+          "description": "The ID or URL-encoded path of a target project"
+        },
+        "target_issue_iid": {
+          "type": "string",
+          "description": "The internal ID of a target project's issue"
+        },
+        "link_type": {
+          "type": "string",
+          "enum": [
+            "relates_to",
+            "blocks",
+            "is_blocked_by"
+          ],
+          "description": "The type of the relation, defaults to relates_to"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid",
+        "target_project_id",
+        "target_issue_iid"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_issue_link",
+    "description": "Delete an issue link. Use this to remove an existing relationship between two issues; use `list_issue_links` or `get_issue_link` to verify the link first. The operation changes issue relationships, requires issue-edit permission, and returns the result or an error when the link is missing or access is denied.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "issue_iid": {
+          "type": "string",
+          "description": "The internal ID of a project's issue"
+        },
+        "issue_link_id": {
+          "type": "string",
+          "description": "The ID of an issue relationship"
+        }
+      },
+      "required": [
+        "project_id",
+        "issue_iid",
+        "issue_link_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_namespaces",
+    "description": "List all namespaces (users and groups) available to the current user. Filter by kind='group' for groups only. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Search term for namespaces"
+        },
+        "owned": {
+          "type": "boolean",
+          "description": "Filter for namespaces owned by current user"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_namespace",
+    "description": "Get details of a namespace (user or group) by ID or path. Groups are namespaces with kind='group'. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "namespace_id": {
+          "type": "string",
+          "description": "Namespace ID or full path"
+        }
+      },
+      "required": [
+        "namespace_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "verify_namespace",
+    "description": "Verify if a namespace path exists. Use parent_id to scope the check to a specific parent namespace \u2014 required for nested namespaces where the same path may exist under different parents.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Namespace path to verify"
+        },
+        "parent_id": {
+          "type": "integer",
+          "description": "Parent namespace ID; required to correctly resolve paths in nested namespaces where the same path may exist under different parents"
+        }
+      },
+      "required": [
+        "path"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_project",
+    "description": "Get details of a specific project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_projects",
+    "description": "List projects accessible by the current user. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Search term for projects"
+        },
+        "search_namespaces": {
+          "type": "boolean",
+          "description": "Needs to be true if search is full path"
+        },
+        "owned": {
+          "type": "boolean",
+          "description": "Filter for projects owned by current user"
+        },
+        "membership": {
+          "type": "boolean",
+          "description": "Filter for projects where current user is a member"
+        },
+        "simple": {
+          "type": "boolean",
+          "description": "Return only limited fields"
+        },
+        "archived": {
+          "type": "boolean",
+          "description": "Filter for archived projects"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "internal",
+            "private"
+          ],
+          "description": "Filter by project visibility"
+        },
+        "order_by": {
+          "type": "string",
+          "enum": [
+            "id",
+            "name",
+            "path",
+            "created_at",
+            "updated_at",
+            "last_activity_at"
+          ],
+          "description": "Return projects ordered by field"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Return projects sorted in ascending or descending order"
+        },
+        "with_issues_enabled": {
+          "type": "boolean",
+          "description": "Filter projects with issues feature enabled"
+        },
+        "with_merge_requests_enabled": {
+          "type": "boolean",
+          "description": "Filter projects with merge requests feature enabled"
+        },
+        "min_access_level": {
+          "type": "number",
+          "description": "Filter by minimum access level"
+        },
+        "topic": {
+          "type": "string",
+          "description": "Filter by topic (projects tagged with this topic)"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_project",
+    "description": "Update project settings such as description, visibility, default branch, and feature access levels. Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "name": {
+          "type": "string",
+          "description": "Project display name"
+        },
+        "path": {
+          "type": "string",
+          "description": "Project path/slug"
+        },
+        "description": {
+          "type": "string",
+          "description": "Project description"
+        },
+        "default_branch": {
+          "type": "string",
+          "description": "Default branch name"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "private",
+            "internal",
+            "public"
+          ],
+          "description": "Project visibility"
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Project topics"
+        },
+        "request_access_enabled": {
+          "type": "boolean",
+          "description": "Allow users to request access"
+        },
+        "remove_source_branch_after_merge": {
+          "type": "boolean",
+          "description": "Remove source branches after merge by default"
+        },
+        "only_allow_merge_if_pipeline_succeeds": {
+          "type": "boolean",
+          "description": "Require successful pipeline before merge"
+        },
+        "only_allow_merge_if_all_discussions_are_resolved": {
+          "type": "boolean",
+          "description": "Require all discussions to be resolved before merge"
+        },
+        "squash_option": {
+          "type": "string",
+          "enum": [
+            "never",
+            "always",
+            "default_on",
+            "default_off"
+          ],
+          "description": "Squash commits setting"
+        },
+        "merge_method": {
+          "type": "string",
+          "enum": [
+            "merge",
+            "rebase_merge",
+            "ff"
+          ],
+          "description": "Merge method"
+        },
+        "issues_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Issues feature visibility"
+        },
+        "merge_requests_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Merge requests feature visibility"
+        },
+        "builds_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "CI/CD pipelines feature visibility"
+        },
+        "wiki_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Wiki feature visibility"
+        },
+        "snippets_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Snippets feature visibility"
+        },
+        "container_registry_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Container registry feature visibility"
+        },
+        "environments_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Environments feature visibility"
+        },
+        "forking_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Forking feature visibility"
+        },
+        "package_registry_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled"
+          ],
+          "description": "Package registry feature visibility"
+        },
+        "pages_access_level": {
+          "type": "string",
+          "enum": [
+            "disabled",
+            "private",
+            "enabled",
+            "public"
+          ],
+          "description": "Pages feature visibility"
+        }
+      }
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_project_members",
+    "description": "List members of a GitLab project. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "query": {
+          "type": "string",
+          "description": "Search for members by name or username"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Filter by user IDs"
+        },
+        "skip_users": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "User IDs to exclude"
+        },
+        "include_inheritance": {
+          "type": "boolean",
+          "description": "Include inherited members. Defaults to false."
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (default: 20, max: 100)"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_group_members",
+    "description": "List members of a GitLab group with optional name or username search. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "string",
+          "description": "Group ID or URL-encoded path"
+        },
+        "query": {
+          "type": "string",
+          "description": "Search for members by name or username"
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Filter by user IDs"
+        },
+        "skip_users": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "User IDs to exclude"
+        },
+        "include_inheritance": {
+          "type": "boolean",
+          "description": "Include inherited members. Defaults to false."
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (default: 20, max: 100)"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        }
+      },
+      "required": [
+        "group_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_labels",
+    "description": "List labels for a project. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "with_counts": {
+          "type": "boolean",
+          "description": "Whether to include issue and merge request counts"
+        },
+        "include_ancestor_groups": {
+          "type": "boolean",
+          "description": "Include ancestor groups"
+        },
+        "search": {
+          "type": "string",
+          "description": "Keyword to filter labels by"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_label",
+    "description": "Get a single label from a project. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "label_id": {
+          "type": "string",
+          "description": "The ID or title of a project's label"
+        },
+        "include_ancestor_groups": {
+          "type": "boolean",
+          "description": "Include ancestor groups"
+        }
+      },
+      "required": [
+        "project_id",
+        "label_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_label",
+    "description": "Create a new label in a project. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the label"
+        },
+        "color": {
+          "type": "string",
+          "description": "The color of the label given in 6-digit hex notation with leading '#' sign"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the label"
+        },
+        "priority": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "The priority of the label"
+        }
+      },
+      "required": [
+        "name",
+        "color",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "update_label",
+    "description": "Update an existing label in a project. Use this for an existing resource; choose the corresponding create tool for a new resource and a note tool for discussion-only text. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "label_id": {
+          "type": "string",
+          "description": "The ID or title of a project's label"
+        },
+        "new_name": {
+          "type": "string",
+          "description": "The new name of the label"
+        },
+        "color": {
+          "type": "string",
+          "description": "The color of the label given in 6-digit hex notation with leading '#' sign"
+        },
+        "description": {
+          "type": "string",
+          "description": "The new description of the label"
+        },
+        "priority": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "The new priority of the label"
+        }
+      },
+      "required": [
+        "project_id",
+        "label_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "delete_label",
+    "description": "Delete a label from a project. Use this only after verifying the target; choose a get or list tool first when you need to inspect state without changing it. It changes or removes remote GitLab data and may be irreversible; it requires the necessary project or group permission and returns validation, conflict, permission, or rate-limit errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "label_id": {
+          "type": "string",
+          "description": "The ID or title of a project's label"
+        }
+      },
+      "required": [
+        "project_id",
+        "label_id"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_group_projects",
+    "description": "List projects in a group. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "string",
+          "description": "Group ID or path"
+        },
+        "include_subgroups": {
+          "type": "boolean",
+          "description": "Include projects from subgroups"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search term to filter projects"
+        },
+        "order_by": {
+          "type": "string",
+          "enum": [
+            "name",
+            "path",
+            "created_at",
+            "updated_at",
+            "last_activity_at"
+          ],
+          "description": "Field to sort by"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Sort direction"
+        },
+        "archived": {
+          "type": "boolean",
+          "description": "Filter for archived projects"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "public",
+            "internal",
+            "private"
+          ],
+          "description": "Filter by project visibility"
+        },
+        "with_issues_enabled": {
+          "type": "boolean",
+          "description": "Filter projects with issues feature enabled"
+        },
+        "with_merge_requests_enabled": {
+          "type": "boolean",
+          "description": "Filter projects with merge requests feature enabled"
+        },
+        "min_access_level": {
+          "type": "number",
+          "description": "Filter by minimum access level"
+        },
+        "with_programming_language": {
+          "type": "string",
+          "description": "Filter by programming language"
+        },
+        "starred": {
+          "type": "boolean",
+          "description": "Filter by starred projects"
+        },
+        "statistics": {
+          "type": "boolean",
+          "description": "Include project statistics"
+        },
+        "with_custom_attributes": {
+          "type": "boolean",
+          "description": "Include custom attributes"
+        },
+        "with_security_reports": {
+          "type": "boolean",
+          "description": "Include security reports"
+        },
+        "topic": {
+          "type": "string",
+          "description": "Filter by topic (projects tagged with this topic)"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "group_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_repository_tree",
+    "description": "List files and directories in a repository. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "The ID or URL-encoded path of the project"
+        },
+        "path": {
+          "type": "string",
+          "description": "The path inside the repository"
+        },
+        "ref": {
+          "type": "string",
+          "description": "The name of a repository branch or tag. Defaults to the default branch."
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "Boolean value to get a recursive tree"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of results to show per page"
+        },
+        "page_token": {
+          "type": "string",
+          "description": "Token for keyset pagination. Use the next_page_token value returned in the previous response to retrieve the next page."
+        },
+        "pagination": {
+          "type": "string",
+          "description": "Pagination method. Use 'keyset' for keyset-based pagination (required for repositories with many files). Non-keyset calls keep the legacy array response for backward compatibility; that legacy response shape is deprecated and may be removed in a future major release. Keyset calls return a structured response with items and next_page_token when more pages are available."
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "validate_ci_lint",
+    "description": "Validate provided GitLab CI/CD YAML content for a project. Use this to check configuration without applying it; choose a create or update tool only after validation succeeds. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "content": {
+          "type": "string",
+          "description": "GitLab CI/CD YAML content to validate"
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "Run pipeline creation simulation"
+        },
+        "include_jobs": {
+          "type": "boolean",
+          "description": "Include jobs in the lint response"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Branch or tag context for dry_run validation"
+        }
+      },
+      "required": [
+        "content",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "validate_project_ci_lint",
+    "description": "Validate an existing .gitlab-ci.yml configuration for a project. Use this to check configuration without applying it; choose a create or update tool only after validation succeeds. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "content_ref": {
+          "type": "string",
+          "description": "Commit SHA, branch, or tag to read the existing CI config from"
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "Run pipeline creation simulation"
+        },
+        "dry_run_ref": {
+          "type": "string",
+          "description": "Branch or tag context for dry_run validation"
+        },
+        "include_jobs": {
+          "type": "boolean",
+          "description": "Include jobs in the lint response"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_ci_catalog_resources",
+    "description": "List GitLab CI/CD Catalog resources/components visible to the user. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Search catalog resources by name or description"
+        },
+        "first": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Number of resources to return (default: 20, max: 100)"
+        },
+        "after": {
+          "type": "string",
+          "description": "GraphQL cursor for the next page"
+        },
+        "group_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Filter to catalog resources in these group IDs"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "ALL",
+            "NAMESPACES"
+          ],
+          "description": "Catalog resource scope"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "CREATED_ASC",
+            "CREATED_DESC",
+            "LATEST_RELEASED_AT_ASC",
+            "LATEST_RELEASED_AT_DESC",
+            "NAME_ASC",
+            "NAME_DESC",
+            "STAR_COUNT_ASC",
+            "STAR_COUNT_DESC",
+            "USAGE_COUNT_ASC",
+            "USAGE_COUNT_DESC"
+          ],
+          "description": "Sort order"
+        },
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Filter by project topic names"
+        },
+        "verification_level": {
+          "type": "string",
+          "enum": [
+            "GITLAB_MAINTAINED",
+            "GITLAB_PARTNER_MAINTAINED",
+            "UNVERIFIED",
+            "VERIFIED_CREATOR_MAINTAINED",
+            "VERIFIED_CREATOR_SELF_MANAGED"
+          ],
+          "description": "Filter by verification level"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_ci_catalog_resource",
+    "description": "Get details for a GitLab CI/CD Catalog resource, including versions and components. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "version_limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Number of versions to include (default: 5, max: 20)"
+        },
+        "component_limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "description": "Number of components per version to include (default: 20, max: 50)"
+        },
+        "component_name": {
+          "type": "string",
+          "description": "Filter returned components by component name"
+        },
+        "include_readme": {
+          "type": "boolean",
+          "description": "Include version README content"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CI/CD Catalog resource global ID. Required when full_path is omitted."
+        },
+        "full_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CI/CD Catalog resource full project path. Required when id is omitted."
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_merge_requests",
+    "description": "List merge requests (without project_id: user's MRs; with project_id: project MRs). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path (optional - if not provided, lists all merge requests the user has access to)"
+        },
+        "assignee_id": {
+          "type": "string",
+          "description": "Return MRs assigned to the given user ID (integer), 'none', or 'any'. Mutually exclusive with assignee_username."
+        },
+        "assignee_username": {
+          "type": "string",
+          "description": "Returns merge requests assigned to the given username. Mutually exclusive with assignee_id."
+        },
+        "author_id": {
+          "type": "string",
+          "description": "Returns merge requests created by the given user ID (integer). Mutually exclusive with author_username."
+        },
+        "author_username": {
+          "type": "string",
+          "description": "Returns merge requests created by the given username. Mutually exclusive with author_id."
+        },
+        "reviewer_id": {
+          "type": "string",
+          "description": "Returns merge requests which have the user as a reviewer. Must be an integer, 'none', or 'any'. Mutually exclusive with reviewer_username."
+        },
+        "reviewer_username": {
+          "type": "string",
+          "description": "Returns merge requests which have the user as a reviewer by username. Mutually exclusive with reviewer_id."
+        },
+        "approved_by_usernames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Returns merge requests approved by the given usernames (array)."
+        },
+        "created_after": {
+          "type": "string",
+          "description": "Return merge requests created after the given time"
+        },
+        "created_before": {
+          "type": "string",
+          "description": "Return merge requests created before the given time"
+        },
+        "updated_after": {
+          "type": "string",
+          "description": "Return merge requests updated after the given time"
+        },
+        "updated_before": {
+          "type": "string",
+          "description": "Return merge requests updated before the given time"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of label names"
+        },
+        "milestone": {
+          "type": "string",
+          "description": "Milestone title"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "created_by_me",
+            "assigned_to_me",
+            "all"
+          ],
+          "description": "Return merge requests from a specific scope"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search for specific terms"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "opened",
+            "closed",
+            "locked",
+            "merged",
+            "all"
+          ],
+          "description": "Return merge requests with a specific state"
+        },
+        "order_by": {
+          "type": "string",
+          "enum": [
+            "created_at",
+            "updated_at",
+            "priority",
+            "label_priority",
+            "milestone_due",
+            "popularity"
+          ],
+          "description": "Return merge requests ordered by the given field"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Return merge requests sorted in ascending or descending order"
+        },
+        "target_branch": {
+          "type": "string",
+          "description": "Return merge requests targeting a specific branch"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Return merge requests from a specific source branch"
+        },
+        "wip": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no"
+          ],
+          "description": "Filter merge requests against their wip status"
+        },
+        "with_labels_details": {
+          "type": "boolean",
+          "description": "Return more details for each label"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_group_merge_requests",
+    "description": "List merge requests across all projects of a group and its subgroups. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "assignee_id": {
+          "type": "string",
+          "description": "Return MRs assigned to the given user ID (integer), 'none', or 'any'. Mutually exclusive with assignee_username."
+        },
+        "assignee_username": {
+          "type": "string",
+          "description": "Returns merge requests assigned to the given username. Mutually exclusive with assignee_id."
+        },
+        "author_id": {
+          "type": "string",
+          "description": "Returns merge requests created by the given user ID (integer). Mutually exclusive with author_username."
+        },
+        "author_username": {
+          "type": "string",
+          "description": "Returns merge requests created by the given username. Mutually exclusive with author_id."
+        },
+        "reviewer_id": {
+          "type": "string",
+          "description": "Returns merge requests which have the user as a reviewer. Must be an integer, 'none', or 'any'. Mutually exclusive with reviewer_username."
+        },
+        "reviewer_username": {
+          "type": "string",
+          "description": "Returns merge requests which have the user as a reviewer by username. Mutually exclusive with reviewer_id."
+        },
+        "approved_by_usernames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Returns merge requests approved by the given usernames (array)."
+        },
+        "created_after": {
+          "type": "string",
+          "description": "Return merge requests created after the given time"
+        },
+        "created_before": {
+          "type": "string",
+          "description": "Return merge requests created before the given time"
+        },
+        "updated_after": {
+          "type": "string",
+          "description": "Return merge requests updated after the given time"
+        },
+        "updated_before": {
+          "type": "string",
+          "description": "Return merge requests updated before the given time"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of label names"
+        },
+        "milestone": {
+          "type": "string",
+          "description": "Milestone title"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "created_by_me",
+            "assigned_to_me",
+            "all"
+          ],
+          "description": "Return merge requests from a specific scope"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search for specific terms"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "opened",
+            "closed",
+            "locked",
+            "merged",
+            "all"
+          ],
+          "description": "Return merge requests with a specific state"
+        },
+        "order_by": {
+          "type": "string",
+          "enum": [
+            "created_at",
+            "updated_at",
+            "priority",
+            "label_priority",
+            "milestone_due",
+            "popularity"
+          ],
+          "description": "Return merge requests ordered by the given field"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Return merge requests sorted in ascending or descending order"
+        },
+        "target_branch": {
+          "type": "string",
+          "description": "Return merge requests targeting a specific branch"
+        },
+        "source_branch": {
+          "type": "string",
+          "description": "Return merge requests from a specific source branch"
+        },
+        "wip": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no"
+          ],
+          "description": "Filter merge requests against their wip status"
+        },
+        "with_labels_details": {
+          "type": "boolean",
+          "description": "Return more details for each label"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        },
+        "group_id": {
+          "type": "string",
+          "description": "Group ID or URL-encoded path"
+        },
+        "non_archived": {
+          "type": "boolean",
+          "description": "Return merge requests from non-archived projects only. Defaults to true."
+        },
+        "source_project_id": {
+          "type": "string",
+          "description": "Return merge requests with the given source project ID"
+        }
+      },
+      "required": [
+        "group_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_users",
+    "description": "Get GitLab user details by usernames. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "usernames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of usernames to search for"
+        }
+      },
+      "required": [
+        "usernames"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_user",
+    "description": "Get user details by ID. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "string",
+          "description": "The ID of the user"
+        }
+      },
+      "required": [
+        "user_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "whoami",
+    "description": "Get current authenticated user details. Use this to identify the authenticated GitLab user; use `get_user` or `get_users` when looking up another user. It is read-only and returns the current user profile, while missing credentials or GitLab permission failures are reported as errors.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_commits",
+    "description": "List repository commits with filtering options. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "ref_name": {
+          "type": "string",
+          "description": "The name of a repository branch, tag or revision range, or if not given the default branch"
+        },
+        "since": {
+          "type": "string",
+          "description": "Only commits after or on this date are returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ"
+        },
+        "until": {
+          "type": "string",
+          "description": "Only commits before or on this date are returned in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ"
+        },
+        "path": {
+          "type": "string",
+          "description": "The file path"
+        },
+        "author": {
+          "type": "string",
+          "description": "Search commits by commit author"
+        },
+        "all": {
+          "type": "boolean",
+          "description": "Retrieve every commit from the repository"
+        },
+        "with_stats": {
+          "type": "boolean",
+          "description": "Stats about each commit are added to the response"
+        },
+        "first_parent": {
+          "type": "boolean",
+          "description": "Follow only the first parent commit upon seeing a merge commit"
+        },
+        "order": {
+          "type": "string",
+          "enum": [
+            "default",
+            "topo"
+          ],
+          "description": "List commits in order"
+        },
+        "trailers": {
+          "type": "boolean",
+          "description": "Parse and include Git trailers for every commit"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_commit",
+    "description": "Get details of a specific commit. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "sha": {
+          "type": "string",
+          "description": "The commit hash or name of a repository branch or tag"
+        },
+        "stats": {
+          "type": "boolean",
+          "description": "Include commit stats"
+        }
+      },
+      "required": [
+        "sha",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_commit_diff",
+    "description": "Get changes/diffs of a specific commit. Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "sha": {
+          "type": "string",
+          "description": "The commit hash or name of a repository branch or tag"
+        },
+        "full_diff": {
+          "type": "boolean",
+          "description": "Whether to return the full diff or only first page (default: false)"
+        }
+      },
+      "required": [
+        "sha",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_file_blame",
+    "description": "Get git blame for a file at a given ref. Each entry maps a contiguous range of source lines to the commit that last changed them (id, author, authored_date, message). Use range_start/range_end to limit blame to specific lines.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "file_path": {
+          "type": "string",
+          "description": "The full path of the file to blame, relative to repo root"
+        },
+        "ref": {
+          "type": "string",
+          "description": "The name of branch, tag or commit (required by GitLab blame API)"
+        },
+        "range_start": {
+          "type": "integer",
+          "description": "First line of the blame range (inclusive, 1-based). Both range[start] and range[end] must be set together."
+        },
+        "range_end": {
+          "type": "integer",
+          "description": "Last line of the blame range (inclusive, 1-based). Both range[start] and range[end] must be set together."
+        }
+      },
+      "required": [
+        "file_path",
+        "ref"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_commit_statuses",
+    "description": "List statuses for a commit. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "sha": {
+          "type": "string",
+          "description": "The commit hash or name of a repository branch or tag"
+        },
+        "ref": {
+          "type": "string",
+          "description": "Filter statuses by Git ref"
+        },
+        "stage": {
+          "type": "string",
+          "description": "Filter statuses by build stage"
+        },
+        "name": {
+          "type": "string",
+          "description": "Filter statuses by status name or context"
+        },
+        "pipeline_id": {
+          "type": "number",
+          "description": "Filter statuses by pipeline ID"
+        },
+        "order_by": {
+          "type": "string",
+          "enum": [
+            "id",
+            "pipeline_id"
+          ],
+          "description": "Field to order statuses by"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Sort direction"
+        },
+        "all": {
+          "type": "boolean",
+          "description": "Return all statuses, not only latest ones"
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "sha",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "create_commit_status",
+    "description": "Create or update the status of a commit. Use this for a new resource or action; choose the corresponding update or edit tool when the resource already exists. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or complete URL-encoded path to project"
+        },
+        "sha": {
+          "type": "string",
+          "description": "The commit hash to set the status on"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "success",
+            "failed",
+            "canceled",
+            "skipped"
+          ],
+          "description": "Commit status state"
+        },
+        "ref": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "The branch or tag ref"
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Status name. GitLab defaults to 'default' when omitted."
+        },
+        "context": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Alias for name. Provide either name or context, not both."
+        },
+        "target_url": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Target URL associated with this status"
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Short status description"
+        },
+        "coverage": {
+          "type": "number",
+          "description": "Total code coverage for this status"
+        },
+        "pipeline_id": {
+          "type": "number",
+          "description": "Pipeline ID to attach the status to"
+        }
+      },
+      "required": [
+        "sha",
+        "state",
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_group_iterations",
+    "description": "List group iterations with filtering options. Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "type": "string",
+          "description": "Group ID or URL-encoded path"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "opened",
+            "upcoming",
+            "current",
+            "closed",
+            "all"
+          ],
+          "description": "Return opened, upcoming, current, closed, or all iterations."
+        },
+        "search": {
+          "type": "string",
+          "description": "Return only iterations with a title matching the provided string."
+        },
+        "search_in": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "title",
+              "cadence_title"
+            ]
+          },
+          "description": "Fields in which fuzzy search should be performed with the query given in the argument search. The available options are title and cadence_title. Default is [title]."
+        },
+        "include_ancestors": {
+          "type": "boolean",
+          "description": "Include iterations for group and its ancestors. Defaults to true."
+        },
+        "include_descendants": {
+          "type": "boolean",
+          "description": "Include iterations for group and its descendants. Defaults to false."
+        },
+        "updated_before": {
+          "type": "string",
+          "description": "Return only iterations updated before the given datetime. Expected in ISO 8601 format (2019-03-15T08:00:00Z)."
+        },
+        "updated_after": {
+          "type": "string",
+          "description": "Return only iterations updated after the given datetime. Expected in ISO 8601 format (2019-03-15T08:00:00Z)."
+        },
+        "page": {
+          "type": "number",
+          "description": "Page number for pagination (default: 1)"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of items per page (max: 100, default: 20)"
+        }
+      },
+      "required": [
+        "group_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "upload_markdown",
+    "description": "Upload a file for use in markdown content. Use this for the specific operation described; choose a sibling tool when you need a different resource or lifecycle action. It changes remote GitLab state and requires the necessary project or group permission; GitLab returns validation, conflict, permission, or rate-limit errors instead of silently applying an invalid request. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path of the project"
+        },
+        "file_path": {
+          "type": "string",
+          "description": "Path to the file to upload"
+        }
+      },
+      "required": [
+        "project_id",
+        "file_path"
+      ]
+    },
+    "annotations": {
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "download_attachment",
+    "description": "Download an uploaded file from a project (images returned as base64; use local_path to save to disk). Use this to retrieve a previously uploaded project attachment; remote mode returns inline base64 for images or a download URL, while local mode can save to a path. It is read-only with respect to GitLab, requires project access, and returns the file content or an attachment/permission error.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path of the project"
+        },
+        "secret": {
+          "type": "string",
+          "description": "The 32-character secret of the upload"
+        },
+        "filename": {
+          "type": "string",
+          "description": "The filename of the upload"
+        },
+        "local_path": {
+          "type": "string",
+          "description": "Local path to save the file (optional, defaults to current directory)"
+        }
+      },
+      "required": [
+        "project_id",
+        "secret",
+        "filename"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "health_check",
+    "description": "Verify server status and authentication. When authenticated, also reports the GitLab instance version from GET /api/v4/version (version, revision, enterprise). Version lookup failures do not fail the health check \u2014 those fields are omitted. Use this to verify server connectivity and authentication before making GitLab requests; use `whoami` when the authenticated user's identity is the goal. It does not mutate GitLab state and returns server/authentication status plus GitLab version details when available.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "list_events",
+    "description": "List events for the authenticated user (before/after: YYYY-MM-DD). Use this for a collection of resources; choose the corresponding get tool when you already know the single resource to inspect. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "If defined, returns events with the specified action type"
+        },
+        "target_type": {
+          "type": "string",
+          "enum": [
+            "epic",
+            "issue",
+            "merge_request",
+            "milestone",
+            "note",
+            "project",
+            "snippet",
+            "user"
+          ],
+          "description": "If defined, returns events with the specified target type"
+        },
+        "before": {
+          "type": "string",
+          "description": "If defined, Returns events created before the specified date (YYYY-MM-DD format). To include events on 2025-08-29, use before=2025-08-30"
+        },
+        "after": {
+          "type": "string",
+          "description": "If defined, Returns events created after the specified date (YYYY-MM-DD format). To include events on 2025-08-29, use after=2025-08-28"
+        },
+        "scope": {
+          "type": "string",
+          "description": "Include all events across a user's projects"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Direction to sort the results by creation date. Default: desc"
+        },
+        "page": {
+          "type": "number",
+          "description": "Returns the specified results page. Default: 1"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of results per page. Default: 20"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "get_project_events",
+    "description": "List events for a project (before/after: YYYY-MM-DD). Use this for a known resource or result; choose the corresponding list or search tool when you need to discover multiple resources. It is read-only and does not mutate GitLab data; missing resources, invalid identifiers, insufficient permission, and rate limits are returned as errors. When `project_id` or `group_id` is accepted, provide the numeric ID or complete URL-encoded path described by the schema; use required identifiers and pagination fields exactly as documented.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string",
+          "description": "Project ID or URL-encoded path"
+        },
+        "action": {
+          "type": "string",
+          "description": "If defined, returns events with the specified action type"
+        },
+        "target_type": {
+          "type": "string",
+          "enum": [
+            "epic",
+            "issue",
+            "merge_request",
+            "milestone",
+            "note",
+            "project",
+            "snippet",
+            "user"
+          ],
+          "description": "If defined, returns events with the specified target type"
+        },
+        "before": {
+          "type": "string",
+          "description": "If defined, Returns events created before the specified date (YYYY-MM-DD format). To include events on 2025-08-29, use before=2025-08-30"
+        },
+        "after": {
+          "type": "string",
+          "description": "If defined, Returns events created after the specified date (YYYY-MM-DD format). To include events on 2025-08-29, use after=2025-08-28"
+        },
+        "sort": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "description": "Direction to sort the results by creation date. Default: desc"
+        },
+        "page": {
+          "type": "number",
+          "description": "Returns the specified results page. Default: 1"
+        },
+        "per_page": {
+          "type": "number",
+          "description": "Number of results per page. Default: 20"
+        }
+      },
+      "required": [
+        "project_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  },
+  {
+    "name": "discover_tools",
+    "description": "Discover and activate additional tool categories for this session. Available categories: merge_requests, issues, repositories, branches, projects, labels, ci, groups, pipelines, milestones, wiki, releases, tags, users, workitems, webhooks, search, variables, dependency_proxy, vulnerabilities. Already-active categories are listed in the response. Use this when a needed opt-in category is not currently exposed; omit `category` to inspect available categories, then call it with a category to activate that group for the current session. It changes only the session's tool registry, returns the active-tool summary, and does not change GitLab data.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Toolset category to activate (e.g. 'pipelines', 'wiki'). Omit to list available categories."
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "openWorldHint": true
+    }
+  }
+]


### PR DESCRIPTION
Adds `gitlab-mcp` (Docker-built `mcp/gitlab-mcp`) from https://github.com/zereight/gitlab-mcp.

Agent-workflow-optimized GitLab MCP server with 100+ tools for projects, merge requests, issues, pipelines, wiki, and releases, including 2-step batched MR review.

Verified locally:
- `task build -- --tools gitlab-mcp`: image built, 117 tools found
- `task catalog` + `docker mcp catalog import`: entry imports and enables
- Gateway `tools list` returns 117 tools; catalog reset afterwards

Note: existing `servers/gitlab` (archived upstream) left untouched; this is a separate entry.