### PR TITLE
Add Outbound Infrastructure Fingerprint MCP server

### DIFF
--- a/servers/outbound-infrastructure-fingerprint/server.yaml
+++ b/servers/outbound-infrastructure-fingerprint/server.yaml
@@ -1,0 +1,24 @@
+name: outbound-infrastructure-fingerprint
+image: mcp/outbound-infrastructure-fingerprint
+type: server
+meta:
+  category: search
+  tags:
+    - email
+    - dns
+    - sales-intelligence
+about:
+  title: Outbound Infrastructure Fingerprint
+  description: Returns whether a company runs cold email outbound, on what stack, and the lookalike sending domains behind it.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-outbound-infrastructure-fingerprint
+  branch: main
+  commit: 69316a19721c48dd8cefbcb22aba26cc00f10116
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: outbound-infrastructure-fingerprint.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** outbound-infrastructure-fingerprint
**Repository URL:** https://github.com/mambalabsdev/mcp-outbound-infrastructure-fingerprint
**Brief Description:** Returns whether a company runs cold email outbound, on what stack, and the lookalike sending domains behind it.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name outbound-infrastructure-fingerprint`
- [x] I have built the MCP Server using `task build -- --tools outbound-infrastructure-fingerprint`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `69316a19721c48dd8cefbcb22aba26cc00f10116`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
