### PR TITLE
Add Domain To LinkedIn URL Resolver MCP server

### DIFF
--- a/servers/domain-to-linkedin-url-resolver/server.yaml
+++ b/servers/domain-to-linkedin-url-resolver/server.yaml
@@ -1,0 +1,24 @@
+name: domain-to-linkedin-url-resolver
+image: mcp/domain-to-linkedin-url-resolver
+type: server
+meta:
+  category: search
+  tags:
+    - social-media
+    - data-enrichment
+    - linkedin
+about:
+  title: Domain To LinkedIn URL Resolver
+  description: Resolves a company domain or name to its LinkedIn company URL with confidence scoring and firmographic metadata.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-domain-to-linkedin-url-resolver
+  branch: main
+  commit: c0c107367c344e99ac78aaa7c58137fd607dba34
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: domain-to-linkedin-url-resolver.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** domain-to-linkedin-url-resolver
**Repository URL:** https://github.com/mambalabsdev/mcp-domain-to-linkedin-url-resolver
**Brief Description:** Resolves a company domain or name to its LinkedIn company URL with confidence scoring and firmographic metadata.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name domain-to-linkedin-url-resolver`
- [x] I have built the MCP Server using `task build -- --tools domain-to-linkedin-url-resolver`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `c0c107367c344e99ac78aaa7c58137fd607dba34`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
