### PR TITLE
Add Xanther MCP server

### DIFF
--- a/servers/xanther/server.yaml
+++ b/servers/xanther/server.yaml
@@ -1,0 +1,45 @@
+name: xanther
+type: server
+meta:
+  category: devops
+  tags:
+    - code-intelligence
+    - knowledge-graph
+    - memory
+    - neo4j
+    - devops
+about:
+  title: Xanther
+  description: Code intelligence and agent memory. Indexes a codebase into a Neo4j knowledge graph and gives agents architecture context, semantic search, impact analysis, and cross-session recall.
+  icon: https://avatars.githubusercontent.com/u/182288589?s=200&v=4
+source:
+  project: https://github.com/Xanther-Ai/xanther-context-engine
+  branch: main
+  commit: 707d1cd1e3e3803487126833e72c62491769e4a5
+  dockerfile: Dockerfile.mcp
+config:
+  description: Configure the connection to Neo4j and (for semantic search / full-mode indexing) OpenRouter
+  secrets:
+    - name: xanther.neo4j_password
+      env: NEO4J_PASSWORD
+      example: your_neo4j_password
+    - name: xanther.openrouter_api_key
+      env: OPENROUTER_API_KEY
+      example: sk-or-v1-your-key-here
+  env:
+    - name: NEO4J_URI
+      example: bolt://localhost:7687
+      value: "{{xanther.neo4j_uri}}"
+    - name: NEO4J_USER
+      example: neo4j
+      value: "{{xanther.neo4j_user}}"
+  parameters:
+    type: object
+    properties:
+      neo4j_uri:
+        type: string
+      neo4j_user:
+        type: string
+    required:
+      - neo4j_uri
+      - neo4j_user

--- a/servers/xanther/server.yaml
+++ b/servers/xanther/server.yaml
@@ -15,7 +15,7 @@ about:
 source:
   project: https://github.com/Xanther-Ai/xanther-context-engine
   branch: main
-  commit: 707d1cd1e3e3803487126833e72c62491769e4a5
+  commit: b60c257cebf5bc60ec91a0eeb246502d6501fb85
   dockerfile: Dockerfile.mcp
 config:
   description: Configure the connection to Neo4j and (for semantic search / full-mode indexing) OpenRouter

--- a/servers/xanther/tools.json
+++ b/servers/xanther/tools.json
@@ -1,0 +1,97 @@
+[
+    {
+        "name": "xce_architecture_context",
+        "description": "Get architectural context for a file or symbol from the indexed knowledge graph.",
+        "arguments": [
+            {
+                "name": "file_or_symbol",
+                "type": "string",
+                "desc": "File path or symbol name to get architectural context for."
+            },
+            {
+                "name": "repo_id",
+                "type": "string",
+                "desc": "Repository identifier the repo was indexed under."
+            }
+        ]
+    },
+    {
+        "name": "xce_search",
+        "description": "Search the knowledge graph by semantic meaning, symbol, or tag.",
+        "arguments": [
+            {
+                "name": "query",
+                "type": "string",
+                "desc": "Natural-language or symbol search query."
+            },
+            {
+                "name": "repo_id",
+                "type": "string",
+                "desc": "Repository identifier the repo was indexed under."
+            },
+            {
+                "name": "search_type",
+                "type": "string",
+                "desc": "Type of search: semantic, symbol, or tag."
+            }
+        ]
+    },
+    {
+        "name": "xce_impact_analysis",
+        "description": "Predict the blast radius (callers, dependents, affected modules) for proposed code changes.",
+        "arguments": [
+            {
+                "name": "changed_files",
+                "type": "array",
+                "desc": "List of changed file paths to analyze."
+            },
+            {
+                "name": "repo_id",
+                "type": "string",
+                "desc": "Repository identifier the repo was indexed under."
+            }
+        ]
+    },
+    {
+        "name": "xce_trace",
+        "description": "Trace relationships between code and design artifacts across abstraction levels (code, component, architecture).",
+        "arguments": [
+            {
+                "name": "source",
+                "type": "string",
+                "desc": "Source code symbol or file to trace from."
+            },
+            {
+                "name": "target_level",
+                "type": "string",
+                "desc": "Target abstraction level: code, component, or architecture."
+            },
+            {
+                "name": "repo_id",
+                "type": "string",
+                "desc": "Repository identifier the repo was indexed under."
+            }
+        ]
+    },
+    {
+        "name": "xce_index_repo",
+        "description": "Index or re-index a code repository into the knowledge graph.",
+        "arguments": [
+            {
+                "name": "repo_path",
+                "type": "string",
+                "desc": "Path to the repository to index."
+            },
+            {
+                "name": "repo_id",
+                "type": "string",
+                "desc": "Repository identifier to index the repo under."
+            },
+            {
+                "name": "incremental",
+                "type": "boolean",
+                "desc": "Only re-index changed files (default true)."
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** xanther
**Repository URL:** https://github.com/Xanther-Ai/xanther-context-engine
**Brief Description:** Xanther is an open-source code intelligence + agent memory engine. It indexes a codebase into a Neo4j knowledge graph (AST → summaries → docs → architecture) and exposes MCP tools for architecture context, semantic search, impact analysis, and cross-abstraction tracing, plus cross-session recall of code facts and past agent sessions.

**Disclosure:** I maintain this project.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements the MCP spec (stdio server via `xce serve`)
- [x] **Active Development**: Actively maintained
- [x] **Docker Artifact**: `Dockerfile.mcp` (dedicated stdio MCP image) — referenced via `source.dockerfile`
- [x] **Documentation**: README with setup instructions
- [x] **Security Contact**: GitHub Issues / security contact in repo

## Details

- **Type:** local (containerized, stdio)
- **Image:** built by Docker from `Dockerfile.mcp` (no pre-published image; installs `xanther-xce[all]` and runs `xce serve`)
- **Config:** Neo4j connection (`NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`) and `OPENROUTER_API_KEY` for semantic search / full-mode indexing.
- A `tools.json` is included listing the five core XCE tools, so `task build --tools` does not need to run the server (which requires a reachable Neo4j).

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review
- [ ] I have tested the MCP Server using `task validate -- --name xanther` — *note: could not run locally (Go/Task not available in my environment); `server.yaml` and `tools.json` were validated for schema/JSON/YAML correctness. Happy to address any CI findings.*
- [ ] I have built the MCP Server using `task build -- --tools xanther` — *uses the included `tools.json` to avoid needing a live Neo4j at build time.*
- [ ] If the server requires credentials to test it, I have shared test credentials using the form — *Xanther needs a reachable Neo4j (and OpenRouter key for semantic search); I will submit test credentials via https://forms.gle/6Lw3nsvu2d6nFg8e6.*