### PR TITLE
Add Global Database remote MCP server

### DIFF
--- a/servers/global-database/readme.md
+++ b/servers/global-database/readme.md
@@ -1,0 +1,1 @@
+Docs: https://github.com/global-database/mcp-server

--- a/servers/global-database/server.yaml
+++ b/servers/global-database/server.yaml
@@ -1,0 +1,24 @@
+name: global-database
+type: remote
+dynamic:
+  tools: true
+meta:
+  category: finance
+  tags:
+    - finance
+    - business
+    - kyb
+    - compliance
+    - data
+    - remote
+about:
+  title: Global Database
+  description: Company profiles, financials, ownership, and KYB/compliance lookups from official government registries across 400+ countries and territories
+  icon: https://www.google.com/s2/favicons?domain=globaldatabase.com&sz=64
+remote:
+  transport_type: streamable-http
+  url: https://mcp.globaldatabase.com/mcp
+oauth:
+  - provider: global-database
+    secret: global-database.personal_access_token
+    env: GLOBAL_DATABASE_PERSONAL_ACCESS_TOKEN

--- a/servers/global-database/tools.json
+++ b/servers/global-database/tools.json
@@ -1,0 +1,117 @@
+[
+  {
+    "name": "check_api_key",
+    "description": "Verify the API connection and return current user info.",
+    "arguments": []
+  },
+  {
+    "name": "get_company_by_website",
+    "description": "Look up a company by website URL or domain.",
+    "arguments": []
+  },
+  {
+    "name": "get_company_by_linkedin",
+    "description": "Look up a company by LinkedIn URL or public ID.",
+    "arguments": []
+  },
+  {
+    "name": "get_company_by_identifiers",
+    "description": "Look up a company by name, registration number, VAT, ticker, website, email, or LinkedIn.",
+    "arguments": []
+  },
+  {
+    "name": "get_company_details",
+    "description": "Get a full company profile by company_id.",
+    "arguments": []
+  },
+  {
+    "name": "get_company_financials",
+    "description": "Get company financial data by company_id.",
+    "arguments": []
+  },
+  {
+    "name": "get_company_ownership",
+    "description": "Get company shareholders and corporate group structure by company_id.",
+    "arguments": []
+  },
+  {
+    "name": "get_digital_insights",
+    "description": "Get a company's digital presence: web traffic, rankings, traffic sources, WHOIS, technologies.",
+    "arguments": []
+  },
+  {
+    "name": "enrich_employee_contacts",
+    "description": "Find and enrich an employee/contact.",
+    "arguments": []
+  },
+  {
+    "name": "search_employees",
+    "description": "Search PEOPLE: the employees of a company, or people by role, department or name.",
+    "arguments": []
+  },
+  {
+    "name": "get_employee_details",
+    "description": "Get one person's profile by employee_id (the 'id' of a search_employees row).",
+    "arguments": []
+  },
+  {
+    "name": "find_people_by_domain",
+    "description": "Find PEOPLE at companies given by WEB DOMAIN, via the contact-enrichment providers.",
+    "arguments": []
+  },
+  {
+    "name": "get_nomenclature",
+    "description": "Resolve nomenclature values into the ids that prospecting and kyb_search filters expect.",
+    "arguments": []
+  },
+  {
+    "name": "prospecting",
+    "description": "Search and filter companies by country, industry, size, revenue and many other criteria.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_search",
+    "description": "Search official government registries for KYB/compliance checks.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_company_details",
+    "description": "Get official registry details for a company.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_officers",
+    "description": "Get company directors, secretaries, and officers from official registry.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_shareholders",
+    "description": "Get company shareholders from official registry.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_shareholders_search",
+    "description": "Reverse shareholder lookup - search by holder name across all jurisdictions.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_group_structure",
+    "description": "Get corporate group structure from official registry.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_financial",
+    "description": "Get detailed financial statements from official registry across multiple years.",
+    "arguments": []
+  },
+  {
+    "name": "kyb_officers_search",
+    "description": "Reverse officer lookup - search by person's name across all jurisdictions.",
+    "arguments": []
+  },
+  {
+    "name": "read_reference",
+    "description": "Read one reference document on how to USE the other tools.",
+    "arguments": []
+  }
+]


### PR DESCRIPTION
## Summary

Adds [Global Database](https://globaldatabase.com/) as a remote MCP server.

- **Server**: `https://mcp.globaldatabase.com/mcp` (Streamable HTTP)
- **Auth**: OAuth 2.1 with PKCE and Dynamic Client Registration (RFC 7591) — no pre-shared client needed, the server exposes `/register`, `/authorize`, `/token` per the MCP auth spec
- **What it does**: company profiles, financials, ownership/corporate group structure, digital footprint, people search and contact enrichment, prospecting, and KYB/compliance lookups against official government registries across 400+ countries and territories
- 23 tools, listed in `tools.json`

## Test plan

- [x] `server.yaml` validated against the schema shape used by other OAuth-based remote entries (`servers/notion-remote`, `servers/atlassian-remote`)
- [x] Server URL is publicly reachable (`https://mcp.globaldatabase.com/mcp` responds; unauthenticated calls correctly return 401)
- [x] OAuth discovery metadata confirmed live at `https://mcp.globaldatabase.com/.well-known/oauth-authorization-server`
- [x] `tools.json` populated with the real, current tool list (name + description) pulled from the live server, not hand-written
- [ ] Test credentials will be shared via the intake form per `CONTRIBUTING.md`