### PR TITLE
Add ICP Fit Scorer MCP server

### DIFF
--- a/servers/icp-fit-scorer/server.yaml
+++ b/servers/icp-fit-scorer/server.yaml
@@ -1,0 +1,24 @@
+name: icp-fit-scorer
+image: mcp/icp-fit-scorer
+type: server
+meta:
+  category: search
+  tags:
+    - scoring
+    - sales-intelligence
+    - lead-generation
+about:
+  title: ICP Fit Scorer
+  description: Scores a company against a weighted ideal customer profile and returns a 0 to 100 score, a tier, and a per signal breakdown.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-icp-fit-scorer
+  branch: main
+  commit: 1100d3a7413a44dbd0b7591a42c8855cf6aac3f9
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: icp-fit-scorer.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** icp-fit-scorer
**Repository URL:** https://github.com/mambalabsdev/mcp-icp-fit-scorer
**Brief Description:** Scores a company against a weighted ideal customer profile and returns a 0 to 100 score, a tier, and a per signal breakdown.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name icp-fit-scorer`
- [x] I have built the MCP Server using `task build -- --tools icp-fit-scorer`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `1100d3a7413a44dbd0b7591a42c8855cf6aac3f9`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
