### PR TITLE
Add Workplace Program Detector MCP server

### DIFF
--- a/servers/workplace-program-detector/server.yaml
+++ b/servers/workplace-program-detector/server.yaml
@@ -1,0 +1,24 @@
+name: workplace-program-detector
+image: mcp/workplace-program-detector
+type: server
+meta:
+  category: search
+  tags:
+    - web-scraping
+    - data-extraction
+    - hr
+about:
+  title: Workplace Program Detector
+  description: "Detects which people programs a company publishes: employee resource groups, DEI, wellbeing, learning, parental leave, and volunteering."
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-workplace-program-detector
+  branch: main
+  commit: c59a10d1b9924ebe4304e1e430db89f28705acbf
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: workplace-program-detector.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** workplace-program-detector
**Repository URL:** https://github.com/mambalabsdev/mcp-workplace-program-detector
**Brief Description:** Detects which people programs a company publishes: employee resource groups, DEI, wellbeing, learning, parental leave, and volunteering.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name workplace-program-detector`
- [x] I have built the MCP Server using `task build -- --tools workplace-program-detector`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `c59a10d1b9924ebe4304e1e430db89f28705acbf`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
