### PR TITLE
Add Trustpilot Reputation Enricher MCP server

### DIFF
--- a/servers/review-platform-reputation-enricher/server.yaml
+++ b/servers/review-platform-reputation-enricher/server.yaml
@@ -1,0 +1,24 @@
+name: review-platform-reputation-enricher
+image: mcp/review-platform-reputation-enricher
+type: server
+meta:
+  category: search
+  tags:
+    - reviews
+    - data-enrichment
+    - trustpilot
+about:
+  title: Trustpilot Reputation Enricher
+  description: Resolves a company domain to its Trustpilot rating, review count, and claimed status.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-review-platform-reputation-enricher
+  branch: main
+  commit: b346fa5d41f6fb59ac7975a17e2f78f979beed3a
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: review-platform-reputation-enricher.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** review-platform-reputation-enricher
**Repository URL:** https://github.com/mambalabsdev/mcp-review-platform-reputation-enricher
**Brief Description:** Resolves a company domain to its Trustpilot rating, review count, and claimed status.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name review-platform-reputation-enricher`
- [x] I have built the MCP Server using `task build -- --tools review-platform-reputation-enricher`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `b346fa5d41f6fb59ac7975a17e2f78f979beed3a`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
