### PR TITLE
Add obsidian-tc

### DIFF
--- a/servers/obsidian-tc/server.yaml
+++ b/servers/obsidian-tc/server.yaml
@@ -1,0 +1,45 @@
+name: obsidian-tc
+image: mcp/obsidian-tc
+type: server
+meta:
+  category: productivity
+  tags:
+    - obsidian
+    - productivity
+    - notes
+    - knowledge-management
+    - pkm
+    - search
+about:
+  title: Obsidian Turbocharged
+  description: Governed, agent-ready MCP server for Obsidian vaults. Three meta-tools expose ~163 governed capabilities across 31 domains (notes, links, search, metadata, structured documents, automation, git, knowledge graph) behind folder ACLs and human-in-the-loop confirmation, with fused BM25 + vector + graph retrieval. Multi-vault native; embeddings are pluggable (local Ollama by default).
+  icon: https://avatars.githubusercontent.com/u/278549586?s=200&v=4
+source:
+  project: https://github.com/The-40-Thieves/obsidian-tc
+  branch: main
+  commit: ce92265e865ab9ce839f428d34714ebe858f0e37
+run:
+  command:
+    - "{{obsidian-tc.vault_path|volume-target|into}}"
+  volumes:
+    - "{{obsidian-tc.vault_path|volume|into}}"
+config:
+  description: >-
+    Mount the vault folder you want obsidian-tc to serve. This boots the zero-config path
+    documented in the project README (`obsidian-tc /path/to/vault`): a single vault named `main`,
+    auth off, no folder ACL — full read/write/delete over the mounted vault, which the project
+    documents as an accepted local-only posture. Multi-vault setups, folder ACLs, HITL
+    confirmation, and non-default embedding providers all need a JSON config file passed via
+    OBSIDIAN_TC_CONFIG instead of a vault path; this catalog entry does not cover that path — see
+    the deviation note in the pull request that added this entry.
+  parameters:
+    type: object
+    properties:
+      vault_path:
+        type: array
+        items:
+          type: string
+        default:
+          - /Users/local-test/vault
+    required:
+      - vault_path

