### PR TITLE
Add GitHub Organization Signal Scanner MCP server

### DIFF
--- a/servers/github-organization-signal-scanner/server.yaml
+++ b/servers/github-organization-signal-scanner/server.yaml
@@ -1,0 +1,24 @@
+name: github-organization-signal-scanner
+image: mcp/github-organization-signal-scanner
+type: server
+meta:
+  category: search
+  tags:
+    - github
+    - data-extraction
+    - sales-intelligence
+about:
+  title: GitHub Organization Signal Scanner
+  description: Resolves a company domain to its GitHub organization with repository, language, and activity signals.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-github-organization-signal-scanner
+  branch: main
+  commit: f818622b89da6394a55e6130dfb1351cc968431e
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: github-organization-signal-scanner.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** github-organization-signal-scanner
**Repository URL:** https://github.com/mambalabsdev/mcp-github-organization-signal-scanner
**Brief Description:** Resolves a company domain to its GitHub organization with repository, language, and activity signals.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name github-organization-signal-scanner`
- [x] I have built the MCP Server using `task build -- --tools github-organization-signal-scanner`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `f818622b89da6394a55e6130dfb1351cc968431e`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
