### PR TITLE
Add AI Tooling Detector MCP server

### DIFF
--- a/servers/ai-tooling-detector/server.yaml
+++ b/servers/ai-tooling-detector/server.yaml
@@ -1,0 +1,24 @@
+name: ai-tooling-detector
+image: mcp/ai-tooling-detector
+type: server
+meta:
+  category: search
+  tags:
+    - web-scraping
+    - data-extraction
+    - sales-intelligence
+about:
+  title: AI Tooling Detector
+  description: Detects whether a company only talks about AI, actually deploys AI tooling on its site, or charges for AI, and returns the supporting evidence.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-ai-tooling-detector
+  branch: main
+  commit: bc30383728ce49ca841593c7f66acd3edfb84aa4
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: ai-tooling-detector.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** ai-tooling-detector
**Repository URL:** https://github.com/mambalabsdev/mcp-ai-tooling-detector
**Brief Description:** Detects whether a company only talks about AI, actually deploys AI tooling on its site, or charges for AI, and returns the supporting evidence.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name ai-tooling-detector`
- [x] I have built the MCP Server using `task build -- --tools ai-tooling-detector`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `bc30383728ce49ca841593c7f66acd3edfb84aa4`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