--- a/servers/obsidian-tc/tools.json
+++ b/servers/obsidian-tc/tools.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "find_capability",
+    "description": "BM25 search over the caller-visible capability catalog (e.g. \"how do I move a note?\"), returning the matching tool names ranked by relevance.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Natural-language description of the capability to find."
+      }
+    ]
+  },
+  {
+    "name": "describe_capability",
+    "description": "Returns one capability's input schema, required scopes, and safety hints.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The capability (tool) name to describe, as returned by find_capability."
+      }
+    ]
+  },
+  {
+    "name": "call_capability",
+    "description": "Invokes the named capability. The call routes through the same auth, scope, folder-ACL, human-in-the-loop, idempotency, and throttle pipeline as a direct call, and the target's own schema validates the arguments.",
+    "arguments": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": "The capability (tool) name to invoke, as returned by find_capability."
+      },
+      {
+        "name": "arguments",
+        "type": "object",
+        "desc": "Arguments for the named capability, validated against that capability's own schema."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** obsidian-tc
**Repository URL:** https://github.com/The-40-Thieves/obsidian-tc
**Brief Description:** Governed, agent-ready MCP server for Obsidian vaults. Three meta-tools (`find_capability`, `describe_capability`, `call_capability`) expose ~163 governed capabilities across 31 domains — notes, links, search, metadata, structured documents, automation, git, knowledge graph — behind folder ACLs and human-in-the-loop confirmation, with fused BM25 + vector + graph retrieval. Multi-vault native; embeddings pluggable (local Ollama by default).

## Basic Requirements

- [ ] **Open Source**: License is AGPL-3.0-only. `task validate` fails on this (see below) because this registry treats `gpl*`/`agpl*`/`npl*` as not "acceptable" per the license allowlist in `internal/licenses/check.go`. I'm opening this submission anyway per the repository owner's request and flagging the conflict here rather than working around it — happy to close this out if AGPL-3.0-only is a hard no for this catalog.
- [x] **MCP Compliant**: Implements MCP API specification (stdio transport; JSON-RPC tool listing confirmed by `task build --tools obsidian-tc` below)
- [x] **Active Development**: Latest commit on `main` (`ce92265e`) is from 2026-09-06; v1.28.4 is the current npm/container release
- [x] **Docker Artifact**: Root `Dockerfile` builds `packages/server/dist` in a multi-stage build on `oven/bun:1-slim` and runs it as the unprivileged `bun` user
- [x] **Documentation**: `README.md` documents the tool surface, quick start, Docker Compose usage, and configuration; `docs/QUICKSTART.md` covers the full multi-vault/ACL setup
- [x] **Security Contact**: `SECURITY.md` at the repo root documents a security contact and a companion-plugin trust boundary section

## Submitter Checklist

- [x] This server meets the basic requirements listed above, **except the license**, which I've flagged rather than hidden (see above)
- [x] I understand this will undergo automated and manual review
- [ ] I have tested the MCP Server using `task validate -- --name obsidian-tc`
  - 7 of the checks this repo's `validate` command runs pass: name, directory, title, YAML formatting, commit pin, secrets, config env. It then hard-fails on the license check before reaching icon/OAuth checks:
    ```
    ✅ Name is valid
    ✅ Directory is valid
    ✅ Title is valid
    ✅ YAML formatting is valid
    ✅ Commit is pinned
    ✅ Secrets are valid
    ✅ Config env is valid
    2026/09/06 20:41:47 project https://github.com/The-40-Thieves/obsidian-tc is licensed under GNU Affero General Public License v3.0 which may be incompatible with some tools
    exit status 1
    ```
- [x] I have built the MCP Server using `task build -- --tools obsidian-tc`
  - Image builds cleanly from the pinned commit and lists all 3 tools via a `tools.json` fallback (see "Deviations from the usual submission" below): `find_capability`, `describe_capability`, `call_capability`.
- [ ] If the server requires credentials to test it, I have shared test credentials using the linked form
  - Not applicable: no credentials are required. The only required input is a vault folder to mount (a local directory, not a secret).

## Deviations from the alexandria-style submission, and why

1. **License.** obsidian-tc is AGPL-3.0-only, not MIT/Apache-2.0 like this org's other submission. I'm not trying to argue the registry into accepting it — I'm submitting transparently with the failing `task validate` output attached above so a maintainer (or the repo owner, if this needs to go back to them) can make the call.
2. **`tools.json` fallback.** obsidian-tc's entrypoint needs a real vault directory or config file to boot — `task build --tools obsidian-tc` without one just runs the container with the unresolved `{{obsidian-tc.vault_path|volume-target|into}}` template string as an argument and gets `no such vault folder or config file` (then prints help, exit 1). Per CONTRIBUTING.md's "Avoiding `build --tools` failures" section, I added `servers/obsidian-tc/tools.json` listing the 3 default meta-tools instead, which lets `task build --tools` succeed by reading the file instead of spawning the container. Verified output: `3 tools found.` / `✅ Image built as mcp/obsidian-tc`.
3. **Config schema only covers zero-config, single-vault mode.** The project's real Docker story (see its own `docker-compose.yml`) is: mount the vault directory, and separately mount a *directory* holding an `obsidian-tc.config.json` (never a single file — the project deliberately avoids bind-mounting one file because a file bind pins the host inode and would serve a stale config after edits), then point `OBSIDIAN_TC_CONFIG` at the file inside that mounted directory. That's how multi-vault, folder ACLs, HITL, and non-default embedding providers get configured. This catalog's `config.parameters` + `run.volumes`/`run.command` templating (`{{ns.field|volume|into}}` / `{{ns.field|volume-target|into}}`) cleanly expresses one directory-to-argv binding — which is exactly what the servers/filesystem, servers/git, and servers/markitdown entries already do — but I did not find a way to also template a *second* mounted directory's resolved path into `config.env`'s `value` field (that field's few existing examples, e.g. alexandria's `ALEXANDRIA_BASE_URL`, only substitute plain string parameters, not the volume-target pipeline), and guessing at an unsupported combination felt worse than being explicit about the gap. So this entry only exposes obsidian-tc's zero-config single-vault mode: mount a vault folder, and the server boots with auth off and no folder ACL over that vault — a posture the project's own README documents as an accepted local-only default (it fails closed if you point a non-loopback HTTP transport at it). Multi-vault/ACL setups aren't reachable from this catalog entry as written; they need the config-file path documented in the upstream README, run outside this catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A52DVwwKYFY95cqxErKu9j
