### PR TITLE
Add Team Page People Extractor MCP server

### DIFF
--- a/servers/team-page-people-extractor/server.yaml
+++ b/servers/team-page-people-extractor/server.yaml
@@ -1,0 +1,24 @@
+name: team-page-people-extractor
+image: mcp/team-page-people-extractor
+type: server
+meta:
+  category: search
+  tags:
+    - web-scraping
+    - contact-data
+    - data-extraction
+about:
+  title: Team Page People Extractor
+  description: Returns the people a company publishes on its own team, leadership, or about page, with names, titles, and the source page.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-team-page-people-extractor
+  branch: main
+  commit: 6b92fa89bab22a180dda4e07fb46dc0078a28e21
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: team-page-people-extractor.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** team-page-people-extractor
**Repository URL:** https://github.com/mambalabsdev/mcp-team-page-people-extractor
**Brief Description:** Returns the people a company publishes on its own team, leadership, or about page, with names, titles, and the source page.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name team-page-people-extractor`
- [x] I have built the MCP Server using `task build -- --tools team-page-people-extractor`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `6b92fa89bab22a180dda4e07fb46dc0078a28e21`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
