### PR TITLE
Add timezone MCP server

### DIFF
--- a/servers/timezone/server.yaml
+++ b/servers/timezone/server.yaml
@@ -1,0 +1,23 @@
+name: timezone
+image: mcp/timezone
+type: server
+meta:
+  category: productivity
+  tags:
+    - claude
+    - cursor
+    - ics
+    - meeting-planner
+    - model-context-protocol
+    - timezone
+about:
+  title: Timezone Meeting Planner
+  description: Convert times between places, find the slots that sit inside everyone's working hours, check DST changes, count business days and write .ics invites. Resolves IANA zones, city, country and abbreviation names from a 490-place table compiled into the image, so it needs no network and no credentials. Free to use; a paid Pro key lifts the free limits on participant count, search horizon, saved contacts and monthly .ics files.
+  icon: https://avatars.githubusercontent.com/u/51033404?v=4
+source:
+  project: https://github.com/theluckystrike/mcp-timezone
+  commit: 54bff6bb65bd865bdbf43d7547e493b510c96be9
+run:
+  volumes:
+    - mcp-timezone-data:/root/.local/share/mcp-servers/timezone
+  disableNetwork: true


### PR DESCRIPTION
Adds one local server: `timezone`, a time zone and cross-zone meeting-planning server.

This is a single-server PR. An earlier PR of ours (#4892) added sixteen entries at once and we
closed it ourselves, because every one of this repository's recent server additions adds one
server. This one replaces it.

## What it does

Eleven tools, all served from a 490-place lookup table compiled into the image:

| tool | what it does |
| --- | --- |
| `now` | current time in one or more places |
| `convert_time` | convert a wall-clock time from one place to others, with explicit DST gap/fold policy |
| `overlap` | the daily window when every listed place is inside working hours |
| `find_meeting_slots` | rank slots that sit inside every participant's own working hours |
| `dst_changes` | the clock changes in a place for a year, with the exact UTC instant and both offsets |
| `business_days` | business days between two dates in a place |
| `contacts_set` / `contacts_list` | remember a colleague's zone and working hours |
| `ics_create` | write a `.ics` file for one meeting |
| `license_status` / `license_activate` | show the tier, activate a Pro key |

Zone input accepts IANA zones (`Europe/Warsaw`), city names (`Warsaw`), country names (`Poland`)
and abbreviations (`PST`, `IST`).

## Requirements: none

- **No network.** There is no outbound HTTP anywhere in the server or its vendored dependencies.
  The entry sets `disableNetwork: true`, and every verification below was run under
  `docker run --network none`.
- **No credentials, no secrets, no env vars.** The entry has no `config` block.
- **No host bind mount.** The only writable path is the named volume
  `mcp-timezone-data:/root/.local/share/mcp-servers/timezone`, which holds saved contacts and, if
  one is ever activated, the licence file. Everything else is read-only computation.

## Licensing, stated plainly

The code is MIT. The server runs free out of the box and all eleven tools are listed and callable
on the free tier. A paid Pro key raises four limits: participants per meeting search (free: 3),
search horizon (free: 5 days — a longer search is shortened, not refused), saved contacts (free:
5) and `.ics` files per month (free: 3). `license_activate` verifies a key offline; it makes no
network call. Nothing else is gated.

## Verification

Built from the pinned commit `54bff6bb65bd865bdbf43d7547e493b510c96be9` by the repository's own
tooling, then handed a real MCP handshake over stdio.

`task validate -- --name timezone`:

```
✅ Name is valid
✅ Directory is valid
✅ Title is valid
✅ YAML formatting is valid
✅ Commit is pinned
✅ Secrets are valid
✅ Config env is valid
✅ License is valid
✅ Icon is valid
✅ Remote validation skipped (not a remote server)
✅ OAuth dynamic configuration is valid
```

`task build -- --tools --pull-community timezone`:

```
#13 naming to docker.io/mcp/timezone:latest done
#13 DONE 0.1s

11 tools found.

-----------------------------------------

✅ Image built as mcp/timezone
```

`task catalog -- timezone` succeeds and writes `catalogs/timezone/catalog.yaml`. `go test ./...`
passes.

Independently of the tooling, the image was fed a handshake on stdin with the network switched
off:

```
$ ( cat handshake.jsonl; sleep 4 ) | docker run -i --rm --network none mcp-timezone:r2
```

`initialize` answered:

```json
{"protocolVersion":"2024-11-05",
 "capabilities":{"tools":{"listChanged":true},"resources":{"listChanged":true},"prompts":{"listChanged":true}},
 "serverInfo":{"name":"mcp-timezone","version":"0.20.0"}}
```

`tools/list` answered 11 tools, and stderr showed `mcp-timezone ready (free), 490 places`.
Real `tools/call` results in the same offline container, abridged:

```
now(["Europe/Warsaw","America/New_York"])
  Europe/Warsaw:    2026-09-09 08:36 Wed (GMT+2, UTC+02:00)
  America/New_York: 2026-09-09 02:36 Wed (EDT,   UTC-04:00)

dst_changes({zone:"Europe/Warsaw", year:2026})
  2026-03-29T01:00:00.000Z  UTC+01:00 -> UTC+02:00 (+60 min)
  2026-10-25T01:00:00.000Z  UTC+02:00 -> UTC+01:00 (-60 min)

find_meeting_slots(Warsaw + New York)
  9 slot(s) fit all 2 participants. Best: 2026-09-09T13:30:00.000Z, fairness 3.00h
```

The named volume was checked the same way: `contacts_set` in one container, then `contacts_list`
in a second, freshly created container sharing only that volume, which returned the saved contact.

## Notes for review

`mcp/timezone` is requested as a Docker-built image; the Dockerfile lives at the root of the
pinned repository and builds in a single stage sequence with no build secrets.
