### PR TITLE
Add Job Board Keyword Signal Scanner MCP server

### DIFF
--- a/servers/job-board-keyword-signal-scanner/server.yaml
+++ b/servers/job-board-keyword-signal-scanner/server.yaml
@@ -1,0 +1,24 @@
+name: job-board-keyword-signal-scanner
+image: mcp/job-board-keyword-signal-scanner
+type: server
+meta:
+  category: search
+  tags:
+    - hiring
+    - job-boards
+    - web-scraping
+about:
+  title: Job Board Keyword Signal Scanner
+  description: Scans Greenhouse, Lever, Ashby, Workday, and Rippling for roles in any category.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-job-board-keyword-signal-scanner
+  branch: main
+  commit: b7812b44a34e3494c7a08f6578e7f0827c058107
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: job-board-keyword-signal-scanner.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** job-board-keyword-signal-scanner
**Repository URL:** https://github.com/mambalabsdev/mcp-job-board-keyword-signal-scanner
**Brief Description:** Scans Greenhouse, Lever, Ashby, Workday, and Rippling for roles in any category.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name job-board-keyword-signal-scanner`
- [x] I have built the MCP Server using `task build -- --tools job-board-keyword-signal-scanner`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `b7812b44a34e3494c7a08f6578e7f0827c058107`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
