### PR TITLE
Add Job Posting Monitor MCP server

### DIFF
--- a/servers/gtm-job-discovery/server.yaml
+++ b/servers/gtm-job-discovery/server.yaml
@@ -1,0 +1,24 @@
+name: gtm-job-discovery
+image: mcp/gtm-job-discovery
+type: server
+meta:
+  category: search
+  tags:
+    - hiring
+    - job-boards
+    - data-extraction
+about:
+  title: Job Posting Monitor
+  description: Finds companies hiring for your role keywords across job boards and returns one flat, firmographically enriched row per posting.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-gtm-job-discovery
+  branch: main
+  commit: 01922633af85b8cab600e7a07387674e7f045f13
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: gtm-job-discovery.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gtm-job-discovery
**Repository URL:** https://github.com/mambalabsdev/mcp-gtm-job-discovery
**Brief Description:** Finds companies hiring for your role keywords across job boards and returns one flat, firmographically enriched row per posting.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gtm-job-discovery`
- [x] I have built the MCP Server using `task build -- --tools gtm-job-discovery`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `01922633af85b8cab600e7a07387674e7f045f13`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
