### PR TITLE
Add Work Email Waterfall MCP server

### DIFF
--- a/servers/email-waterfall-orchestrator/server.yaml
+++ b/servers/email-waterfall-orchestrator/server.yaml
@@ -1,0 +1,24 @@
+name: email-waterfall-orchestrator
+image: mcp/email-waterfall-orchestrator
+type: server
+meta:
+  category: search
+  tags:
+    - email
+    - contact-data
+    - data-enrichment
+about:
+  title: Work Email Waterfall
+  description: Finds and verifies a work email for each contact across your own provider keys, and returns real per provider spend attribution.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-email-waterfall-orchestrator
+  branch: main
+  commit: 4537f663d13f14dff025801b2c49b2e29e7cf067
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: email-waterfall-orchestrator.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** email-waterfall-orchestrator
**Repository URL:** https://github.com/mambalabsdev/mcp-email-waterfall-orchestrator
**Brief Description:** Finds and verifies a work email for each contact across your own provider keys, and returns real per provider spend attribution.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name email-waterfall-orchestrator`
- [x] I have built the MCP Server using `task build -- --tools email-waterfall-orchestrator`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `4537f663d13f14dff025801b2c49b2e29e7cf067`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
