### PR TITLE
Add pdfops — inspect, fill, merge and invoice PDFs

### DIFF
--- a/servers/pdfops/server.yaml
+++ b/servers/pdfops/server.yaml
@@ -1,0 +1,24 @@
+name: pdfops
+image: mcp/pdfops
+type: server
+meta:
+  category: productivity
+  tags:
+    - pdf
+    - forms
+    - documents
+    - invoice
+about:
+  title: PDFops
+  description: Deterministic PDF tools for agents — inspect AcroForm fields, fill forms, merge PDFs, generate invoices, backed by the PDFops API (no Chromium). Inputs are https URLs or data URIs; outputs return inline.
+  icon: https://pdfops.dev/og/pdfops-mcp-400.png
+source:
+  project: https://github.com/pdfops/pdfops-mcp
+  branch: main
+  commit: f057a3ee968492830cce47d435b1eea3c7aa6930
+config:
+  description: Optional PDFops API key (free tier 250 requests/month at https://pdfops.dev/pricing). Leave empty for the keyless trial (100 requests/IP/month).
+  secrets:
+    - name: pdfops.api_key
+      env: PDFOPS_API_KEY
+      example: pdfops_live_xxxxxxxx


### PR DESCRIPTION
Adds **pdfops** (`servers/pdfops/server.yaml`), a stdio MCP server that gives agents deterministic PDF tools backed by the PDFops API: `pdf_inspect` (AcroForm fields + a paste-ready fill template), `pdf_fill` (optionally flatten), `pdf_merge`, `pdf_invoice` (byte-identical output for identical input) and `pdfops_usage`.

- Source: https://github.com/pdfops/pdfops-mcp (MIT) — Dockerfile at the repo root, multi-stage `node:22-alpine`, runs as `node`.
- Container mode is first-class: inputs accept `https://` URLs and `data:application/pdf;base64` URIs and results return inline as `application/pdf` resources, so the server is useful without any host filesystem access.
- Every tool carries MCP annotations (title, readOnlyHint, destructiveHint). Privacy policy: https://pdfops.dev/privacy.
- `PDFOPS_API_KEY` is optional (keyless trial: 100 requests/IP/month; free key: 250/month, no card), declared as a secret.
- Also published: npm `pdfops-mcp` 0.3.1 (OIDC provenance), official registry `dev.pdfops/pdfops-mcp`.

Built and verified locally: `docker build` from the repo root, then `tools/list` and a `pdf_inspect` call over stdio through `docker run -i` succeeded against https://pdfops.dev/flat-sample.pdf. No test credentials needed — the keyless path exercises every tool.