### PR TITLE
Add total-agent-memory MCP server

### DIFF
--- a/servers/total-agent-memory/server.yaml
+++ b/servers/total-agent-memory/server.yaml
@@ -1,0 +1,36 @@
+name: total-agent-memory
+image: mcp/total-agent-memory
+type: server
+meta:
+  category: ai
+  tags:
+    - agent-memory
+    - ai-memory
+    - claude-code
+    - claude-code-mcp
+    - claude-code-plugin
+    - claude-memory
+    - codex-cli
+    - developer-tools
+    - knowledge-graph
+    - knowledge-management
+    - llm-tools
+    - model-context-protocol
+    - persistent-memory
+    - python
+    - rag
+    - self-improving-agent
+    - semantic-search
+    - sqlite
+about:
+  title: Total Agent Memory
+  description: Persistent local memory for coding agents. Stores decisions, solutions and conventions across sessions in a local SQLite store and retrieves them with hybrid search over a temporal knowledge graph, plus procedural and episodic recall. No cloud, no API key.
+  icon: https://avatars.githubusercontent.com/u/11525488?v=4
+source:
+  project: https://github.com/vbcherepanov/total-agent-memory
+  commit: 14ccb6ca95567e58fd2a12b59096a818039f6d86
+run:
+  command:
+    - stdio
+  volumes:
+    - mcp-total-agent-memory:/data


### PR DESCRIPTION
## MCP Server Information

**Server Name:** total-agent-memory
**Repository URL:** https://github.com/vbcherepanov/total-agent-memory
**Brief Description:** Persistent local memory for coding agents. Stores decisions, solutions and conventions across sessions in a local SQLite store and retrieves them with hybrid search over a temporal knowledge graph, plus procedural and episodic recall. No cloud, no API key.

74 tools. Also published in the official MCP Registry as `io.github.vbcherepanov/total-agent-memory`.

The image speaks stdio via the `stdio` argument (`run.command`), and keeps its SQLite store and the embedding model in `/data`, hence the named volume — without it the server loses every memory and re-downloads a 240 MB ONNX model on each start.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license) — MIT
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues — SECURITY.md + GitHub private vulnerability reporting

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name total-agent-memory`
- [x] I have built the MCP Server using `task build -- --tools total-agent-memory` — 74 tools found
- [x] If the server requires credentials to test it, I have shared test credentials using this form — not applicable, the server needs no credentials
