### PR TITLE
Add Company Firmographic Enricher MCP server

### DIFF
--- a/servers/company-firmographic-enricher/server.yaml
+++ b/servers/company-firmographic-enricher/server.yaml
@@ -1,0 +1,24 @@
+name: company-firmographic-enricher
+image: mcp/company-firmographic-enricher
+type: server
+meta:
+  category: search
+  tags:
+    - data-enrichment
+    - sales-intelligence
+    - firmographics
+about:
+  title: Company Firmographic Enricher
+  description: "Turns a company domain into structured firmographics: employee band, industry, headquarters, founded year, revenue estimate, logo, and description, with provenance."
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-company-firmographic-enricher
+  branch: main
+  commit: c316106395c1e865673b7bf9e5ba36d6f272fc80
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: company-firmographic-enricher.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** company-firmographic-enricher
**Repository URL:** https://github.com/mambalabsdev/mcp-company-firmographic-enricher
**Brief Description:** Turns a company domain into structured firmographics: employee band, industry, headquarters, founded year, revenue estimate, logo, and description, with provenance.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name company-firmographic-enricher`
- [x] I have built the MCP Server using `task build -- --tools company-firmographic-enricher`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `c316106395c1e865673b7bf9e5ba36d6f272fc80`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
