### PR TITLE
Add Public Company Reporting Window Finder MCP server

### DIFF
--- a/servers/public-company-reporting-window-finder/server.yaml
+++ b/servers/public-company-reporting-window-finder/server.yaml
@@ -1,0 +1,24 @@
+name: public-company-reporting-window-finder
+image: mcp/public-company-reporting-window-finder
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - earnings
+    - sec
+about:
+  title: Public Company Reporting Window Finder
+  description: Takes a domain, ticker, ISIN, LEI, or CIK and returns fiscal year end, reporting cadence, the next reporting date, days to event, and the quiet period window.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-public-company-reporting-window-finder
+  branch: main
+  commit: 7d63bde1e8d5108395b225c8187e494315080f1e
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: public-company-reporting-window-finder.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** public-company-reporting-window-finder
**Repository URL:** https://github.com/mambalabsdev/mcp-public-company-reporting-window-finder
**Brief Description:** Takes a domain, ticker, ISIN, LEI, or CIK and returns fiscal year end, reporting cadence, the next reporting date, days to event, and the quiet period window.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name public-company-reporting-window-finder`
- [x] I have built the MCP Server using `task build -- --tools public-company-reporting-window-finder`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `7d63bde1e8d5108395b225c8187e494315080f1e`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
