### PR TITLE
Add Company Identity Resolver MCP server

### DIFF
--- a/servers/company-identity-resolver/server.yaml
+++ b/servers/company-identity-resolver/server.yaml
@@ -1,0 +1,24 @@
+name: company-identity-resolver
+image: mcp/company-identity-resolver
+type: server
+meta:
+  category: search
+  tags:
+    - data-enrichment
+    - entity-resolution
+    - sales-intelligence
+about:
+  title: Company Identity Resolver
+  description: Resolves any combination of company name, domain, or LinkedIn URL into one canonical identity tuple with per field and overall confidence scores.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-company-identity-resolver
+  branch: main
+  commit: 848a2bcfd5c42d435ff545bb05c6509cbdfea63f
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: company-identity-resolver.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** company-identity-resolver
**Repository URL:** https://github.com/mambalabsdev/mcp-company-identity-resolver
**Brief Description:** Resolves any combination of company name, domain, or LinkedIn URL into one canonical identity tuple with per field and overall confidence scores.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name company-identity-resolver`
- [x] I have built the MCP Server using `task build -- --tools company-identity-resolver`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `848a2bcfd5c42d435ff545bb05c6509cbdfea63f`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
