### PR TITLE
Add marketplaces-mcp-ru (Wildberries, Ozon, Yandex Market & Avito Seller APIs)

### DIFF
--- a/servers/marketplaces-mcp-ru/server.yaml
+++ b/servers/marketplaces-mcp-ru/server.yaml
@@ -1,0 +1,47 @@
+name: marketplaces-mcp-ru
+image: ghcr.io/ilyautov/marketplaces-mcp-ru
+type: server
+meta:
+  category: ecommerce
+  tags:
+    - ecommerce
+    - wildberries
+    - ozon
+    - marketplace
+    - seller-api
+    - russia
+about:
+  title: Wildberries & Ozon Seller APIs
+  description: Connects an assistant to a seller's Wildberries and Ozon accounts (the two largest Russian marketplaces) through their official Seller APIs — sales, stocks, prices, finance, reviews, ads. 793 schema-driven methods behind generic search / describe / call tools plus typed convenience tools and step-by-step seller workflows (reorder planner, ABC analysis, reviews pulse). Every method is classified read / write / destructive; writes require an explicit confirmation flag before anything changes in the store. Set only the keys for the marketplaces you sell on.
+  icon: https://raw.githubusercontent.com/ilyautov/marketplaces-mcp-ru/main/assets/logo-400.png
+source:
+  project: https://github.com/ilyautov/marketplaces-mcp-ru
+  commit: 037fcb31d9290ab35ec4aea3a30bc7dc6a1a8f69
+config:
+  description: Seller API keys — set only the marketplaces you sell on
+  secrets:
+    - name: marketplaces-mcp-ru.wb_api_token
+      env: WB_API_TOKEN
+      example: eyJhbGciOi...
+    - name: marketplaces-mcp-ru.ozon_api_key
+      env: OZON_API_KEY
+      example: 12345678-90ab-cdef-1234-567890abcdef
+    - name: marketplaces-mcp-ru.ozon_perf_client_secret
+      env: OZON_PERF_CLIENT_SECRET
+      example: your-performance-api-secret
+  env:
+    - name: OZON_CLIENT_ID
+      example: "1234567"
+      value: "{{marketplaces-mcp-ru.ozon_client_id}}"
+    - name: OZON_PERF_CLIENT_ID
+      example: "1234567-1234567890"
+      value: "{{marketplaces-mcp-ru.ozon_perf_client_id}}"
+  parameters:
+    type: object
+    properties:
+      ozon_client_id:
+        type: string
+        description: Ozon Seller Client-Id (seller.ozon.ru → Settings → API keys). Leave empty if you do not sell on Ozon.
+      ozon_perf_client_id:
+        type: string
+        description: Ozon Performance (ads) API Client-Id. Optional.

--- a/servers/marketplaces-mcp-ru/server.yaml
+++ b/servers/marketplaces-mcp-ru/server.yaml
@@ -18,7 +18,7 @@ about:
   icon: https://raw.githubusercontent.com/ilyautov/marketplaces-mcp-ru/main/assets/logo-400.png
 source:
   project: https://github.com/ilyautov/marketplaces-mcp-ru
-  commit: ef9ffb2640b1fee6df5737efb2e3a42e01a56d4e
+  commit: 2b4214f31e7285594e9dca918c3593cdc05ffd45
 config:
   description: Seller API keys — set only the marketplaces you sell on
   secrets:

--- a/servers/marketplaces-mcp-ru/server.yaml
+++ b/servers/marketplaces-mcp-ru/server.yaml
@@ -9,14 +9,16 @@ meta:
     - ozon
     - marketplace
     - seller-api
+    - yandex-market
+    - avito
     - russia
 about:
-  title: Wildberries & Ozon Seller APIs
-  description: Connects an assistant to a seller's Wildberries and Ozon accounts (the two largest Russian marketplaces) through their official Seller APIs — sales, stocks, prices, finance, reviews, ads. 793 schema-driven methods behind generic search / describe / call tools plus typed convenience tools and step-by-step seller workflows (reorder planner, ABC analysis, reviews pulse). Every method is classified read / write / destructive; writes require an explicit confirmation flag before anything changes in the store. Set only the keys for the marketplaces you sell on.
+  title: Wildberries, Ozon, Yandex Market & Avito Seller APIs
+  description: Connects an assistant to a seller's Wildberries, Ozon, Yandex Market and Avito accounts (the largest Russian marketplaces) through their official APIs — sales, orders, stocks, prices, finance, reviews, chats, ads. 1022 schema-driven methods behind generic search / describe / call tools plus typed convenience tools and step-by-step seller workflows (reorder planner, ABC analysis, reviews pulse). Every method is classified read / write / destructive; writes require an explicit confirmation flag before anything changes in the store. Set only the keys for the marketplaces you sell on.
   icon: https://raw.githubusercontent.com/ilyautov/marketplaces-mcp-ru/main/assets/logo-400.png
 source:
   project: https://github.com/ilyautov/marketplaces-mcp-ru
