### PR TITLE
Add Hiring Signal Scraper MCP server

### DIFF
--- a/servers/gtm-hiring-signal-scraper/server.yaml
+++ b/servers/gtm-hiring-signal-scraper/server.yaml
@@ -1,0 +1,24 @@
+name: gtm-hiring-signal-scraper
+image: mcp/gtm-hiring-signal-scraper
+type: server
+meta:
+  category: search
+  tags:
+    - hiring
+    - web-scraping
+    - sales-intelligence
+about:
+  title: Hiring Signal Scraper
+  description: Detects go to market hiring activity across Greenhouse, Lever, and Ashby career pages, with role counts, signal strength, and ATS detection.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-gtm-hiring-signal-scraper
+  branch: main
+  commit: 55a7643c4a7782fbbede1eab058006e653ddf9a5
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: gtm-hiring-signal-scraper.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gtm-hiring-signal-scraper
**Repository URL:** https://github.com/mambalabsdev/mcp-gtm-hiring-signal-scraper
**Brief Description:** Detects go to market hiring activity across Greenhouse, Lever, and Ashby career pages, with role counts, signal strength, and ATS detection.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gtm-hiring-signal-scraper`
- [x] I have built the MCP Server using `task build -- --tools gtm-hiring-signal-scraper`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `55a7643c4a7782fbbede1eab058006e653ddf9a5`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
