### PR TITLE
Add sigtap-agent-tools remote MCP server

### DIFF
--- a/servers/sigtap-agent-tools/readme.md
+++ b/servers/sigtap-agent-tools/readme.md
@@ -1,0 +1,5 @@
+Docs: https://github.com/unnamedaiagent/sigtap-agent-tools
+
+13 paid micro-tools for AI agents over x402 (USDC on Base) - one payment
+header per call, no API keys. Free catalog tool and free preview routes at
+https://sigtap-outreach-api.sigtap.workers.dev/

--- a/servers/sigtap-agent-tools/server.yaml
+++ b/servers/sigtap-agent-tools/server.yaml
@@ -1,0 +1,20 @@
+name: sigtap-agent-tools
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: ai
+  tags:
+    - ai
+    - tools
+    - payments
+    - x402
+    - crypto
+    - remote
+about:
+  title: Sigtap Agent Tools
+  description: 13 paid micro-tools for AI agents over x402 (USDC on Base) - one payment header per call, no API keys. Cold-email grading and deliverability audits, hashing/JWT/JSON/regex/UUID/slugify utilities, crypto prices, domain age and weather. The free catalog tool lists live prices and free preview routes for every paid tool.
+  icon: https://www.google.com/s2/favicons?domain=github.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://sigtap-mcp.sigtap.workers.dev/mcp


### PR DESCRIPTION
## MCP Server Information

**Server Name:** sigtap-agent-tools
**Type:** Remote (hosted) - `streamable-http` at `https://sigtap-mcp.sigtap.workers.dev/mcp`
**Source Repository:** https://github.com/unnamedaiagent/sigtap-agent-tools (MIT)
**Brief Description:** 13 paid micro-tools for AI agents over x402 (USDC on Base) - one payment header per call, no API keys and no accounts. Cold-email grading and deliverability audits, hashing/JWT/JSON/regex/UUID/slugify utilities, crypto prices, domain age and weather. A free `catalog` tool lists every paid tool with live prices and its free preview route, so an agent can verify output shapes before any payment. Unpaid calls to paid tools return an HTTP 402 challenge (x402 v2) describing the USDC/Base payment terms; settlement is on-chain on Base mainnet.

## Basic Requirements

- [x] **Open Source**: MIT, LICENSE at the repository root.
- [x] **MCP Compliant**: Streamable HTTP transport; `initialize` + `tools/list` return a live catalog of 13 tools (verified at submission time).
- [x] **Active Development**: pushed 2026-09-06; hosted API and MCP endpoints actively maintained.
- [x] **Docker Artifact**: not applicable - `type: remote`; `task build --tools sigtap-agent-tools` reports "Build skipped for remote server" by design.
- [x] **Documentation**: README with setup instructions for Claude Desktop / Claude Code / Cursor and direct HTTP, plus hosted `openapi.json` and `llms.txt` discovery docs on the API origin.
- [x] **Security Contact**: SECURITY.md (GitHub private vulnerability reporting + email).

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name sigtap-agent-tools` - all 12 checks pass (run locally with Go 1.23.4).
- [x] I have built the MCP Server using `task build -- --tools sigtap-agent-tools` - skipped for remote servers.
- [x] If the server requires credentials to test it - it does not: the `catalog` tool and free preview routes work with no credentials and no payment; paid tools settle per call via x402.
