### PR TITLE
Add Event Presence Index MCP server

### DIFF
--- a/servers/event-presence-index/server.yaml
+++ b/servers/event-presence-index/server.yaml
@@ -1,0 +1,24 @@
+name: event-presence-index
+image: mcp/event-presence-index
+type: server
+meta:
+  category: search
+  tags:
+    - web-scraping
+    - data-extraction
+    - sales-intelligence
+about:
+  title: Event Presence Index
+  description: Returns the third party conferences and trade shows a company publicly says it attends, with a year for each.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-event-presence-index
+  branch: main
+  commit: 789034f9cdccec992ea5647ca82f8af819862bcb
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: event-presence-index.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** event-presence-index
**Repository URL:** https://github.com/mambalabsdev/mcp-event-presence-index
**Brief Description:** Returns the third party conferences and trade shows a company publicly says it attends, with a year for each.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name event-presence-index`
- [x] I have built the MCP Server using `task build -- --tools event-presence-index`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `789034f9cdccec992ea5647ca82f8af819862bcb`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
