### PR TITLE
Add rechtssysteem-mcp (Dutch court-case outcome prediction with leakage measurement)

### DIFF
--- a/servers/rechtssysteem-mcp/server.yaml
+++ b/servers/rechtssysteem-mcp/server.yaml
@@ -1,0 +1,39 @@
+name: rechtssysteem-mcp
+image: mcp/rechtssysteem-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - ai
+    - legal
+    - legal-tech
+    - netherlands
+    - law
+about:
+  title: Rechtssysteem.ai
+  description: >-
+    Leakage-free prediction of Dutch court case outcomes (dismissed, partly
+    granted, or granted), trained on 609,715 rulings. The client measures and
+    removes the outcome leakage itself: 92% of Dutch judgment texts state their
+    own verdict verbatim, and after the R2 cut only 0.1% remains — giving 78.2%
+    accuracy against a 43.7% majority baseline (5-fold CV, out-of-fold). The
+    lekkage_check and rechtspraak_cijfers tools need no API key so anyone can
+    test a dataset or someone else's AI claim for leakage; voorspel_uitkomst
+    uses a shared trial key. Single-file Python client, standard library only.
+  icon: https://www.google.com/s2/favicons?domain=rechtssysteem.ai&sz=64
+source:
+  project: https://github.com/rechtssysteem-ai/rechtssysteem-mcp
+  branch: main
+  commit: 4b24219f71e57098544624c0308d1241517be8dd
+config:
+  description: Configure Rechtssysteem.ai MCP server
+  env:
+    - name: RECHTSSYSTEEM_API_KEY
+      description: >-
+        Optional. Required only for the voorspel_uitkomst tool. lekkage_check
+        and rechtspraak_cijfers work without a key. Get a free trial key at
+        rechtssysteem.ai.
+      example: "0000000000000000000000000000000000000000000000000000000000000000"
+    - name: RECHTSSYSTEEM_API_URL
+      description: Optional. Defaults to https://api.rechtssysteem.ai
+      example: "https://api.rechtssysteem.ai"


### PR DESCRIPTION
Adds a containerized MCP server for Dutch court-case outcome prediction, Apache-2.0, single-file stdlib client.

- Category: ai (no legal category exists yet in the registry)
- Repo has Dockerfile at root (python:3.12-slim, entrypoint runs the stdio client)
- lekkage_check and rechtspraak_cijfers need no API key; voorspel_uitkomst uses a shared trial key
- Source commit pinned: 4b24219 (v0.3.2)