### PR TITLE
Add OrcaReplay MCP server

### DIFF
--- a/servers/orcareplay/server.yaml
+++ b/servers/orcareplay/server.yaml
@@ -1,0 +1,29 @@
+name: orcareplay
+image: mcp/orcareplay
+type: server
+meta:
+  category: developer-tools
+  tags:
+    - debugging
+    - observability
+    - coding-agents
+about:
+  title: OrcaReplay
+  description: Read recorded coding-agent runs — what was sent, run and changed — and replay or fork them.
+  icon: https://avatars.githubusercontent.com/u/234866093?v=4
+source:
+  project: https://github.com/Continuum-AI-Corp/OrcaReplay
+  branch: main
+  commit: 057a708af93e400665a9ce062b3c1869181c384a
+run:
+  volumes:
+    - '{{orcareplay.runs_path}}:/work/.orca:ro'
+config:
+  - name: orcareplay
+    description: Where OrcaReplay keeps its recordings
+    type: object
+    parameters:
+      - name: runs_path
+        type: string
+        description: Host path to the .orca directory written by 'orca record' (usually PROJECT/.orca)
+        required: true


### PR DESCRIPTION
Adds `servers/orcareplay/server.yaml`.

**What the server does.** OrcaReplay records a coding-agent run below the harness — at the process and socket boundary — so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP JSON-RPC calls all land on one timeline. This MCP server exposes those recordings: `orca_list_runs`, `orca_show_run`, `orca_checkpoints`, `orca_graph`, `orca_replay`, `orca_compare`.

**License:** Apache-2.0 — consumable per your requirement.

**Two things I want to be straight about rather than have CI find them:**

1. **I could not run `task create` locally.** There is no Docker on the machine I prepared this from, so the image has not been built or tool-listed here. I wrote `server.yaml` by hand against the schema and the existing entries. If your CI's build-and-list check fails, tell me what it reports and I will fix it — I am not asking you to take the manifest on trust.

2. **The container ships only the read side, deliberately.** Recording wraps a host process (local proxy, PATH shim, shadow git index), and none of that crosses a container boundary — `orca record` inside the image would watch an empty namespace. What travels is reading recordings that already exist, so the entry mounts the user's `.orca` directory. I mounted it `:ro` because `orca_replay` and `orca_compare` run a real agent and can spend money; a container that only reads is the honest default.

**Verified against the published package** (`orcareplay@0.2.2`, npm, 12 packages with sigstore provenance): protocol `2025-06-18`, `initialize` and `tools/list` both answer, six tools returned. Also published to the official MCP Registry as `io.github.Continuum-AI-Corp/orcareplay`.

The Dockerfile referenced by `source.commit` was added for this submission and pins the exact npm version rather than `latest`, so the image cannot silently change what it runs.

Worth stating plainly: the repository is nine days old with ~168 stars.
