### PR TITLE
Add QuantApe Markets (remote server)

### DIFF
--- a/servers/quantape-markets/readme.md
+++ b/servers/quantape-markets/readme.md
@@ -1,0 +1,13 @@
+# QuantApe Markets
+
+Stock screens by momentum, technical signals, fundamentals, earnings events, social sentiment,
+themes, curated baskets and investment theses, plus today's market conditions (fear and greed,
+sector rotation, market cycle phase, categorized news) as MCP tools.
+
+No account needed. Every caller gets a free daily allowance on metered tools, and two discovery
+tools are always free. `get_my_watchlist` only works for signed-in QuantApe users. x402
+pay-per-call is in testnet preview, so no real funds are used yet.
+
+Informational only. Not investment advice.
+
+Docs: https://quantape.com/mcp

--- a/servers/quantape-markets/server.yaml
+++ b/servers/quantape-markets/server.yaml
@@ -1,0 +1,21 @@
+name: quantape-markets
+type: remote
+meta:
+  category: finance
+  tags:
+    - finance
+    - stocks
+    - watchlist
+    - market-data
+    - remote
+about:
+  title: QuantApe Markets
+  description: >-
+    Stock screens (momentum, technical signals, earnings, themes), sector
+    rotation, fear and greed, and your watchlist for AI assistants. Free
+    daily allowance, pay-per-call (x402) is in testnet preview.
+    Informational only, not investment advice.
+  icon: https://quantape.com/android-chrome-512x512.png
+remote:
+  transport_type: streamable-http
+  url: https://mcp.quantape.com/mcp

