### PR TITLE
Add Tech Stack Signal Scraper MCP server

### DIFF
--- a/servers/gtm-tech-stack-signal-scraper/server.yaml
+++ b/servers/gtm-tech-stack-signal-scraper/server.yaml
@@ -1,0 +1,24 @@
+name: gtm-tech-stack-signal-scraper
+image: mcp/gtm-tech-stack-signal-scraper
+type: server
+meta:
+  category: search
+  tags:
+    - tech-stack
+    - web-scraping
+    - sales-intelligence
+about:
+  title: Tech Stack Signal Scraper
+  description: Detects CRM, sequencer, and marketing automation tools from a company's public website.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-gtm-tech-stack-signal-scraper
+  branch: main
+  commit: 3db0869d84dcf35a021887a17b00cdb72b6f3e58
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: gtm-tech-stack-signal-scraper.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** gtm-tech-stack-signal-scraper
**Repository URL:** https://github.com/mambalabsdev/mcp-gtm-tech-stack-signal-scraper
**Brief Description:** Detects CRM, sequencer, and marketing automation tools from a company's public website.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name gtm-tech-stack-signal-scraper`
- [x] I have built the MCP Server using `task build -- --tools gtm-tech-stack-signal-scraper`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `3db0869d84dcf35a021887a17b00cdb72b6f3e58`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
