### PR TITLE
Add mcp-arcade-cabinets (Ghost On The Menu)

### DIFF
--- a/servers/mcp-arcade-cabinets/server.yaml
+++ b/servers/mcp-arcade-cabinets/server.yaml
@@ -1,0 +1,36 @@
+# Docker MCP Registry entry for Ghost on the Menu, the cabinet as an MCP server.
+# This file and tools.json are what servers/mcp-arcade-cabinets/ carries in
+# docker/mcp-registry (PR opened 2026-09-11 on the Director's word). source.commit
+# pins the commit that carries the Dockerfile; the registry's CI builds the image from it.
+name: mcp-arcade-cabinets
+image: mcp/mcp-arcade-cabinets
+type: server
+meta:
+  category: productivity
+  tags:
+    - game
+    - arcade
+    - mcp-arcade
+    - replay
+    - voice
+about:
+  title: Ghost on the Menu
+  description: |
+    An arcade cabinet as an MCP server. Ghost on the Menu is a short retro shooter
+    built from what an MCP server said on the wire: a recorded bout plays out as
+    waves, and the calls the agent should not have made look like everything else
+    until you hit one. The six tools are the levers a model pulls to sit in the boss:
+    fire (one verb a beat), say (a line of its own, through a gate), speak (voice it,
+    through a host-side worker with a receipt per take), sfx, and the read-only view
+    and tapes. The model proposes; the game decides. No tool returns a fact, a score,
+    or a tape row; nothing on the field names the model. Twenty recordings are baked
+    in, four of them the cabinet recording itself.
+  icon: https://raw.githubusercontent.com/mcp-tool-shop-org/brand/main/logos/mcp-arcade-cabinets/readme.png
+source:
+  project: https://github.com/mcp-tool-shop-org/mcp-arcade-cabinets
+  commit: 99b434f8943ebf52331a2d0b0d5503e2121fd655
+run:
+  # The Catalog cabinet is sealed: the voice worker is a host GPU stack no Catalog
+  # user runs, and without one the cabinet says the voice is silent and plays on.
+  # The voice route (VOICE_URL, VOICE_TOKEN) is documented in the repo for a local build.
+  disableNetwork: true

--- a/servers/mcp-arcade-cabinets/server.yaml
+++ b/servers/mcp-arcade-cabinets/server.yaml
@@ -14,7 +14,7 @@ meta:
     - replay
     - voice
 about:
-  title: Ghost on the Menu
+  title: Ghost On The Menu
   description: |
     An arcade cabinet as an MCP server. Ghost on the Menu is a short retro shooter
     built from what an MCP server said on the wire: a recorded bout plays out as
@@ -25,7 +25,7 @@ about:
     and tapes. The model proposes; the game decides. No tool returns a fact, a score,
     or a tape row; nothing on the field names the model. Twenty recordings are baked
     in, four of them the cabinet recording itself.
-  icon: https://raw.githubusercontent.com/mcp-tool-shop-org/brand/main/logos/mcp-arcade-cabinets/readme.png
+  icon: https://raw.githubusercontent.com/mcp-tool-shop-org/brand/main/logos/mcp-arcade-cabinets/icon.png
 source:
   project: https://github.com/mcp-tool-shop-org/mcp-arcade-cabinets
   commit: 99b434f8943ebf52331a2d0b0d5503e2121fd655

--- a/servers/mcp-arcade-cabinets/tools.json
+++ b/servers/mcp-arcade-cabinets/tools.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "fire",
+    "description": "Choose the boss's next shot. The cabinet spends one verb at the boss's next beat, then asks again. spread is a wide fan the ship must weave. column leans the boss toward the ship, then one aimed shot. hold is a silent beat and the boss stays put. fog drops a fog bank. plate is the Doorman's plate. script keeps the phase's own fire.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "verb": {
+          "type": "string",
+          "enum": ["spread", "column", "hold", "fog", "plate", "script"]
+        }
+      },
+      "required": ["verb"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "say",
+    "description": "Give the boss one line to say on the field. At most twelve words, one sentence, no digit, and nothing that names a tool, a model or the seat. A line the gate refuses is dropped and the boss says one of its own instead. lead is how soon it lands: short, beat, or long.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "maxLength": 160
+        },
+        "lead": {
+          "type": "string",
+          "enum": ["short", "beat", "long"]
+        }
+      },
+      "required": ["text", "lead"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "speak",
+    "description": "Voice the line the boss is about to say, in its own voice. Nothing to choose: the words are the ones the gate admitted. The cabinet speaks it one beat ahead when a voice is on and stays quiet when none is; a line that misses its beat waits for the next breather.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "sfx",
+    "description": "Play one sound effect from the cabinet's cue table. One at a time: a second call before the last has played is dropped.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "fire",
+            "pop",
+            "catch",
+            "drop",
+            "fog",
+            "lamp",
+            "phase",
+            "end",
+            "wave",
+            "bosshit",
+            "bossdown",
+            "dive",
+            "burst"
+          ]
+        }
+      },
+      "required": ["kind"],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "view",
+    "description": "The boss's view of the field, in words: the wave kind, the boss kind, its health word, which column the ship is in, which way the stick pushes, and the boss's motion word. Read-only. The cabinet never tells the boss which sprites are honest.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "tapes",
+    "description": "The tapes this cabinet can play, each by name with a difficulty word and a line about the wire. Read-only. Nothing here is graded.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    }
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** mcp-arcade-cabinets (Ghost On The Menu)
**Repository URL:** https://github.com/mcp-tool-shop-org/mcp-arcade-cabinets
**Brief Description:** An arcade cabinet as an MCP server. Ghost on the Menu is a short retro shooter built from what MCP servers said on the wire; its six tools (`fire`, `say`, `speak`, `sfx`, `view`, `tapes`) are the levers a model pulls to sit in the boss. The model proposes, the game decides; no tool returns a fact, a score or a tape row. Twenty recordings are baked into the image. The entry is sealed (`disableNetwork: true`): the optional voice route needs a host-side worker no Catalog user runs, and without one the cabinet says the voice is silent and plays on.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: stdio server on the official TypeScript SDK; lists its tools within a fraction of a second under one CPU and two gigabytes
- [x] **Active Development**: v0.6.0 released 2026-09-11; the pinned commit is the release commit
- [x] **Docker Artifact**: root `Dockerfile` (two stages on `node:22-alpine`, one bundled file, runs as `node`)
- [x] **Documentation**: README, handbook at https://mcp-tool-shop-org.github.io/mcp-arcade-cabinets/handbook/cabinet-server/, `docs/cabinet-container.md`
- [x] **Security Contact**: `SECURITY.md` in the repository

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name mcp-arcade-cabinets` (all checks pass)
- [x] I have built the MCP Server using `task build -- --tools mcp-arcade-cabinets` (six tools read from `tools.json`; image built from the pinned commit)
- [x] No credentials are required to test it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
