### PR TITLE
Add Pinterest Brand Presence Mapper MCP server

### DIFF
--- a/servers/pinterest-brand-presence-mapper/server.yaml
+++ b/servers/pinterest-brand-presence-mapper/server.yaml
@@ -1,0 +1,24 @@
+name: pinterest-brand-presence-mapper
+image: mcp/pinterest-brand-presence-mapper
+type: server
+meta:
+  category: search
+  tags:
+    - social-media
+    - pinterest
+    - data-extraction
+about:
+  title: Pinterest Brand Presence Mapper
+  description: Resolves a company domain to its Pinterest business account with exact follower, pin, and board counts.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-pinterest-brand-presence-mapper
+  branch: main
+  commit: 28625f275794eff67b60e808fc6fc0362148f17d
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: pinterest-brand-presence-mapper.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** pinterest-brand-presence-mapper
**Repository URL:** https://github.com/mambalabsdev/mcp-pinterest-brand-presence-mapper
**Brief Description:** Resolves a company domain to its Pinterest business account with exact follower, pin, and board counts.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name pinterest-brand-presence-mapper`
- [x] I have built the MCP Server using `task build -- --tools pinterest-brand-presence-mapper`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `28625f275794eff67b60e808fc6fc0362148f17d`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
