### PR TITLE
Add Sequencer Lead Push MCP server

### DIFF
--- a/servers/clay-to-instantly-smartlead-push/server.yaml
+++ b/servers/clay-to-instantly-smartlead-push/server.yaml
@@ -1,0 +1,24 @@
+name: clay-to-instantly-smartlead-push
+image: mcp/clay-to-instantly-smartlead-push
+type: server
+meta:
+  category: productivity
+  tags:
+    - sales-intelligence
+    - lead-generation
+    - email
+about:
+  title: Sequencer Lead Push
+  description: Pushes enriched lead rows into an Instantly or Smartlead campaign with ICP score gating, deduplication, and a zero write dry run.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-clay-to-instantly-smartlead-push
+  branch: main
+  commit: e95eab181efc86a9608bcb2d2e649af5f607e0c1
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: clay-to-instantly-smartlead-push.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** clay-to-instantly-smartlead-push
**Repository URL:** https://github.com/mambalabsdev/mcp-clay-to-instantly-smartlead-push
**Brief Description:** Pushes enriched lead rows into an Instantly or Smartlead campaign with ICP score gating, deduplication, and a zero write dry run.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name clay-to-instantly-smartlead-push`
- [x] I have built the MCP Server using `task build -- --tools clay-to-instantly-smartlead-push`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `e95eab181efc86a9608bcb2d2e649af5f607e0c1`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