-  commit: 037fcb31d9290ab35ec4aea3a30bc7dc6a1a8f69
+  commit: ef9ffb2640b1fee6df5737efb2e3a42e01a56d4e
 config:
   description: Seller API keys — set only the marketplaces you sell on
   secrets:
@@ -29,6 +31,12 @@ config:
     - name: marketplaces-mcp-ru.ozon_perf_client_secret
       env: OZON_PERF_CLIENT_SECRET
       example: your-performance-api-secret
+    - name: marketplaces-mcp-ru.yandex_market_api_key
+      env: YANDEX_MARKET_API_KEY
+      example: ACMA:your-yandex-market-api-key
+    - name: marketplaces-mcp-ru.avito_client_secret
+      env: AVITO_CLIENT_SECRET
+      example: your-avito-client-secret
   env:
     - name: OZON_CLIENT_ID
       example: "1234567"
@@ -36,6 +44,9 @@ config:
     - name: OZON_PERF_CLIENT_ID
       example: "1234567-1234567890"
       value: "{{marketplaces-mcp-ru.ozon_perf_client_id}}"
+    - name: AVITO_CLIENT_ID
+      example: "abcdef1234567890"
+      value: "{{marketplaces-mcp-ru.avito_client_id}}"
   parameters:
     type: object
     properties:
@@ -45,3 +56,6 @@ config:
       ozon_perf_client_id:
         type: string
         description: Ozon Performance (ads) API Client-Id. Optional.
+      avito_client_id:
+        type: string
+        description: Avito API client_id (avito.ru → For business → Integrations → API). Leave empty if you do not sell on Avito.


### PR DESCRIPTION
## MCP Server Information

**Server Name:** marketplaces-mcp-ru
**Repository URL:** https://github.com/ilyautov/marketplaces-mcp-ru
**Brief Description:** Connects an assistant to a seller's Wildberries, Ozon, Yandex Market and Avito accounts (the largest Russian marketplaces) through their official Seller APIs — sales, orders, stocks, prices, finance, reviews, chats, ads. 1022 schema-driven methods behind generic search / describe / call tools, plus typed convenience tools and step-by-step seller workflows; every write is gated behind an explicit confirmation flag. Ships its own image: `ghcr.io/ilyautov/marketplaces-mcp-ru` (also the OCI package listed in the official MCP Registry as `io.github.ilyautov/marketplaces-mcp-ru`).

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: Python `mcp` SDK (FastMCP), stdio; Streamable HTTP optional
- [x] **Active Development**: v0.5.2 released 2026-09-07, CI on Linux / macOS / Windows
- [x] **Docker Artifact**: `Dockerfile` at the repo root; image published to GHCR on every tag, carries the `io.modelcontextprotocol.server.name` label
- [x] **Documentation**: README (RU + EN), QUICKSTART, `llms-install.md`
- [x] **Security Contact**: `SECURITY.md` in the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name marketplaces-mcp-ru` (all checks green)
- [ ] I have built the MCP Server using `task build -- --tools SERVER_NAME` — not run: the entry uses our own published image (`image: ghcr.io/ilyautov/marketplaces-mcp-ru`). The image lists all 106 tools without any credentials configured (`docker run --rm --entrypoint python ghcr.io/ilyautov/marketplaces-mcp-ru -c 'import asyncio; from core.combined import build; print(len(asyncio.run(build().list_tools())))'` → 106), so tool discovery does not need secrets.
- [x] Test credentials: not needed for tool listing. Actual API calls need a seller's own Wildberries / Ozon / Yandex Market / Avito keys, which are per-store and cannot be shared; `docker run --rm ghcr.io/ilyautov/marketplaces-mcp-ru doctor` shows what is configured without printing secrets.

---

**Updated 2026-09-10.** The PR was opened against 0.5.0 and the description had fallen behind the entry it ships. Corrected: 1022 methods (not 793), 106 tools (not 58), four marketplaces (Yandex Market and Avito were already in `server.yaml` and its tags, only this text was stale), v0.5.2. The pinned commit now points at the v0.5.2 release commit `2b4214f` instead of the 0.5.0 commit; no Python code changed between them, so the tool count holds for both.
