### PR TITLE
Add Hiring Index MCP server (jobs, salary percentiles, posting age)

### DIFF
--- a/servers/hiringindex/server.yaml
+++ b/servers/hiringindex/server.yaml
@@ -1,0 +1,24 @@
+name: hiringindex
+image: mcp/hiringindex
+type: server
+meta:
+  category: data
+  tags:
+    - jobs
+    - labor-market
+    - salary-data
+    - search
+about:
+  title: Hiring Index
+  description: Gives an agent live job postings and the market numbers behind them. The index is read straight from the catalogue APIs of ten applicant tracking systems — Workday, SmartRecruiters, Greenhouse, Workable, Lever, Ashby, Recruitee, Teamtailor, Breezy and Personio — so the rows are the employers' own postings, not scraped boards. Four tools - search postings by title, keyword, city, country, salary, work arrangement or ATS board; aggregate the same filter into counts, salary percentiles, top employers and city splits; report how long the postings in a slice have been open; and fetch one posting with its description and apply link. Answers come back as Markdown by default, which costs an agent fewer tokens than raw JSON.
+  icon: https://www.google.com/s2/favicons?domain=hiringindex.org&sz=64
+source:
+  project: https://github.com/starnikovoleg/hiringindex-mcp
+  branch: main
+  commit: f242cde3ef7fa3d03c1fe7bce0820c572f4b7b85
+config:
+  description: Configure the connection to the Hiring Index API
+  secrets:
+    - name: hiringindex.api_key
+      env: HIRINGINDEX_API_KEY
+      example: 0123456789abcdef0123456789abcdef


### PR DESCRIPTION
Adds `servers/hiringindex/server.yaml`.

**What the server does.** It gives an agent live job postings and the market numbers behind them. The index is read straight from the catalogue APIs of ten applicant tracking systems — Workday, SmartRecruiters, Greenhouse, Workable, Lever, Ashby, Recruitee, Teamtailor, Breezy and Personio — so the rows are the employers' own postings rather than scraped boards.

**Tools**

| Tool | Answer |
|---|---|
| `search_jobs` | postings by title, keyword, city, country, salary, work arrangement, posting age or ATS board handle |
| `job_market_insights` | counts, salary percentiles by currency, top employers, seniority and city splits for the same filter |
| `posting_age_report` | median days live and the share of postings open more than sixty days |
| `get_job` | one posting with the description and the employer apply link |

Output is Markdown by default, which costs fewer tokens than raw JSON. Tool schemas are closed and expose only the filters the index can apply, so a model cannot invent a parameter and get a silently wrong slice.

**Source:** https://github.com/starnikovoleg/hiringindex-mcp (MIT, Dockerfile in the repository root, commit pinned in the entry).

**Key:** one secret, `HIRINGINDEX_API_KEY`. A free tier is available on RapidAPI without a card.

I could not run `task validate` locally — Docker is not available in this environment — so please flag anything the linter objects to and I will fix it.