### PR TITLE
Add Neither MCP server (local stdio, Docker-built)

### DIFF
--- a/servers/neither-mcp/server.yaml
+++ b/servers/neither-mcp/server.yaml
@@ -1,0 +1,34 @@
+name: neither-mcp
+image: mcp/neither-mcp
+type: server
+meta:
+  category: ai
+  tags:
+    - neither
+    - memory
+    - knowledge
+    - ai
+about:
+  title: Neither
+  description: Decision memory for Cursor and Claude Desktop. Search cited decisions, fetch snippets, view timelines, and push new records.
+  icon: https://www.google.com/s2/favicons?domain=neither.online&sz=64
+source:
+  project: https://github.com/stonianua/neither-mcp
+  commit: 51afcf2c31664f4a160d6231cbb3434a898472dc
+config:
+  description: Configure the connection to Neither
+  secrets:
+    - name: neither-mcp.api_key
+      env: NEITHER_API_KEY
+      example: sk_ctx_your_workspace_key
+      description: Workspace API key from [Neither](https://www.neither.online/developers/quickstart)
+  env:
+    - name: NEITHER_API_BASE
+      example: https://api.neither.online
+      value: "{{neither-mcp.api_base}}"
+  parameters:
+    type: object
+    properties:
+      api_base:
+        type: string
+        description: Optional API base URL (defaults to https://api.neither.online)

--- a/servers/neither-mcp/tools.json
+++ b/servers/neither-mcp/tools.json
@@ -1,0 +1,109 @@
+[
+  {
+    "name": "memory_search",
+    "description": "At a delivery fork or planning write, search workspace decision memory (NL query). Returns Decision/Citation prose — use top hits to answer; fetch at most 1–2 snippets with node_id=hit.id. Do not fall back to DB/repo archaeology for decisions.",
+    "arguments": [
+      {
+        "name": "query",
+        "type": "string",
+        "desc": "Search query"
+      },
+      {
+        "name": "maxResults",
+        "type": "number",
+        "desc": "Max results (default 10, max 50). Prefer ≤8 at forks.",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "memory_for_file",
+    "description": "Hero tool at delivery forks when a repo path is in play — cited Decision/Rejected/Constraint/Citation. Prefer this over memory_search when editing or planning a specific file. Honest empty if uncovered.",
+    "arguments": [
+      {
+        "name": "file_path",
+        "type": "string",
+        "desc": "Repo-relative file path"
+      },
+      {
+        "name": "symbols",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "desc": "Optional symbol or topic hints",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "memory_snippet_fetch",
+    "description": "Fetch verbatim quote by provenance source_document_id. ALWAYS pass node_id = memory_search hit id so content matches that Decision title (same document can have unrelated nodes). At most 1–2 fetches per fork; then answer or abstain.",
+    "arguments": [
+      {
+        "name": "source_id",
+        "type": "string",
+        "desc": "Provenance source_document_id from a search hit"
+      },
+      {
+        "name": "node_id",
+        "type": "string",
+        "desc": "Required for alignment: search hit id (node) — prefers that node's project_context",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "memory_timeline",
+    "description": "Time-ordered decision memory for a topic after a fork. Prefer memory_search prose first; use timeline only when sequence matters. Do not use as a substitute for answering.",
+    "arguments": [
+      {
+        "name": "anchor_id",
+        "type": "string",
+        "desc": "Optional source document or anchor id",
+        "optional": true
+      },
+      {
+        "name": "q",
+        "type": "string",
+        "desc": "Optional natural-language query",
+        "optional": true
+      },
+      {
+        "name": "window",
+        "type": "string",
+        "desc": "Lookback window label (default 30d)",
+        "optional": true
+      },
+      {
+        "name": "maxResults",
+        "type": "number",
+        "desc": "Max events (default 20, max 50)",
+        "optional": true
+      }
+    ]
+  },
+  {
+    "name": "memory_push",
+    "description": "Close a decision or seed an ADR snippet with provenance metadata (source id, occurred_at, participants, thread id).",
+    "arguments": [
+      {
+        "name": "content",
+        "type": "string",
+        "desc": "Snippet text"
+      },
+      {
+        "name": "bc_hint",
+        "type": "string",
+        "desc": "Optional business-context hint uuid",
+        "optional": true
+      },
+      {
+        "name": "metadata",
+        "type": "object",
+        "desc": "Optional provenance metadata (source_id, occurred_at, participants, thread_id, content_type)",
+        "optional": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## MCP Server Information

**Server Name:** neither-mcp
**Repository URL:** https://github.com/stonianua/neither-mcp
**Brief Description:** Local stdio MCP for project/decision memory (Cursor / Claude Desktop). Docker-built Option A. Requires workspace key `NEITHER_API_KEY`; optional `NEITHER_API_BASE`.

## Basic Requirements

- [x] **Open Source**: MIT
- [x] **MCP Compliant**: tools/list verified (memory_search, memory_for_file, memory_snippet_fetch, memory_timeline, memory_push)
- [x] **Active Development**: yes
- [x] **Docker Artifact**: root Dockerfile on stonianua/neither-mcp main (`CMD [node,dist/index.js]`)
- [x] **Documentation**: README + https://www.neither.online/docs/mcp
- [x] **Security Contact**: https://github.com/stonianua/neither-mcp/issues

## Submitter Checklist

- [x] This server meets the basic requirements listed above
- [x] I understand this will undergo automated and manual review.
- [x] I have tested the MCP Server using `task validate -- --name neither-mcp`
- [x] I have built the MCP Server using `task build -- --tools neither-mcp`
- [x] If the server requires credentials to test it, I have [shared test credentials using this form](https://forms.gle/6Lw3nsvu2d6nFg8e6)

Auth is **not** none: `NEITHER_API_KEY` is required (secret `neither-mcp.api_key`).
