### PR TITLE
Add Agent Chef MCP server

### DIFF
--- a/servers/agent-chef/server.yaml
+++ b/servers/agent-chef/server.yaml
@@ -1,0 +1,26 @@
+name: agent-chef
+image: mcp/agent-chef
+type: server
+meta:
+  category: productivity
+  tags:
+    - productivity
+    - meal-planning
+    - recipes
+    - grocery
+    - family
+    - food
+about:
+  title: Agent Chef
+  description: Family meal planning run by your own AI agent. Each week the agent proposes ten dinners, household members vote and leave feedback from personal links (no accounts), the top three win, and Agent Chef builds a grocery list minus what is already in the pantry. Ratings after dinner feed next week's proposals. 34 tools with annotations and output schemas; the agent never places orders, a human approves checkout. Say "Run Agent Chef."
+  icon: https://agentchef.net/static/icon-256.png
+source:
+  project: https://github.com/coryshaw/agent-chef-mcp
+  branch: main
+  commit: 82bd7248c4351854afe420462e3985843afcbf6a
+config:
+  description: Connect to your Agent Chef household. Create a key at https://agentchef.net/app/settings/agents (free trial, no card). Without a key the server lists its tools but cannot act on a household.
+  secrets:
+    - name: agent-chef.api_key
+      env: AGENT_CHEF_API_KEY
+      example: ac_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
## MCP Server Information

**Server Name:** agent-chef
**Repository URL:** https://github.com/coryshaw/agent-chef-mcp
**Brief Description:** Family meal planning run by the user's own AI agent. Each week the agent proposes ten dinners, household members vote and leave feedback from personal links (no accounts), the top three win, and Agent Chef builds a grocery list minus what is already in the pantry. Ratings after dinner feed the next week. 34 tools, all with `title`, annotations and `outputSchema`. The server never places orders; a human approves checkout.

The repository is a stdio MCP server (Node 20+, `@modelcontextprotocol/sdk`). It ships the tool catalog, so `initialize`, `tools/list` and `prompts/list` work offline; tool calls are executed by the hosted Agent Chef service (https://agentchef.net/mcp) for the household identified by `AGENT_CHEF_API_KEY`. Also published on npm as `agent-chef-mcp`, listed in the Official MCP Registry as `net.agentchef/agent-chef`, and rated B on Glama.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: Implements MCP API specification (tools, prompts, annotations, output schemas)
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile at repository root
- [x] **Documentation**: README with setup for OAuth, API key, npx and Docker
- [x] **Security Contact**: support@agentchef.net, https://agentchef.net/.well-known/security.txt

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] Tested: built the Dockerfile at the pinned commit and verified `initialize` + `tools/list` (34 tools) over stdio with a placeholder key. (`task validate`/`task build` were not run locally; relying on CI.)
- [x] Credentials: without a key the server starts and lists tools; a reviewer API key will be shared via the test-credentials form.