### PR TITLE
Add Publication Cadence Tracker MCP server

### DIFF
--- a/servers/publication-cadence-tracker/server.yaml
+++ b/servers/publication-cadence-tracker/server.yaml
@@ -1,0 +1,24 @@
+name: publication-cadence-tracker
+image: mcp/publication-cadence-tracker
+type: server
+meta:
+  category: search
+  tags:
+    - content
+    - web-scraping
+    - data-extraction
+about:
+  title: Publication Cadence Tracker
+  description: Measures how much long form work a company publishes per month and whether the rate is rising or falling.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-publication-cadence-tracker
+  branch: main
+  commit: b1cd3035d2afe0f61ceb636d2abba0b61d974d05
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: publication-cadence-tracker.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** publication-cadence-tracker
**Repository URL:** https://github.com/mambalabsdev/mcp-publication-cadence-tracker
**Brief Description:** Measures how much long form work a company publishes per month and whether the rate is rising or falling.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name publication-cadence-tracker`
- [x] I have built the MCP Server using `task build -- --tools publication-cadence-tracker`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `b1cd3035d2afe0f61ceb636d2abba0b61d974d05`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
