### PR TITLE
Add Meta Ad Library Monitor MCP server

### DIFF
--- a/servers/meta-ad-library-monitor/server.yaml
+++ b/servers/meta-ad-library-monitor/server.yaml
@@ -1,0 +1,24 @@
+name: meta-ad-library-monitor
+image: mcp/meta-ad-library-monitor
+type: server
+meta:
+  category: search
+  tags:
+    - advertising
+    - social-media
+    - data-extraction
+about:
+  title: Meta Ad Library Monitor
+  description: Finds a company's active Facebook and Instagram ads through the Meta Ad Library API.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-meta-ad-library-monitor
+  branch: main
+  commit: 8b719fa65ab088c9efafc643c7b1209e7b3f4f81
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: meta-ad-library-monitor.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** meta-ad-library-monitor
**Repository URL:** https://github.com/mambalabsdev/mcp-meta-ad-library-monitor
**Brief Description:** Finds a company's active Facebook and Instagram ads through the Meta Ad Library API.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name meta-ad-library-monitor`
- [x] I have built the MCP Server using `task build -- --tools meta-ad-library-monitor`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `8b719fa65ab088c9efafc643c7b1209e7b3f4f81`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
