### PR TITLE
Add dfx-real-estate: US commercial real estate, remote streamable-http

### DIFF
--- a/servers/dfx-real-estate/readme.md
+++ b/servers/dfx-real-estate/readme.md
@@ -1,0 +1,1 @@
+Docs: https://dfxintel.com/ai/real-estate-mcp

--- a/servers/dfx-real-estate/server.yaml
+++ b/servers/dfx-real-estate/server.yaml
@@ -1,0 +1,17 @@
+name: dfx-real-estate
+type: remote
+meta:
+  category: finance
+  tags:
+    - real-estate
+    - commercial-real-estate
+    - property-data
+    - mortgage
+    - remote
+about:
+  title: DFX Real Estate Intelligence
+  description: "US commercial and multifamily real estate. Confirmed mortgage maturities in 52 states, plus property records, parcels, owners and recorded sales in Massachusetts and New York. 12 of the 13 tools are free, keyless and unauthenticated."
+  icon: https://raw.githubusercontent.com/Capital-W-Holdings/us-property-parcel-real-estate-debt/main/icon-400.png
+remote:
+  transport_type: streamable-http
+  url: https://exchange-production-9123.up.railway.app/mcp


### PR DESCRIPTION
Adds `servers/dfx-real-estate`, a remote streamable-http MCP server for US commercial and multifamily real estate.

Two files, no Dockerfile, no OAuth, no secret: the server is already hosted and 12 of its 13 tools are free, keyless and unauthenticated.

### What it serves

19,881 loans carry a CONFIRMED maturity date, filed with the SEC by a servicer or recorded by HUD rather than estimated from a term length, and 1,782 of them mature inside the next 548 days. Also LIHTC compliance period endings, HUD subsidy contract expiries, CMBS distress and foreclosure flags, recorded sales with registry book and page, Boston building permits, commercial tenancy with lease expiries, and address and organisation resolution.

### Coverage is uneven and the entry says so

Confirmed mortgage maturities are national across 52 state codes. Parcels, ownership and recorded sales are Massachusetts and New York only. Building permits are Boston only. `dfx_coverage` returns the measured grid at call time, and an unknown input is refused with the accepted values attached rather than answered with an empty list.

### The one priced tool, since `finance` invites the question

`debt_maturity_schedule` is $1.00 USD per delivered schedule. Called with no authorization it returns a full quote for the caller's exact arguments, the price, every field that would arrive and how many rows the dollar buys, and charges nothing. Opening an account is a separate explicit tool call, the account starts at $0.00, and there is no argument anywhere on the server through which a balance can be proposed. This build collects Stripe TEST payments only. The other twelve tools need no account and never will.

### Verification

```bash
curl -s https://exchange-production-9123.up.railway.app/mcp | head -40
```

That is a plain GET: it returns the full tool list, the coverage numbers, the price and a worked example with no handshake and no key.

Measured today from a clean client: `initialize` plus `tools/list` over Streamable HTTP returns 13 tools, on both the current protocol revision and the older 2024-11-05 handshake. Independently: agentprobe.org grades the endpoint A, score 100, 100% uptime over its probe window; mcpqueen.com grades it A, score 100.

Licence is MIT. The MIT text covers the example code and documentation; `NOTICE` states plainly that it does not grant rights in the data served, which is governed by the published terms and by the licences of the underlying public sources that every response names in its `source` and `sources` fields.

Registry: `io.github.Capital-W-Holdings/us-property-parcel-real-estate-debt`
Docs: https://dfxintel.com/ai/real-estate-mcp
