### PR TITLE
Add Company Change Event Feed MCP server

### DIFF
--- a/servers/company-change-event-feed/server.yaml
+++ b/servers/company-change-event-feed/server.yaml
@@ -1,0 +1,24 @@
+name: company-change-event-feed
+image: mcp/company-change-event-feed
+type: server
+meta:
+  category: search
+  tags:
+    - sales-intelligence
+    - data-enrichment
+    - monitoring
+about:
+  title: Company Change Event Feed
+  description: Monitors a company domain for changes across hiring, tech stack, funding, firmographics, and social since the last run, returned as flat change events.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-company-change-event-feed
+  branch: main
+  commit: 67e3a5ae65eba0aba15b6eaa507f5e3d88ce7674
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: company-change-event-feed.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** company-change-event-feed
**Repository URL:** https://github.com/mambalabsdev/mcp-company-change-event-feed
**Brief Description:** Monitors a company domain for changes across hiring, tech stack, funding, firmographics, and social since the last run, returned as flat change events.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name company-change-event-feed`
- [x] I have built the MCP Server using `task build -- --tools company-change-event-feed`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `67e3a5ae65eba0aba15b6eaa507f5e3d88ce7674`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
