### PR TITLE
Add Company Social Presence Mapper MCP server

### DIFF
--- a/servers/company-social-presence-mapper/server.yaml
+++ b/servers/company-social-presence-mapper/server.yaml
@@ -1,0 +1,24 @@
+name: company-social-presence-mapper
+image: mcp/company-social-presence-mapper
+type: server
+meta:
+  category: search
+  tags:
+    - social-media
+    - data-enrichment
+    - sales-intelligence
+about:
+  title: Company Social Presence Mapper
+  description: Maps a company domain to its official LinkedIn, X, Instagram, Facebook, and YouTube URLs plus follower counts.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-company-social-presence-mapper
+  branch: main
+  commit: 68fe5f65ab94a0b204a20b67f25f4848c5b31c5b
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: company-social-presence-mapper.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** company-social-presence-mapper
**Repository URL:** https://github.com/mambalabsdev/mcp-company-social-presence-mapper
**Brief Description:** Maps a company domain to its official LinkedIn, X, Instagram, Facebook, and YouTube URLs plus follower counts.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name company-social-presence-mapper`
- [x] I have built the MCP Server using `task build -- --tools company-social-presence-mapper`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `68fe5f65ab94a0b204a20b67f25f4848c5b31c5b`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
