### PR TITLE
Add Website Traffic Rank Estimator MCP server

### DIFF
--- a/servers/website-traffic-rank-estimator/server.yaml
+++ b/servers/website-traffic-rank-estimator/server.yaml
@@ -1,0 +1,24 @@
+name: website-traffic-rank-estimator
+image: mcp/website-traffic-rank-estimator
+type: server
+meta:
+  category: search
+  tags:
+    - analytics
+    - tranco
+    - data-enrichment
+about:
+  title: Website Traffic Rank Estimator
+  description: Returns a research grade Tranco popularity rank and trend for any company domain.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-website-traffic-rank-estimator
+  branch: main
+  commit: 306d27845044f0279897e1460ba31523d47b1529
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: website-traffic-rank-estimator.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** website-traffic-rank-estimator
**Repository URL:** https://github.com/mambalabsdev/mcp-website-traffic-rank-estimator
**Brief Description:** Returns a research grade Tranco popularity rank and trend for any company domain.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name website-traffic-rank-estimator`
- [x] I have built the MCP Server using `task build -- --tools website-traffic-rank-estimator`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `306d27845044f0279897e1460ba31523d47b1529`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
