### PR TITLE
Add YouTube Channel Stats Extractor MCP server

### DIFF
--- a/servers/youtube-channel-transcript-extractor/server.yaml
+++ b/servers/youtube-channel-transcript-extractor/server.yaml
@@ -1,0 +1,24 @@
+name: youtube-channel-transcript-extractor
+image: mcp/youtube-channel-transcript-extractor
+type: server
+meta:
+  category: search
+  tags:
+    - social-media
+    - youtube
+    - data-extraction
+about:
+  title: YouTube Channel Stats Extractor
+  description: Resolves a company domain or YouTube handle to the channel with subscriber count and channel metadata.
+  icon: https://avatars.githubusercontent.com/u/289610954?v=4
+source:
+  project: https://github.com/mambalabsdev/mcp-youtube-channel-transcript-extractor
+  branch: main
+  commit: a2720e702c90687c61b9c1ce47e6645c7e78341a
+config:
+  description: Configure the connection to the Apify API
+  secrets:
+    - name: youtube-channel-transcript-extractor.apify_token
+      env: APIFY_TOKEN
+      example: <APIFY_TOKEN>
+      description: Apify API token, created at https://console.apify.com/account/integrations


### PR DESCRIPTION
## MCP Server Information

**Server Name:** youtube-channel-transcript-extractor
**Repository URL:** https://github.com/mambalabsdev/mcp-youtube-channel-transcript-extractor
**Brief Description:** Resolves a company domain or YouTube handle to the channel with subscriber count and channel metadata.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name youtube-channel-transcript-extractor`
- [x] I have built the MCP Server using `task build -- --tools youtube-channel-transcript-extractor`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

MIT licensed, TypeScript, stdio. The image is a two stage `node:22-alpine` build
and the container answers an MCP `initialize` handshake and `tools/list` with no
credential set, so `build --tools` lists tools without one. `APIFY_TOKEN` is
required only to call a tool.

`source.commit` is `a2720e702c90687c61b9c1ce47e6645c7e78341a`, the current head of `main`.

Build and handshake evidence for this image, and for the other 46 servers in
this family, is public at https://github.com/mambalabsdev/mcp-docker-verify.
