### PR TITLE
Add Aggrete (MCP policy/security proxy)

### DIFF
--- a/servers/aggrete/server.yaml
+++ b/servers/aggrete/server.yaml
@@ -1,0 +1,18 @@
+name: aggrete
+image: mcp/aggrete
+type: server
+meta:
+  category: security
+  tags:
+    - security
+    - governance
+    - guardrails
+    - proxy
+about:
+  title: Aggrete
+  description: A policy proxy that governs what AI assistants can reach and do across MCP connectors. It enforces a code-of-conduct document with deterministic, deny-before-fetch rules and per-user cross-session memory, so forbidden combinations of data are refused before any upstream is contacted. Adds a prompt-injection egress shield, tool-integrity checks against rug-pulls and poisoned tool descriptions, inbound-secret blocking and output redaction, per-user rate limiting, on-behalf-of per-user credentials, and a tamper-evident hash-chained audit. No model in the decision path. This image is a self-contained demo with mock HR, finance, and ops connectors; start with the aggrete__scenarios and aggrete__check tools.
+  icon: https://www.google.com/s2/favicons?domain=aggrete.com&sz=64
+source:
+  project: https://github.com/Aggrete/aggrete
+  branch: docker-catalog
+  commit: 01664a8eef38256dfa2f6aaf05a459d9f9c5937f


### PR DESCRIPTION
Adds **Aggrete**, an open-source (Apache-2.0) MCP policy/security proxy, under the `security` category.

Aggrete sits in front of your MCP connectors and enforces a code-of-conduct document: deterministic, deny-before-fetch rules with per-user cross-session memory, so forbidden combinations of data are refused before any upstream is contacted. It also adds a prompt-injection egress shield, tool-integrity checks (rug-pull and poisoned-description detection), inbound-secret blocking and output redaction, per-user rate limiting, on-behalf-of per-user credentials, and a tamper-evident hash-chained audit. No model in the decision path.

- **Project:** https://github.com/Aggrete/aggrete (also on PyPI as `aggrete`, and in the official MCP Registry as `io.github.Aggrete/aggrete`)
- **Image:** built from the `docker-catalog` branch's self-contained Dockerfile, which bundles mock HR/finance/ops connectors so the server runs and lists tools with no configuration or secrets.
- **No credentials needed** to review: the demo image is fully self-contained. Start with the `aggrete__scenarios` and `aggrete__check` tools.

`task validate -- --name aggrete` passes locally, and the image builds and answers `tools/list` (13 tools) via stdio.