### PR TITLE
Add registry-mcp (Finance)

### DIFF
--- a/servers/registry-mcp/server.yaml
+++ b/servers/registry-mcp/server.yaml
@@ -1,0 +1,29 @@
+name: registry-mcp
+image: mcp/registry-mcp
+type: server
+meta:
+  category: finance
+  tags:
+    - finance
+    - company-data
+    - kyb
+    - due-diligence
+about:
+  title: registry-mcp
+  description: Look up a company at Norway's Brønnøysundregistrene, the UK's Companies House or Sweden's Bolagsverket by its national identifier. Identity and filing data only — no UBO, sanctions or fraud screening.
+  icon: https://api.foretak.dev/icon.png
+source:
+  project: https://github.com/foretak/registry-mcp
+  commit: 114364bdf13b254848bc3c890c3d8b459da4df03
+config:
+  description: Norway needs no key. Free keys unlock the UK (Companies House) and Sweden (Bolagsverket).
+  secrets:
+    - name: registry-mcp.companies_house_api_key
+      env: COMPANIES_HOUSE_API_KEY
+      example: YOUR_COMPANIES_HOUSE_API_KEY
+    - name: registry-mcp.bolagsverket_client_id
+      env: BOLAGSVERKET_CLIENT_ID
+      example: YOUR_BOLAGSVERKET_CLIENT_ID
+    - name: registry-mcp.bolagsverket_client_secret
+      env: BOLAGSVERKET_CLIENT_SECRET
+      example: YOUR_BOLAGSVERKET_CLIENT_SECRET


### PR DESCRIPTION
Adds `registry-mcp` to the Finance category.

MCP server + REST API over national company registries. `lookup_company` looks up a company by its national identifier at Norway's Brønnøysundregistrene, the UK's Companies House, or Sweden's Bolagsverket, returning identity and filing data (legal form, status, address, VAT registration where published, board/accounts duties, employees). No API key needed for Norway; free keys unlock the UK and Sweden. Read-only: no UBO, sanctions, PEP or fraud screening — the tool description says so explicitly.

MIT-licensed. Root `Dockerfile` is dual-mode by design (see its own comments): `PORT` set runs the HTTP API via uvicorn, `PORT` unset — the case this registry's build uses — runs the MCP server over stdio (`registry-mcp`, a `[project.scripts]` entry), so `docker run -i <image>` with no environment set should speak MCP on stdin/stdout as this registry's build/introspection expects.

Source pinned to `114364bdf13b254848bc3c890c3d8b459da4df03` per the Source Pinning convention in `docs/configuration.md`.