### PR TITLE
Add Contact Classifier MCP server

### DIFF
--- a/servers/contact-classifier/server.yaml
+++ b/servers/contact-classifier/server.yaml
@@ -1,0 +1,24 @@
+name: contact-classifier
+image: mcp/contact-classifier
+type: server
+meta:
+  category: search
+  tags:
+    - data-enrichment
+    - contact-data
+    - sales-intelligence
+about:
+  title: Contact Classifier
+  description: Turns a contact title into department and seniority, with an optional check on whether the person still holds the role.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-contact-classifier
+  branch: main
+  commit: 178835ac5f595de05697fe57a7ea93736d84e3f8
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: contact-classifier.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** contact-classifier
**Repository URL:** https://github.com/mambalabsdev/mcp-contact-classifier
**Brief Description:** Turns a contact title into department and seniority, with an optional check on whether the person still holds the role.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name contact-classifier`
- [x] I have built the MCP Server using `task build -- --tools contact-classifier`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `178835ac5f595de05697fe57a7ea93736d84e3f8`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
