### PR TITLE
Add B2B Prospect Engine MCP server

### DIFF
--- a/servers/b2b-prospect-engine/server.yaml
+++ b/servers/b2b-prospect-engine/server.yaml
@@ -1,0 +1,24 @@
+name: b2b-prospect-engine
+image: mcp/b2b-prospect-engine
+type: server
+meta:
+  category: search
+  tags:
+    - sales-intelligence
+    - lead-generation
+    - data-enrichment
+about:
+  title: B2B Prospect Engine
+  description: Turns a domain or a hiring keyword into enriched company records and verified contacts, with ICP scoring and per field provenance.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-b2b-prospect-engine
+  branch: main
+  commit: 4a8541cae259e7f5775460195e6d3b165c488207
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: b2b-prospect-engine.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** b2b-prospect-engine
**Repository URL:** https://github.com/mambalabsdev/mcp-b2b-prospect-engine
**Brief Description:** Turns a domain or a hiring keyword into enriched company records and verified contacts, with ICP scoring and per field provenance.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name b2b-prospect-engine`
- [x] I have built the MCP Server using `task build -- --tools b2b-prospect-engine`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `4a8541cae259e7f5775460195e6d3b165c488207`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
