### PR TITLE
Add Backblaze B2 MCP server

### DIFF
--- a/servers/backblaze-b2/server.yaml
+++ b/servers/backblaze-b2/server.yaml
@@ -10,7 +10,7 @@ meta:
     - s3
     - object-storage
 about:
-  title: Backblaze B2
+  title: Backblaze B2 MCP Server
   description: Official Backblaze B2 MCP server. Operate B2 Cloud Storage from any MCP client through a focused, safe 40-tool surface — buckets, files, application keys, Object Lock, event notifications, the S3-compatible data plane (presigned URLs, multipart), and storage analytics. Destructive actions are gated; you supply your own B2 application key.
   icon: https://www.google.com/s2/favicons?domain=backblaze.com&sz=64
 source:

--- a/servers/backblaze-b2/server.yaml
+++ b/servers/backblaze-b2/server.yaml
@@ -1,0 +1,30 @@
+name: backblaze-b2
+image: mcp/backblaze-b2
+type: server
+meta:
+  category: devops
+  tags:
+    - backblaze
+    - b2
+    - storage
+    - s3
+    - object-storage
+about:
+  title: Backblaze B2
+  description: Official Backblaze B2 MCP server. Operate B2 Cloud Storage from any MCP client through a focused, safe 40-tool surface — buckets, files, application keys, Object Lock, event notifications, the S3-compatible data plane (presigned URLs, multipart), and storage analytics. Destructive actions are gated; you supply your own B2 application key.
+  icon: https://www.google.com/s2/favicons?domain=backblaze.com&sz=64
+source:
+  project: https://github.com/backblaze-labs/b2-mcp
+  commit: a5e9760d09f7bd74f5c6fca556a1f1f4b698edaf
+run:
+  command:
+    - --transport=stdio
+config:
+  description: Backblaze B2 application key credentials (use a non-master key). Partner/Groups tools additionally require a master key, which is not configured through this catalog entry.
+  secrets:
+    - name: backblaze-b2.application_key_id
+      env: B2_APPLICATION_KEY_ID
+      example: 0012ab34cd56ef78000000001
+    - name: backblaze-b2.application_key
+      env: B2_APPLICATION_KEY
+      example: K001xxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
## MCP Server Information

**Server Name:** backblaze-b2 (Backblaze B2 MCP Server)
**Repository URL:** https://github.com/backblaze-labs/b2-mcp
**Brief Description:** Official Backblaze B2 MCP server. Operate B2 Cloud Storage from any MCP client through a focused, safe 40-tool surface — buckets, files, application keys, Object Lock, event notifications, the S3-compatible data plane (presigned URLs, multipart), and storage analytics. Destructive actions are gated; users supply their own B2 application key.

## Basic Requirements

- [x] **Open Source**: MIT license
- [x] **MCP Compliant**: Implements the MCP specification (stdio + Streamable HTTP); published to the Official MCP Registry as `io.github.backblaze-labs/b2-mcp`
- [x] **Active Development**: Recent commits and maintained (v0.2.1)
- [x] **Docker Artifact**: Dockerfile in the repo (this entry runs it with `--transport=stdio`)
- [x] **Documentation**: README + GitHub Pages (https://backblaze-labs.github.io/b2-mcp/)
- [x] **Security Contact**: `SECURITY.md` in the repo

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name backblaze-b2` (all checks pass)
- [x] I have built the MCP Server using `task build -- --tools backblaze-b2` (**40 tools found**, image built)
- [ ] If the server requires credentials to test it, I have shared test credentials using the form

### Notes
- The published Docker image defaults to the HTTP transport (for hosted deployments), so this entry sets `run.command: [--transport=stdio]` to run the local stdio transport the catalog expects. Tool enumeration succeeds over stdio (credential-free discovery mode lists all 40 tools without keys).
- Config declares the two B2 application-key secrets (`B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`). Use a non-master key. Partner/Groups tools additionally need a master key, intentionally not surfaced through this entry.
- **Test credentials:** exercising tool *calls* (beyond discovery) needs a real B2 application key — the maintainer will share reviewer test credentials via the credentials form.
