### PR TITLE
Add LinkedIn Post And Commenter Capture MCP server

### DIFF
--- a/servers/linkedin-post-engager-capture/server.yaml
+++ b/servers/linkedin-post-engager-capture/server.yaml
@@ -1,0 +1,24 @@
+name: linkedin-post-engager-capture
+image: mcp/linkedin-post-engager-capture
+type: server
+meta:
+  category: search
+  tags:
+    - linkedin
+    - social-media
+    - data-extraction
+about:
+  title: LinkedIn Post And Commenter Capture
+  description: Returns recent posts from LinkedIn profiles and company pages with real engagement counts, plus the commenters LinkedIn shows publicly. No cookies and no account.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-linkedin-post-engager-capture
+  branch: main
+  commit: f5a2617a4c7faa65f3232b60edc25b0eab29783c
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: linkedin-post-engager-capture.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** linkedin-post-engager-capture
**Repository URL:** https://github.com/mambalabsdev/mcp-linkedin-post-engager-capture
**Brief Description:** Returns recent posts from LinkedIn profiles and company pages with real engagement counts, plus the commenters LinkedIn shows publicly. No cookies and no account.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name linkedin-post-engager-capture`
- [x] I have built the MCP Server using `task build -- --tools linkedin-post-engager-capture`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `f5a2617a4c7faa65f3232b60edc25b0eab29783c`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
