### PR TITLE
Add People Finder And Email Verifier MCP server

### DIFF
--- a/servers/people-finder/server.yaml
+++ b/servers/people-finder/server.yaml
@@ -1,0 +1,24 @@
+name: people-finder
+image: mcp/people-finder
+type: server
+meta:
+  category: search
+  tags:
+    - contact-data
+    - lead-generation
+    - data-enrichment
+about:
+  title: People Finder And Email Verifier
+  description: Finds people at a company by role, seniority, and department, and returns structured contact records with an optional verified business email.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-people-finder
+  branch: main
+  commit: f3b41ca62c288f1443da4455d29990453df40705
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: people-finder.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** people-finder
**Repository URL:** https://github.com/mambalabsdev/mcp-people-finder
**Brief Description:** Finds people at a company by role, seniority, and department, and returns structured contact records with an optional verified business email.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name people-finder`
- [x] I have built the MCP Server using `task build -- --tools people-finder`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `f3b41ca62c288f1443da4455d29990453df40705`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
