### PR TITLE
Add Funding Investor Record MCP server

### DIFF
--- a/servers/funding-investor-record/server.yaml
+++ b/servers/funding-investor-record/server.yaml
@@ -1,0 +1,24 @@
+name: funding-investor-record
+image: mcp/funding-investor-record
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - sec
+    - companies-house
+about:
+  title: Funding Investor Record
+  description: Returns a company funding record from SEC Form D, Companies House, and press, with each source labeled.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-funding-investor-record
+  branch: main
+  commit: 8c9b53800faa4e58ce7df7af76388a391d365c14
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: funding-investor-record.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** funding-investor-record
**Repository URL:** https://github.com/mambalabsdev/mcp-funding-investor-record
**Brief Description:** Returns a company funding record from SEC Form D, Companies House, and press, with each source labeled.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name funding-investor-record`
- [x] I have built the MCP Server using `task build -- --tools funding-investor-record`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `8c9b53800faa4e58ce7df7af76388a391d365c14`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
