### PR TITLE
Add Legal Entity Resolver MCP server

### DIFF
--- a/servers/legal-entity-resolver/server.yaml
+++ b/servers/legal-entity-resolver/server.yaml
@@ -1,0 +1,24 @@
+name: legal-entity-resolver
+image: mcp/legal-entity-resolver
+type: server
+meta:
+  category: search
+  tags:
+    - legal
+    - entity-resolution
+    - data-enrichment
+about:
+  title: Legal Entity Resolver
+  description: "Turns a company domain into its registered legal entity: legal name, company number, jurisdiction, status, LEI, and VAT number."
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-legal-entity-resolver
+  branch: main
+  commit: c47f0bd22414226c522f30e372f16b87133e74f0
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: legal-entity-resolver.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** legal-entity-resolver
**Repository URL:** https://github.com/mambalabsdev/mcp-legal-entity-resolver
**Brief Description:** Turns a company domain into its registered legal entity: legal name, company number, jurisdiction, status, LEI, and VAT number.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name legal-entity-resolver`
- [x] I have built the MCP Server using `task build -- --tools legal-entity-resolver`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `c47f0bd22414226c522f30e372f16b87133e74f0`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
