### PR TITLE
Add Company Discovery List Builder MCP server

### DIFF
--- a/servers/company-discovery-list-builder/server.yaml
+++ b/servers/company-discovery-list-builder/server.yaml
@@ -1,0 +1,24 @@
+name: company-discovery-list-builder
+image: mcp/company-discovery-list-builder
+type: server
+meta:
+  category: search
+  tags:
+    - sales-intelligence
+    - lead-generation
+    - data-extraction
+about:
+  title: Company Discovery List Builder
+  description: "Builds a company list from a market definition: companies hiring for a role, or US SEC filers whose filings mention a phrase."
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-company-discovery-list-builder
+  branch: main
+  commit: 7e863fe8800da7199e0862c97db11ff61bef33c4
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: company-discovery-list-builder.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** company-discovery-list-builder
**Repository URL:** https://github.com/mambalabsdev/mcp-company-discovery-list-builder
**Brief Description:** Builds a company list from a market definition: companies hiring for a role, or US SEC filers whose filings mention a phrase.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name company-discovery-list-builder`
- [x] I have built the MCP Server using `task build -- --tools company-discovery-list-builder`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `7e863fe8800da7199e0862c97db11ff61bef33c4`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
