### PR TITLE
Add OpenHire — job-search MCP server over employers' public ATS APIs

### DIFF
--- a/servers/openhire/server.yaml
+++ b/servers/openhire/server.yaml
@@ -1,0 +1,18 @@
+name: openhire
+image: mcp/openhire
+type: server
+meta:
+  category: productivity
+  tags:
+    - jobs
+    - recruiting
+    - careers
+    - productivity
+about:
+  title: OpenHire
+  description: Job-search radar over 139 employers' own ATS APIs (Greenhouse, Lever, Ashby, Beisen, Moka). Every listing carries the real posting date, days_open and a ghost_score; no résumé ever transits the server.
+  icon: https://raw.githubusercontent.com/gzchenhao/openhire/main/docs/brand/icon-512.png
+source:
+  project: https://github.com/gzchenhao/openhire
+  branch: main
+  commit: 7b5ee3709b1bf2cb949291cd3e3349ac67abf6cb


### PR DESCRIPTION
## What it is
**OpenHire** is an MCP server that turns an agent into a job-search radar for AI / Infra, autonomous-driving and embodied-AI roles. Instead of job boards it reads **139 employers' own public ATS APIs** (Greenhouse, Lever, Ashby, Beisen, Moka — US/EU/China), so every listing carries the **real posting date**, `days_open` and a `ghost_score` that ages off the employer's timestamp, plus a direct employer apply link.

- Repo: https://github.com/gzchenhao/openhire (MIT) · PyPI `openhire` 0.4.0 · official registry `io.github.gzchenhao/openhire`
- Tools: `search_jobs`, `get_company_info`, `watch_intent`, `check_watches`, `authorize_application` (all with title + readOnly/destructive annotations)
- No API keys, accounts or secrets. No résumé field in the protocol (CI-enforced); only an anonymous fingerprint is ever stored. Privacy policy: https://github.com/gzchenhao/openhire/blob/main/docs/PRIVACY.md

## Build notes
- Dockerfile at repo root (python:3.11-slim, `pip install .`, `ENTRYPOINT ["ohp","serve"]`, stdio by default; `--transport streamable-http --host 0.0.0.0` exposes :8000).
- **First start downloads the ~25 MB public job snapshot** (jobs/companies only) into `/data` before answering `list_tools` — allow ~30 s on a cold container. Set `OPENHIRE_NO_AUTO_BOOTSTRAP=1` to skip.
- Weekly automated index refresh upstream (GitHub Actions, zero secrets). 253 tests.