### PR TITLE
Add Page Finder And Extractor MCP server

### DIFF
--- a/servers/page-finder-extractor/server.yaml
+++ b/servers/page-finder-extractor/server.yaml
@@ -1,0 +1,24 @@
+name: page-finder-extractor
+image: mcp/page-finder-extractor
+type: server
+meta:
+  category: search
+  tags:
+    - web-scraping
+    - data-extraction
+    - crawling
+about:
+  title: Page Finder And Extractor
+  description: Locates a named page type on a company's own website and returns the method that found it with a confidence for that method.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-page-finder-extractor
+  branch: main
+  commit: a932730b5ad0c1019a0f9ca493569cb9711020ec
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: page-finder-extractor.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** page-finder-extractor
**Repository URL:** https://github.com/mambalabsdev/mcp-page-finder-extractor
**Brief Description:** Locates a named page type on a company's own website and returns the method that found it with a confidence for that method.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name page-finder-extractor`
- [x] I have built the MCP Server using `task build -- --tools page-finder-extractor`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `a932730b5ad0c1019a0f9ca493569cb9711020ec`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
