### PR TITLE
Add Agent Accessibility Auditor MCP server

### DIFF
--- a/servers/agent-accessibility-auditor/server.yaml
+++ b/servers/agent-accessibility-auditor/server.yaml
@@ -1,0 +1,24 @@
+name: agent-accessibility-auditor
+image: mcp/agent-accessibility-auditor
+type: server
+meta:
+  category: search
+  tags:
+    - web-scraping
+    - data-extraction
+    - seo
+about:
+  title: Agent Accessibility Auditor
+  description: "Audits whether an AI agent can read a website: llms.txt, robots.txt AI crawler rules, structured data, and machine readable endpoints, with the evidence for each check."
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-agent-accessibility-auditor
+  branch: main
+  commit: e6534a9ecd6cfe121748a86e0703d76c5f5d1582
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: agent-accessibility-auditor.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** agent-accessibility-auditor
**Repository URL:** https://github.com/mambalabsdev/mcp-agent-accessibility-auditor
**Brief Description:** Audits whether an AI agent can read a website: llms.txt, robots.txt AI crawler rules, structured data, and machine readable endpoints, with the evidence for each check.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name agent-accessibility-auditor`
- [x] I have built the MCP Server using `task build -- --tools agent-accessibility-auditor`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `e6534a9ecd6cfe121748a86e0703d76c5f5d1582`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