--- a/servers/quantape-markets/tools.json
+++ b/servers/quantape-markets/tools.json
@@ -1,0 +1,129 @@
+[
+  {
+    "name": "list_smart_lists",
+    "description": "Browse stock screens by category \u2014 momentum, technical signals, fundamentals, earnings events, social sentiment, themes, curated baskets, investment theses \u2014 with display names, descriptions, member counts, and the per-tool pricing/allowance for the metered tools below. Always free. Start here to find a screen id.",
+    "arguments": [
+      {
+        "name": "category_id",
+        "type": "string",
+        "desc": "Restrict the catalog to one category id (e.g. momentum, technical, events, thematic); omit for every category.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_list_criteria",
+    "description": "Metadata for one stock screen (smart list): display name, short description, icon, category ids and parent screen. Always free.",
+    "arguments": [
+      {
+        "name": "list_id",
+        "type": "string",
+        "desc": "Screen id from list_smart_lists (e.g. day_gainers, todays_earnings)."
+      }
+    ]
+  },
+  {
+    "name": "get_smart_list",
+    "description": "Symbols currently in a stock screen \u2014 e.g. today's earnings, golden-cross buy signals, AI beneficiaries (paged, max 200 per call). Descriptive, not a recommendation. Free within your daily allowance (anonymous 5/day by IP, signed-in users 10/day, power users 50/day); beyond that $0.01 per call via x402 (USDC).",
+    "arguments": [
+      {
+        "name": "list_id",
+        "type": "string",
+        "desc": "Screen id from list_smart_lists (e.g. day_gainers, golden_cross, ai_beneficiaries)."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Symbols per page, 1-200 (default 200).",
+        "optional": true
+      },
+      {
+        "name": "offset",
+        "type": "integer",
+        "desc": "Zero-based offset into the screen for paging.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_smart_list_metrics",
+    "description": "Per-symbol metrics for a stock screen \u2014 price and 1-day/7-day/1-month/3-month change, 52-week range, 50-day/200-day averages, forward/trailing P/E, PEG, beta, dividend yield, short interest, last earnings reaction and drift since, next earnings date, implied move, expectations score, and technical signals (paged, max 200 per call). Descriptive, not a recommendation. Free within your daily allowance (anonymous 5/day by IP, signed-in users 10/day, power users 50/day); beyond that $0.05 per call via x402 (USDC).",
+    "arguments": [
+      {
+        "name": "list_id",
+        "type": "string",
+        "desc": "Screen id from list_smart_lists (e.g. day_gainers, golden_cross, ai_beneficiaries)."
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Symbols per page, 1-200 (default 200).",
+        "optional": true
+      },
+      {
+        "name": "offset",
+        "type": "integer",
+        "desc": "Zero-based offset into the screen for paging.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_my_watchlist",
+    "description": "The same per-symbol metrics as get_smart_list_metrics, plus the latest headlines, for your own watchlist \u2014 the tool behind \"What's going on with my watchlist today?\". Requires your session token (Authorization: Bearer). Descriptive, not a recommendation. Free within your daily allowance (anonymous 5/day by IP, signed-in users 10/day, power users 50/day); beyond that $0.05 per call via x402 (USDC).",
+    "arguments": [
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Watchlist symbols per page, 1-100 (default 50).",
+        "optional": true
+      },
+      {
+        "name": "offset",
+        "type": "integer",
+        "desc": "Zero-based offset into the watchlist for paging.",
+        "optional": true
+      },
+      {
+        "name": "news_days",
+        "type": "integer",
+        "desc": "How many days of headlines to attach per symbol, 1-7 (default 2).",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_market_overview",
+    "description": "Today's market conditions: the daily overview narrative, the fear & greed index and per-sector scores, sector rotation and market-cycle phase, and categorized market news. Pick sections to keep the answer small. Pairs with get_my_watchlist for \"how is my watchlist doing against the market?\". Descriptive, not a recommendation. Free within your daily allowance (anonymous 5/day by IP, signed-in users 10/day, power users 50/day); beyond that $0.02 per call via x402 (USDC).",
+    "arguments": [
+      {
+        "name": "sections",
+        "type": "array",
+        "desc": "Which sections to return; omit for all five. Pick fewer to keep the answer small.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "get_smart_list_changes",
+    "description": "Which symbols entered or left a stock screen since its last recorded baseline (which can span several rebuilds) \u2014 e.g. new golden crosses, or names that dropped out of the momentum leaders. Free within your daily allowance (anonymous 5/day by IP, signed-in users 10/day, power users 50/day); beyond that $0.02 per call via x402 (USDC).",
+    "arguments": [
+      {
+        "name": "list_id",
+        "type": "string",
+        "desc": "Screen id from list_smart_lists whose additions and removals you want."
+      }
+    ]
+  },
+  {
+    "name": "find_symbol_lists",
+    "description": "Every stock screen a given ticker is currently in \u2014 its momentum, technical-signal, earnings, theme and thesis memberships, in one call. Free within your daily allowance (anonymous 5/day by IP, signed-in users 10/day, power users 50/day); beyond that $0.01 per call via x402 (USDC).",
+    "arguments": [
+      {
+        "name": "symbol",
+        "type": "string",
+        "desc": "Ticker symbol, e.g. NVDA or BRK-B."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds `quantape-markets`, a remote MCP server (Streamable HTTP, https://mcp.quantape.com/mcp) exposing stock screens (momentum, technical signals, fundamentals, earnings events, social sentiment, themes, curated baskets and investment theses), a signed-in user's own watchlist, and a daily market read (fear and greed, sector rotation, market-news analysis) as 8 tools.

- No account required to start; a free rolling 24-hour allowance covers metered tools (5 calls/day anonymous, 10 signed in). x402 pay-per-call is in testnet preview (Base Sepolia, no real funds yet). Two discovery tools are always free.
- This entry configures no auth, so Docker users connect anonymously. The server also accepts an optional `Authorization: Bearer <token>` that unlocks the signed-in-only `get_my_watchlist` tool; it is intentionally not wired here.
- All data is informational only and not investment advice; see https://quantape.com/terms#mcp.

Docs: https://quantape.com/mcp

## MCP Server Information

**Server Name:** QuantApe Markets (`quantape-markets`)
**Repository URL:** N/A. Remote server; the source repository is private, so `source` is omitted and the license check is skipped. Docs: https://quantape.com/mcp
**Brief Description:** Stock screens, earnings, technical signals, sector rotation and fear and greed as MCP tools.

## Basic Requirements

- [ ] **Open Source**: N/A for this remote entry (no image is built; source is private)
- [x] **MCP Compliant**: Implements MCP API specification (Streamable HTTP)
- [x] **Active Development**: Recent commits and maintained
- [ ] **Docker Artifact**: N/A (remote server, no Dockerfile)
- [x] **Documentation**: https://quantape.com/mcp
- [x] **Security Contact**: admin@quantape.com

## Submitter Checklist

- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name quantape-markets` (all checks pass; tools.json lists 8 tools)
- [x] I have built the MCP Server using `task build -- --tools quantape-markets` (build skipped for remote server)
- [x] No credentials are required to test it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MALCva4WqnRZCiL2ND11KE