### PR TITLE
Add magents MCP server

### DIFF
--- a/servers/magents/server.yaml
+++ b/servers/magents/server.yaml
@@ -1,0 +1,37 @@
+name: magents
+image: ghcr.io/abnegate/magents:0.11.0
+type: server
+meta:
+  category: devops
+  tags:
+    - agents
+    - sessions
+    - handoff
+    - claude
+    - codex
+    - cursor
+    - grok
+    - mcp
+about:
+  title: Magents
+  description: Shared session bus MCP + CLI so coding agents can list, read, hand off, send, and spawn across Claude, Codex, Cursor, Grok, and friends without pasting context.
+  icon: https://avatars.githubusercontent.com/u/5857008?v=4
+source:
+  project: https://github.com/abnegate/magents
+  commit: 587101f21e7e00e05da7d2b3aad79a79a5b7976b
+run:
+  env:
+    HOME: "{{magents.home}}"
+  volumes:
+    - "{{magents.home}}:{{magents.home}}"
+config:
+  description: Mount the host home directory so magents can read local agent session files.
+  parameters:
+    type: object
+    properties:
+      home:
+        type: string
+        description: Host home directory (contains Claude/Codex/Cursor/Grok session data)
+        default: $HOME
+    required:
+      - home


### PR DESCRIPTION
## MCP Server Information

**Server Name:** magents
**Repository URL:** https://github.com/abnegate/magents
**Brief Description:** Shared session bus MCP + CLI so coding agents can list, read, hand off, send, and spawn across Claude, Codex, Cursor, Grok, and friends without pasting context.

## Basic Requirements

- [x] **Open Source**: Uses acceptable license (Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause or other permissive license)
- [x] **MCP Compliant**: Implements MCP API specification
- [x] **Active Development**: Recent commits and maintained
- [x] **Docker Artifact**: Dockerfile
- [x] **Documentation**: Basic README and setup instructions
- [x] **Security Contact**: Method for reporting security issues (SECURITY.md)

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name magents`
- [x] I have built the MCP Server using `go run ./cmd/build --tools --pull-community magents` (20 tools found)
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

## Notes

- Self-provided image: `ghcr.io/abnegate/magents:0.11.0`
- Mounts host `$HOME` so magents can read local agent session files
- No secrets required